### PR TITLE
Improve lemma detail skip handling and highlight layering

### DIFF
--- a/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -194,7 +194,8 @@ public class ReaderView extends TextView {
             return;
         }
         activeLetterSpan = new ForegroundColorSpan(letterHighlightColor);
-        text.setSpan(activeLetterSpan, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        int flags = Spanned.SPAN_EXCLUSIVE_EXCLUSIVE | (1 << Spanned.SPAN_PRIORITY_SHIFT);
+        text.setSpan(activeLetterSpan, start, end, flags);
         invalidate();
     }
 

--- a/src/main/java/com/example/ttreader/reader/TokenSpan.java
+++ b/src/main/java/com/example/ttreader/reader/TokenSpan.java
@@ -2,6 +2,8 @@ package com.example.ttreader.reader;
 
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.text.Spanned;
+import android.text.style.ForegroundColorSpan;
 import android.text.style.ReplacementSpan;
 
 import com.example.ttreader.model.Token;
@@ -33,15 +35,50 @@ public class TokenSpan extends ReplacementSpan {
     }
 
     @Override public void draw(Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, Paint paint) {
+        int baseColor = paint.getColor();
+        float segmentWidth = paint.measureText(text, start, end);
+
         if (lastAlpha > 0.03f) {
-            int old = paint.getColor();
-            int bg = (int)((lastAlpha * 0.18f) * 255) & 0xFF;
-            int color = (bg << 24) | (old & 0x00FFFFFF);
-            Paint p = new Paint(paint);
-            p.setColor(color);
-            float w = paint.measureText(text, start, end);
-            canvas.drawRect(x, top, x + w, bottom, p);
+            int alpha = Math.round(Math.min(1f, Math.max(0f, (float) (lastAlpha * 0.18f))) * 255f);
+            if (alpha > 0) {
+                Paint backgroundPaint = new Paint(paint);
+                int color = (alpha << 24) | (baseColor & 0x00FFFFFF);
+                backgroundPaint.setColor(color);
+                canvas.drawRect(x, top, x + segmentWidth, bottom, backgroundPaint);
+            }
         }
-        canvas.drawText(text, start, end, x, y, paint);
+
+        if (text instanceof Spanned) {
+            Spanned spanned = (Spanned) text;
+            float currentX = x;
+            int segmentStart = start;
+            while (segmentStart < end) {
+                int segmentEnd = spanned.nextSpanTransition(segmentStart, end, ForegroundColorSpan.class);
+                if (segmentEnd <= segmentStart) {
+                    segmentEnd = end;
+                }
+                ForegroundColorSpan[] spans = spanned.getSpans(segmentStart, segmentEnd, ForegroundColorSpan.class);
+                int segmentColor = baseColor;
+                int bestPriority = Integer.MIN_VALUE;
+                if (spans != null) {
+                    for (ForegroundColorSpan span : spans) {
+                        if (span == null) continue;
+                        int flags = spanned.getSpanFlags(span);
+                        int priority = (flags & Spanned.SPAN_PRIORITY) >>> Spanned.SPAN_PRIORITY_SHIFT;
+                        if (priority > bestPriority || (priority == bestPriority && spanned.getSpanStart(span) >= segmentStart)) {
+                            bestPriority = priority;
+                            segmentColor = span.getForegroundColor();
+                        }
+                    }
+                }
+                paint.setColor(segmentColor);
+                canvas.drawText(spanned, segmentStart, segmentEnd, currentX, y, paint);
+                currentX += paint.measureText(spanned, segmentStart, segmentEnd);
+                segmentStart = segmentEnd;
+            }
+            paint.setColor(baseColor);
+        } else {
+            canvas.drawText(text, start, end, x, y, paint);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure lemma detail skip commands stop the current playback and start the adjacent token while tracking the last detail span and resume preference, including external media controls
- dismiss the lemma info bottom sheet when returning to reading mode and restore focus to the reader view
- render letter highlights with higher priority so the green speech overlay sits above the grey token shading

## Testing
- `./mvnw -q -DskipTests package` *(fails: missing Android platform jar in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cf13537c48832abf66a463721ac0a4