### PR TITLE
Show icons for stats actions in overflow menu

### DIFF
--- a/src/main/java/com/example/ttreader/MainActivity.java
+++ b/src/main/java/com/example/ttreader/MainActivity.java
@@ -190,6 +190,11 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         return true;
     }
 
+    @Override public boolean onPrepareOptionsMenu(Menu menu) {
+        setOverflowMenuIconsVisible(menu);
+        return super.onPrepareOptionsMenu(menu);
+    }
+
     @Override public boolean onOptionsItemSelected(MenuItem item) {
         if (item == null) return super.onOptionsItemSelected(item);
         int id = item.getItemId();
@@ -358,6 +363,17 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                 setForceShowIcon.setAccessible(true);
                 setForceShowIcon.invoke(helper, true);
             }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void setOverflowMenuIconsVisible(Menu menu) {
+        if (menu == null) return;
+        try {
+            Method setOptionalIconsVisible = menu.getClass()
+                    .getDeclaredMethod("setOptionalIconsVisible", boolean.class);
+            setOptionalIconsVisible.setAccessible(true);
+            setOptionalIconsVisible.invoke(menu, true);
         } catch (Exception ignored) {
         }
     }


### PR DESCRIPTION
## Summary
- ensure the overflow options menu enables icon visibility so the stats actions use their SVG icons even when they overflow into the context menu

## Testing
- ./mvnw -q -DskipTests package *(fails: missing android-28 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68cef558c4e8832ab961ead0241202b2