### PR TITLE
Add sorting controls and filtering to statistics screen

### DIFF
--- a/src/main/res/drawable/ic_sort_alpha_down.xml
+++ b/src/main/res/drawable/ic_sort_alpha_down.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,19 L8,5 H10 L14,19 H11.7 L10.9,16.5 H7.1 L6.3,19 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.8,13 H12.2 V14.8 H7.8 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,15 H20 L16,19 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,5 H17 V15 H15 Z" />
+</vector>

--- a/src/main/res/drawable/ic_sort_alpha_up.xml
+++ b/src/main/res/drawable/ic_sort_alpha_up.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,19 L8,5 H10 L14,19 H11.7 L10.9,16.5 H7.1 L6.3,19 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.8,13 H12.2 V14.8 H7.8 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,9 L20,9 L16,5 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,9 H17 V19 H15 Z" />
+</vector>

--- a/src/main/res/drawable/ic_sort_exposure_down.xml
+++ b/src/main/res/drawable/ic_sort_exposure_down.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,5 H7 V19 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,5 H13 V8 H7 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,10.5 H12 V13.5 H7 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,16 H13 V19 H7 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,15 H20 L16,19 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,5 H17 V15 H15 Z" />
+</vector>

--- a/src/main/res/drawable/ic_sort_exposure_up.xml
+++ b/src/main/res/drawable/ic_sort_exposure_up.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,5 H7 V19 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,5 H13 V8 H7 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,10.5 H12 V13.5 H7 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,16 H13 V19 H7 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,9 L20,9 L16,5 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,9 H17 V19 H15 Z" />
+</vector>

--- a/src/main/res/drawable/ic_sort_lookup_down.xml
+++ b/src/main/res/drawable/ic_sort_lookup_down.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,5 H7 V19 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,16 H12 V19 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,15 H20 L16,19 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,5 H17 V15 H15 Z" />
+</vector>

--- a/src/main/res/drawable/ic_sort_lookup_up.xml
+++ b/src/main/res/drawable/ic_sort_lookup_up.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,5 H7 V19 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,16 H12 V19 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,9 L20,9 L16,5 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,9 H17 V19 H15 Z" />
+</vector>

--- a/src/main/res/drawable/ic_sort_time_down.xml
+++ b/src/main/res/drawable/ic_sort_time_down.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,5 H14 V8 H11 V19 H7 V8 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,15 H20 L16,19 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,5 H17 V15 H15 Z" />
+</vector>

--- a/src/main/res/drawable/ic_sort_time_up.xml
+++ b/src/main/res/drawable/ic_sort_time_up.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,5 H14 V8 H11 V19 H7 V8 H4 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,9 L20,9 L16,5 Z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,9 H17 V19 H15 Z" />
+</vector>

--- a/src/main/res/layout/activity_stats.xml
+++ b/src/main/res/layout/activity_stats.xml
@@ -9,6 +9,120 @@
         android:orientation="vertical"
         android:padding="16dp">
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingBottom="12dp">
+
+            <EditText
+                android:id="@+id/statsFilterInput"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/stats_filter_hint"
+                android:imeOptions="actionDone"
+                android:inputType="text"
+                android:maxLines="1"
+                android:padding="8dp" />
+
+            <HorizontalScrollView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:overScrollMode="never"
+                android:scrollbars="none">
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <ImageButton
+                        android:id="@+id/buttonSortAlphaAsc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_alpha_asc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_alpha_up" />
+
+                    <ImageButton
+                        android:id="@+id/buttonSortAlphaDesc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_alpha_desc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_alpha_down" />
+
+                    <ImageButton
+                        android:id="@+id/buttonSortLookupCountDesc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_lookup_count_desc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_lookup_down" />
+
+                    <ImageButton
+                        android:id="@+id/buttonSortLookupTimeDesc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_lookup_time_desc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_time_down" />
+
+                    <ImageButton
+                        android:id="@+id/buttonSortLookupTimeAsc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_lookup_time_asc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_time_up" />
+
+                    <ImageButton
+                        android:id="@+id/buttonSortLookupCountAsc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_lookup_count_asc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_lookup_up" />
+
+                    <ImageButton
+                        android:id="@+id/buttonSortExposureCountDesc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_exposure_count_desc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_exposure_down" />
+
+                    <ImageButton
+                        android:id="@+id/buttonSortExposureCountAsc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/stats_sort_exposure_count_asc"
+                        android:padding="6dp"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/ic_sort_exposure_up" />
+
+                </LinearLayout>
+            </HorizontalScrollView>
+        </LinearLayout>
+
         <TextView
             android:id="@+id/statsAxisDescription"
             android:layout_width="wrap_content"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -26,6 +26,16 @@
     <string name="stats_lookup_label">Открыто в подсказке: %1$d (последний раз %2$s)</string>
     <string name="stats_feature_label">%1$s — %2$d (последний раз %3$s)</string>
     <string name="stats_time_never">никогда</string>
+    <string name="stats_filter_hint">Фильтр по слову</string>
+    <string name="stats_filter_empty">Совпадений не найдено</string>
+    <string name="stats_sort_alpha_asc">Сортировать по алфавиту</string>
+    <string name="stats_sort_alpha_desc">Сортировать по алфавиту (обратно)</string>
+    <string name="stats_sort_lookup_count_desc">Сортировать по частоте подглядывания (по убыванию)</string>
+    <string name="stats_sort_lookup_time_desc">Сортировать по последнему времени подглядывания</string>
+    <string name="stats_sort_lookup_time_asc">Сортировать по самому раннему времени подглядывания</string>
+    <string name="stats_sort_lookup_count_asc">Сортировать по частоте подглядывания (по возрастанию)</string>
+    <string name="stats_sort_exposure_count_desc">Сортировать по встречаемости слова (по убыванию)</string>
+    <string name="stats_sort_exposure_count_asc">Сортировать по встречаемости слова (по возрастанию)</string>
     <string name="stats_axis_time">Ось времени: от %1$s до %2$s</string>
     <string name="stats_axis_text">Ось текста: от начала до символа %1$d</string>
     <string name="speech_toggle_content_start">Начать озвучку</string>


### PR DESCRIPTION
## Summary
- add sorting toolbar with filter field to the statistics screen layout
- implement customizable lemma sorting using Tatar alphabetical order and frequency/time criteria
- provide dedicated icons and strings for each sorting mode and show a message when filtering hides all entries

## Testing
- `./mvnw -q test` *(fails: requires Android platform jars that are not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbe0c0168832aba506c9f688a359b