### PR TITLE
Handle media buttons for word details

### DIFF
--- a/src/main/java/com/example/ttreader/MainActivity.java
+++ b/src/main/java/com/example/ttreader/MainActivity.java
@@ -473,7 +473,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                 if (mediaButtonIntent == null) return super.onMediaButtonEvent(mediaButtonIntent);
                 KeyEvent event = mediaButtonIntent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
                 if (event != null && event.getAction() == KeyEvent.ACTION_DOWN &&
-                        KeyEvent.isMediaKey(event.getKeyCode())) {
+                        isMediaKeyCode(event.getKeyCode())) {
                     Toast.makeText(MainActivity.this,
                             String.valueOf(event.getKeyCode()), Toast.LENGTH_SHORT).show();
                     handleMediaButton(event);
@@ -488,6 +488,29 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
 
     private void handleMediaButton(KeyEvent event) {
         speechProgressHandler.post(this::performMediaButtonAction);
+    }
+
+    private boolean isMediaKeyCode(int keyCode) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_MEDIA_PLAY:
+            case KeyEvent.KEYCODE_MEDIA_PAUSE:
+            case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+            case KeyEvent.KEYCODE_MEDIA_STOP:
+            case KeyEvent.KEYCODE_MEDIA_NEXT:
+            case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+            case KeyEvent.KEYCODE_MEDIA_REWIND:
+            case KeyEvent.KEYCODE_MEDIA_FAST_FORWARD:
+            case KeyEvent.KEYCODE_MEDIA_CLOSE:
+            case KeyEvent.KEYCODE_MEDIA_EJECT:
+            case KeyEvent.KEYCODE_MEDIA_AUDIO_TRACK:
+            case KeyEvent.KEYCODE_MEDIA_RECORD:
+            case KeyEvent.KEYCODE_MEDIA_STEP_FORWARD:
+            case KeyEvent.KEYCODE_MEDIA_STEP_BACKWARD:
+            case KeyEvent.KEYCODE_HEADSETHOOK:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private void performMediaButtonAction() {


### PR DESCRIPTION
## Summary
- keep speech running when the activity pauses instead of force-pausing it
- keep the media session active and react to any media button by opening the details for the word that is currently being narrated
- expand playback-state reporting so transport controls stay available while playback is idle
- display a Toast with the pressed media key code when handling media buttons

## Testing
- ./mvnw -q verify -DskipTests *(fails: missing /usr/lib/android-sdk/platforms/android-28/android.jar in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd5814d70832a993f62cb99d33b6a