### PR TITLE
Improve timeline stats interactions

### DIFF
--- a/src/main/java/com/example/ttreader/MainActivity.java
+++ b/src/main/java/com/example/ttreader/MainActivity.java
@@ -4,7 +4,9 @@ import android.app.Activity;
 import android.content.Intent;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
+import android.view.ViewTreeObserver;
 import android.widget.Button;
+import android.widget.ScrollView;
 
 import com.example.ttreader.data.DbHelper;
 import com.example.ttreader.data.MemoryDao;
@@ -21,9 +23,13 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private static final String SAMPLE_ASSET = "sample_book.ttmorph.jsonl";
     private static final String SAMPLE_WORK_ID = "sample_book.ttmorph";
 
+    public static final String EXTRA_TARGET_CHAR_INDEX = "com.example.ttreader.TARGET_CHAR_INDEX";
+
     private DbHelper dbHelper;
     private MemoryDao memoryDao;
     private UsageStatsDao usageStatsDao;
+    private ScrollView readerScrollView;
+    private ReaderView readerView;
 
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -35,10 +41,19 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         memoryDao = new MemoryDao(db);
         usageStatsDao = new UsageStatsDao(db);
 
-        ReaderView reader = findViewById(R.id.readerView);
-        reader.setup(dbHelper, memoryDao, usageStatsDao, this);
-        reader.setUsageContext(LANGUAGE_PAIR_TT_RU, SAMPLE_WORK_ID);
-        reader.loadFromJsonlAsset(SAMPLE_ASSET);
+        readerScrollView = findViewById(R.id.readerScrollView);
+        readerView = findViewById(R.id.readerView);
+        readerView.setup(dbHelper, memoryDao, usageStatsDao, this);
+        readerView.setUsageContext(LANGUAGE_PAIR_TT_RU, SAMPLE_WORK_ID);
+        readerView.loadFromJsonlAsset(SAMPLE_ASSET);
+
+        if (readerScrollView != null) {
+            ViewTreeObserver observer = readerScrollView.getViewTreeObserver();
+            observer.addOnScrollChangedListener(() ->
+                    readerView.onViewportChanged(readerScrollView.getScrollY(), readerScrollView.getHeight()));
+            readerScrollView.post(() ->
+                    readerView.onViewportChanged(readerScrollView.getScrollY(), readerScrollView.getHeight()));
+        }
 
         Button languageStatsButton = findViewById(R.id.btnLanguageStats);
         languageStatsButton.setOnClickListener(v -> {
@@ -56,11 +71,66 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
             intent.putExtra(StatsActivity.EXTRA_WORK_ID, SAMPLE_WORK_ID);
             startActivity(intent);
         });
+
+        handleNavigationIntent(getIntent());
+    }
+
+    @Override protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleNavigationIntent(intent);
     }
 
     @Override public void onTokenLongPress(TokenSpan span, List<String> ruLemmas) {
+        showTokenSheet(span, ruLemmas);
+    }
+
+    private void handleNavigationIntent(Intent intent) {
+        if (intent == null) return;
+        int targetIndex = intent.getIntExtra(EXTRA_TARGET_CHAR_INDEX, -1);
+        if (targetIndex < 0) return;
+        intent.removeExtra(EXTRA_TARGET_CHAR_INDEX);
+        if (readerView == null) return;
+        readerView.post(() -> navigateToCharIndex(targetIndex, 0));
+    }
+
+    private void navigateToCharIndex(int charIndex, int attempt) {
+        if (readerView == null) return;
+        TokenSpan span = readerView.findSpanForCharIndex(charIndex);
+        if (span == null) {
+            if (attempt < 5) {
+                readerView.postDelayed(() -> navigateToCharIndex(charIndex, attempt + 1), 50);
+            }
+            return;
+        }
+        readerView.ensureExposureLogged(span);
+        scrollToSpan(span, attempt);
+        readerView.postDelayed(() -> readerView.showTokenInfo(span), 150);
+    }
+
+    private void scrollToSpan(TokenSpan span, int attempt) {
+        if (readerView == null || readerScrollView == null || span == null) return;
+        android.text.Layout layout = readerView.getLayout();
+        CharSequence text = readerView.getText();
+        if ((layout == null || text == null) && attempt < 5) {
+            readerView.postDelayed(() -> scrollToSpan(span, attempt + 1), 50);
+            return;
+        } else if (layout == null || text == null) {
+            return;
+        }
+        int textLength = text.length();
+        int start = Math.max(0, Math.min(span.getStartIndex(), textLength));
+        int line = layout.getLineForOffset(start);
+        int y = readerView.getTotalPaddingTop() + layout.getLineTop(line);
+        readerScrollView.smoothScrollTo(0, y);
+        readerScrollView.post(() ->
+                readerView.onViewportChanged(readerScrollView.getScrollY(), readerScrollView.getHeight()));
+    }
+
+    private void showTokenSheet(TokenSpan span, List<String> ruLemmas) {
         if (span == null || span.token == null || span.token.analysis == null) return;
-        String ruCsv = ruLemmas.isEmpty()? "—" : String.join(", ", ruLemmas);
+        List<String> safeRu = ruLemmas == null ? new java.util.ArrayList<>() : ruLemmas;
+        String ruCsv = safeRu.isEmpty()? "—" : String.join(", ", safeRu);
         TokenInfoBottomSheet sheet = TokenInfoBottomSheet.newInstance(span.token.surface, span.token.analysis, ruCsv);
         sheet.setUsageStatsDao(usageStatsDao);
         sheet.setUsageContext(LANGUAGE_PAIR_TT_RU, SAMPLE_WORK_ID, span.getStartIndex());

--- a/src/main/res/layout/activity_main.xml
+++ b/src/main/res/layout/activity_main.xml
@@ -27,6 +27,7 @@
     </LinearLayout>
 
     <ScrollView
+        android:id="@+id/readerScrollView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1">

--- a/src/main/res/layout/item_stats_entry.xml
+++ b/src/main/res/layout/item_stats_entry.xml
@@ -24,6 +24,28 @@
         android:layout_height="36dp"
         android:paddingTop="4dp"/>
 
+    <LinearLayout
+        android:id="@+id/statsExposureTimelineLabels"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="2dp">
+
+        <TextView
+            android:id="@+id/statsExposureTimelineStart"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+
+        <TextView
+            android:id="@+id/statsExposureTimelineEnd"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="end"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+    </LinearLayout>
+
     <TextView
         android:id="@+id/statsLookup"
         android:layout_width="wrap_content"
@@ -35,5 +57,27 @@
         android:layout_width="match_parent"
         android:layout_height="36dp"
         android:paddingTop="4dp"/>
+
+    <LinearLayout
+        android:id="@+id/statsLookupTimelineLabels"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="2dp">
+
+        <TextView
+            android:id="@+id/statsLookupTimelineStart"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+
+        <TextView
+            android:id="@+id/statsLookupTimelineEnd"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="end"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- log lemma exposure events when tokens actually enter the viewport and expose helpers for navigation from statistics
- surface start and current timestamps under language timelines and enable work timelines to launch the reader at the selected occurrence
- add the necessary view identifiers and label containers to support the new interactions

## Testing
- ./mvnw -q -DskipTests package *(fails: missing Android SDK platform files in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd826e3040832ab5281c09e57859b5