### PR TITLE
Refactor TTS playback around MediaBrowserServiceCompat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,5 +361,10 @@ fi
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>androidx.media</groupId>
+      <artifactId>media</artifactId>
+      <version>1.7.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -21,5 +21,13 @@
         </activity>
         <activity android:name=".StatsActivity" />
 
+        <service
+            android:name=".reader.ReaderTtsService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
+        </service>
+
     </application>
 </manifest>

--- a/src/main/java/com/example/ttreader/reader/ReaderTtsService.java
+++ b/src/main/java/com/example/ttreader/reader/ReaderTtsService.java
@@ -1,0 +1,101 @@
+package com.example.ttreader.reader;
+
+import android.content.Intent;
+import android.os.Binder;
+import android.os.Bundle;
+import android.os.IBinder;
+
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.MediaBrowserServiceCompat;
+import android.support.v4.media.session.MediaSessionCompat;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * MediaBrowserService-based host for {@link TtsReaderController} that exposes
+ * reader speech playback through a media session.
+ */
+public class ReaderTtsService extends MediaBrowserServiceCompat {
+    private static final String MEDIA_ROOT_ID = "uqureader.media.ROOT";
+
+    private final IBinder localBinder = new LocalBinder();
+    private TtsReaderController controller;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        controller = new TtsReaderController(this, null);
+        MediaSessionCompat session = controller.getMediaSession();
+        if (session != null) {
+            setSessionToken(session.getSessionToken());
+        }
+    }
+
+    @Override
+    public BrowserRoot onGetRoot(String clientPackageName, int clientUid, Bundle rootHints) {
+        return new BrowserRoot(MEDIA_ROOT_ID, null);
+    }
+
+    @Override
+    public void onLoadChildren(String parentId, Result<List<MediaBrowserCompat.MediaItem>> result) {
+        result.sendResult(Collections.emptyList());
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        if (SERVICE_INTERFACE.equals(intent.getAction())) {
+            return super.onBind(intent);
+        }
+        return localBinder;
+    }
+
+    public void setTranslationProvider(TtsReaderController.TranslationProvider provider) {
+        if (controller != null) {
+            controller.setTranslationProvider(provider);
+        }
+    }
+
+    public void setTokenSequence(List<TokenSpan> spans) {
+        if (controller != null) {
+            controller.setTokenSequence(spans);
+        }
+    }
+
+    public void startReading() {
+        if (controller != null) {
+            controller.startReading();
+        }
+    }
+
+    public void resumeReading() {
+        if (controller != null) {
+            controller.resumeReading();
+        }
+    }
+
+    public void speakTokenDetails(TokenSpan span, List<String> translations, boolean resumeAfter) {
+        if (controller != null) {
+            controller.speakTokenDetails(span, translations, resumeAfter);
+        }
+    }
+
+    public void releaseController() {
+        if (controller != null) {
+            controller.release();
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        releaseController();
+        controller = null;
+        super.onDestroy();
+    }
+
+    public final class LocalBinder extends Binder {
+        public ReaderTtsService getService() {
+            return ReaderTtsService.this;
+        }
+    }
+}

--- a/src/main/java/com/example/ttreader/reader/TtsReaderController.java
+++ b/src/main/java/com/example/ttreader/reader/TtsReaderController.java
@@ -2,8 +2,8 @@ package com.example.ttreader.reader;
 
 import android.content.Context;
 import android.media.AudioAttributes;
-import android.media.session.MediaSession;
-import android.media.session.PlaybackState;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -49,13 +49,13 @@ public class TtsReaderController {
     }
 
     private final Context context;
-    private final TranslationProvider translationProvider;
+    private TranslationProvider translationProvider;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final AtomicInteger utteranceCounter = new AtomicInteger();
     private final List<TokenSpan> sequence = new ArrayList<>();
 
     private TextToSpeech tts;
-    private MediaSession mediaSession;
+    private MediaSessionCompat mediaSession;
     private boolean initialized = false;
     private boolean pendingStart = false;
     private boolean isSpeaking = false;
@@ -71,6 +71,14 @@ public class TtsReaderController {
         initializeMediaSession();
     }
 
+    public void setTranslationProvider(TranslationProvider provider) {
+        this.translationProvider = provider;
+    }
+
+    public MediaSessionCompat getMediaSession() {
+        return mediaSession;
+    }
+
     private void initializeTextToSpeech() {
         if (context == null) return;
         tts = new TextToSpeech(context, this::handleTtsInit, RHVOICE_PACKAGE);
@@ -79,9 +87,9 @@ public class TtsReaderController {
 
     private void initializeMediaSession() {
         if (context == null) return;
-        mediaSession = new MediaSession(context, TAG);
+        mediaSession = new MediaSessionCompat(context, TAG);
         mediaSession.setCallback(new ReaderMediaSessionCallback(this));
-        mediaSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS | MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+        mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS | MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
         mediaSession.setActive(true);
         updatePlaybackState();
     }
@@ -297,23 +305,23 @@ public class TtsReaderController {
         int playbackState;
         switch (mode) {
             case Mode.READING:
-                playbackState = PlaybackState.STATE_PLAYING;
+                playbackState = PlaybackStateCompat.STATE_PLAYING;
                 break;
             case Mode.DETAIL:
             case Mode.WAITING_RESUME:
-                playbackState = PlaybackState.STATE_PAUSED;
+                playbackState = PlaybackStateCompat.STATE_PAUSED;
                 break;
             case Mode.IDLE:
             default:
-                playbackState = PlaybackState.STATE_STOPPED;
+                playbackState = PlaybackStateCompat.STATE_STOPPED;
                 break;
         }
-        PlaybackState.Builder builder = new PlaybackState.Builder()
-                .setActions(PlaybackState.ACTION_PLAY
-                        | PlaybackState.ACTION_PAUSE
-                        | PlaybackState.ACTION_PLAY_PAUSE
-                        | PlaybackState.ACTION_STOP)
-                .setState(playbackState, PlaybackState.PLAYBACK_POSITION_UNKNOWN, 1.0f);
+        PlaybackStateCompat.Builder builder = new PlaybackStateCompat.Builder()
+                .setActions(PlaybackStateCompat.ACTION_PLAY
+                        | PlaybackStateCompat.ACTION_PAUSE
+                        | PlaybackStateCompat.ACTION_PLAY_PAUSE
+                        | PlaybackStateCompat.ACTION_STOP)
+                .setState(playbackState, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 1.0f);
         mediaSession.setPlaybackState(builder.build());
     }
 
@@ -358,7 +366,7 @@ public class TtsReaderController {
         }
     }
 
-    private static final class ReaderMediaSessionCallback extends MediaSession.Callback {
+    private static final class ReaderMediaSessionCallback extends MediaSessionCompat.Callback {
         private final TtsReaderController controller;
 
         ReaderMediaSessionCallback(TtsReaderController controller) {


### PR DESCRIPTION
## Summary
- add a ReaderTtsService that exposes TTS playback through MediaBrowserServiceCompat
- convert TtsReaderController to use MediaSessionCompat and allow the translation provider to be set from clients
- bind MainActivity to the new service, configure sequences, and register the service in the manifest along with the androidx.media dependency

## Testing
- ./mvnw -q -DskipTests package *(fails: missing Android platform and androidx.media dependency resolution in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdebf9ec5c832a80b0c9986efdba02