### PR TITLE
Show only the UquReader logo in the toolbar corner

### DIFF
--- a/src/main/java/com/example/ttreader/MainActivity.java
+++ b/src/main/java/com/example/ttreader/MainActivity.java
@@ -1,5 +1,6 @@
 package com.example.ttreader;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.app.AlertDialog;
@@ -148,8 +149,16 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
 
         toolbar = findViewById(R.id.topToolbar);
         if (toolbar != null) {
+            toolbar.setTitle(null);
+            toolbar.setSubtitle(null);
             setActionBar(toolbar);
-            toolbar.setTitle(R.string.app_name);
+            ActionBar actionBar = getActionBar();
+            if (actionBar != null) {
+                actionBar.setDisplayShowTitleEnabled(false);
+                actionBar.setDisplayUseLogoEnabled(true);
+                actionBar.setDisplayShowHomeEnabled(true);
+                actionBar.setLogo(R.mipmap.ic_launcher);
+            }
         }
 
         readerScrollView = findViewById(R.id.readerScrollView);
@@ -335,9 +344,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
 
     private void updateLanguagePairIcon() {
         if (languagePairMenuItem == null) return;
-        int iconRes = LANGUAGE_PAIR_TT_RU.equals(currentLanguagePair)
-                ? R.drawable.ic_language_pair_tt_ru
-                : R.drawable.ic_language_menu;
+        int iconRes = R.drawable.ic_language_menu;
         languagePairMenuItem.setIcon(iconRes);
         View actionView = languagePairMenuItem.getActionView();
         if (actionView == null) return;
@@ -407,9 +414,6 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
             if (actionView != null) {
                 actionView.setContentDescription(menuTitle);
             }
-        }
-        if (toolbar != null) {
-            toolbar.setSubtitle(subtitle);
         }
         updateLanguagePairIcon();
     }

--- a/src/main/res/layout/activity_main.xml
+++ b/src/main/res/layout/activity_main.xml
@@ -11,10 +11,12 @@
         android:background="?android:colorBackground"
         android:elevation="4dp"
         android:gravity="center_vertical"
+        android:logo="@mipmap/ic_launcher"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
         android:popupTheme="@android:style/ThemeOverlay.Material.Light"
-        android:title="@string/app_name" />
+        android:title="@null"
+        android:subtitle="@null" />
 
     <ScrollView
         android:id="@+id/readerScrollView"

--- a/src/main/res/layout/menu_action_language_pair.xml
+++ b/src/main/res/layout/menu_action_language_pair.xml
@@ -16,5 +16,5 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:contentDescription="@null"
-        android:src="@drawable/ic_language_pair_tt_ru" />
+        android:src="@drawable/ic_language_menu" />
 </FrameLayout>

--- a/src/main/res/menu/main_actions.xml
+++ b/src/main/res/menu/main_actions.xml
@@ -13,7 +13,7 @@
     <item
         android:id="@+id/action_language_pair"
         android:actionLayout="@layout/menu_action_language_pair"
-        android:icon="@drawable/ic_language_pair_tt_ru"
+        android:icon="@drawable/ic_language_menu"
         android:title="@string/language_pair_button_unset"
         android:showAsAction="always" />
     <item


### PR DESCRIPTION
## Summary
- hide the toolbar title and subtitle so the top-left corner only shows the UquReader logo
- replace the language pair flag icon with the generic language icon to avoid showing the Russian flag
- stop using the toolbar subtitle for the language pair label so no text appears next to the logo

## Testing
- ./mvnw -q -DskipTests compile *(fails: missing android-28 platform in the build image)*

------
https://chatgpt.com/codex/tasks/task_e_68cef99d564c832ab553952922860417