### PR TITLE
Fix tat-rus importer to read nested lemma entries

### DIFF
--- a/web-app/src/main/java/com/example/uqureader/webapp/dictionary/TatRusDictionaryImporter.java
+++ b/web-app/src/main/java/com/example/uqureader/webapp/dictionary/TatRusDictionaryImporter.java
@@ -141,8 +141,8 @@ public final class TatRusDictionaryImporter {
     }
 
     private Entry parseEntry(Element element, String sectionId) {
-        Element lElement = findFirstChild(element, "l");
-        Element rElement = findFirstChild(element, "r");
+        Element lElement = findFirstDescendant(element, "l");
+        Element rElement = findFirstDescendant(element, "r");
         if (lElement == null || rElement == null) {
             return null;
         }
@@ -182,16 +182,13 @@ public final class TatRusDictionaryImporter {
         );
     }
 
-    private Element findFirstChild(Element parent, String tag) {
-        Node child = parent.getFirstChild();
-        while (child != null) {
-            if (child.getNodeType() == Node.ELEMENT_NODE) {
-                Element element = (Element) child;
-                if (tag.equals(element.getTagName())) {
-                    return element;
-                }
+    private Element findFirstDescendant(Element parent, String tag) {
+        NodeList nodes = parent.getElementsByTagName(tag);
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                return (Element) node;
             }
-            child = child.getNextSibling();
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- update the TatRus dictionary importer to locate lemma and translation elements anywhere under an entry
- ensure entries nested inside <p> tags are parsed so that the resulting list is populated

## Testing
- `./mvnw -pl web-app -am clean package`
- `JAVA_TOOL_OPTIONS="-Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080" ./mvnw -pl web-app exec:java -Dexec.mainClass=com.example.uqureader.webapp.Main -Dexec.args=--import-tat-rus`

------
https://chatgpt.com/codex/tasks/task_e_68cfac2a8600832aaed02b5064e58746