### PR TITLE
Show lemma usage dots and auto-increment build version

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -30,6 +30,20 @@ jobs:
       - name: Set up Android SDK tools
         uses: android-actions/setup-android@v3
 
+      - name: Determine build version
+        id: version
+        run: |
+          set -euo pipefail
+          minor="${GITHUB_RUN_NUMBER}"
+          version="1.${minor}.0"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "code=${minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Update Maven project version
+        run: |
+          set -euo pipefail
+          ./mvnw -B versions:set -DnewVersion=${{ steps.version.outputs.version }} -DgenerateBackupPoms=false
+
       - name: Install Android platform tools
         run: |
           yes | sdkmanager --install "platforms;android-28" "build-tools;28.0.3"
@@ -38,7 +52,9 @@ jobs:
           fi
 
       - name: Build with Maven Wrapper
-        run: ./mvnw -B verify
+        env:
+          APP_VERSION_CODE: ${{ steps.version.outputs.code }}
+        run: ./mvnw -B verify -Dapp.version.code=${APP_VERSION_CODE}
 
 #      - name: Run API 28 installation smoke test
 #        shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
     <java.version>1.8</java.version>
     <base64encoder.jar>${project.basedir}/tools/base64encoder/base64encoder.jar</base64encoder.jar>
     <android.debug.keystore>${user.home}/.android/debug.keystore</android.debug.keystore>
+    <app.version>${project.version}</app.version>
+    <app.version.code>1</app.version.code>
   </properties>
 
   <build>
@@ -35,6 +37,8 @@
           <undeployBeforeDeploy>true</undeployBeforeDeploy>
           <manifest>
             <debuggable>true</debuggable>
+            <versionName>${app.version}</versionName>
+            <versionCode>${app.version.code}</versionCode>
           </manifest>
           <artifactSet>
             <excludes>

--- a/src/main/java/com/example/ttreader/StatsActivity.java
+++ b/src/main/java/com/example/ttreader/StatsActivity.java
@@ -23,6 +23,8 @@ import java.util.Locale;
 import java.util.Map;
 
 public class StatsActivity extends Activity {
+    private static final int MAX_DOT_COUNT = 12;
+    private static final char DOT_CHAR = '\u2B24';
     private UsageStatsDao usageStatsDao;
     private DateFormat dateFormat;
 
@@ -76,9 +78,13 @@ public class StatsActivity extends Activity {
             TextView title = item.findViewById(R.id.statsTitle);
             TextView exposure = item.findViewById(R.id.statsExposure);
             TextView lookup = item.findViewById(R.id.statsLookup);
+            TextView exposureDots = item.findViewById(R.id.statsExposureDots);
+            TextView lookupDots = item.findViewById(R.id.statsLookupDots);
             title.setText(formatLemmaTitle(entry));
             exposure.setText(getString(R.string.stats_exposure_label, entry.exposureCount, formatTime(entry.lastExposure)));
             lookup.setText(getString(R.string.stats_lookup_label, entry.lookupCount, formatTime(entry.lastLookup)));
+            bindDots(exposureDots, entry.exposureCount);
+            bindDots(lookupDots, entry.lookupCount);
             container.addView(item);
         }
     }
@@ -130,6 +136,29 @@ public class StatsActivity extends Activity {
     private String formatTime(long ms) {
         if (ms <= 0) return getString(R.string.stats_time_never);
         return dateFormat.format(ms);
+    }
+
+    private void bindDots(TextView view, int count) {
+        if (view == null) return;
+        if (count <= 0) {
+            view.setText("");
+            view.setVisibility(View.GONE);
+        } else {
+            view.setVisibility(View.VISIBLE);
+            view.setText(buildDotString(count));
+        }
+    }
+
+    private CharSequence buildDotString(int count) {
+        int dots = Math.min(count, MAX_DOT_COUNT);
+        if (dots <= 0) return "";
+        StringBuilder sb = new StringBuilder(dots * 2);
+        for (int i = 0; i < dots; i++) {
+            if (i > 0) sb.append(' ');
+            sb.append(DOT_CHAR);
+        }
+        if (count > MAX_DOT_COUNT) sb.append(' ').append('+');
+        return sb.toString();
     }
 
     private static class LemmaStats {

--- a/src/main/res/layout/item_stats_entry.xml
+++ b/src/main/res/layout/item_stats_entry.xml
@@ -19,9 +19,25 @@
         android:paddingTop="4dp"/>
 
     <TextView
+        android:id="@+id/statsExposureDots"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="2dp"
+        android:textColor="@android:color/holo_green_dark"
+        android:textSize="12sp"/>
+
+    <TextView
         android:id="@+id/statsLookup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="2dp"/>
+
+    <TextView
+        android:id="@+id/statsLookupDots"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="2dp"
+        android:textColor="@android:color/holo_blue_dark"
+        android:textSize="12sp"/>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- display exposure and lookup dot indicators in the stats screen so the count matches the usage totals
- ensure the Android build manifest picks up dynamic version name/code properties
- update the CI workflow to bump the minor version on every build based on the run number

## Testing
- ./mvnw -B verify

------
https://chatgpt.com/codex/tasks/task_e_68cd73ee6ae4832aa17069487b8cd24e