### PR TITLE
Fix Android smoke test and manage APK artifacts

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -46,7 +46,9 @@ jobs:
           export ANDROID_HOME="$ANDROID_SDK_ROOT"
           export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
 
+          set +o pipefail
           yes | sdkmanager --install "platforms;android-28" "system-images;android-28;google_apis;x86"
+          set -o pipefail
 
           if avdmanager list avd | grep -q "${AVD_NAME}"; then
             avdmanager delete avd -n "${AVD_NAME}"
@@ -65,3 +67,60 @@ jobs:
           adb shell 'while [ -z "$(getprop sys.boot_completed 2>/dev/null)" ]; do sleep 1; done'
           adb shell input keyevent 82
           adb emu kill
+
+      - name: Upload built APK artifact
+        if: ${{ always() }}
+        id: upload_apk
+        uses: actions/upload-artifact@v4
+        with:
+          name: uqureader-apk-${{ github.run_number }}
+          path: target/*.apk
+          if-no-files-found: ignore
+
+      - name: Prune old APK artifacts
+        if: ${{ always() && steps.upload_apk.outputs.artifact-id }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prefix = 'uqureader-apk-';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const perPage = 100;
+            let page = 1;
+            const artifacts = [];
+
+            while (true) {
+              const { data } = await github.rest.actions.listArtifactsForRepo({
+                owner,
+                repo,
+                per_page: perPage,
+                page,
+              });
+
+              if (!data.artifacts.length) {
+                break;
+              }
+
+              artifacts.push(
+                ...data.artifacts.filter((artifact) => artifact.name && artifact.name.startsWith(prefix))
+              );
+
+              if (data.artifacts.length < perPage) {
+                break;
+              }
+
+              page += 1;
+            }
+
+            artifacts.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            const toDelete = artifacts.slice(3);
+
+            for (const artifact of toDelete) {
+              core.info(`Deleting artifact ${artifact.name} (${artifact.id})`);
+              await github.rest.actions.deleteArtifact({
+                owner,
+                repo,
+                artifact_id: artifact.id,
+              });
+            }


### PR DESCRIPTION
## Summary
- prevent the Android emulator smoke test from failing because of the sdkmanager license acceptance pipeline
- always publish any generated APK even if later steps fail
- prune repository APK artifacts to keep only the three most recent builds

## Testing
- not run (CI workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd4604c328832abd0d987b56dbc821