### PR TITLE
Add tool to augment JSONL assets with Russian translations

### DIFF
--- a/android-app/src/main/assets/berenche_teatr.ttmorph.jsonl
+++ b/android-app/src/main/assets/berenche_teatr.ttmorph.jsonl
@@ -1,153 +1,153 @@
-{"prefix": "", "surface": "Комедия", "analysis": "комедия+N+Sg+Nom;"}
+{"prefix": "", "surface": "Комедия", "analysis": "комедия+N+Sg+Nom;", "translations": ["комедия"]}
 {"prefix": " ", "surface": "1", "analysis": "Num"}
 {"prefix": " ", "surface": "пәрдәдә", "analysis": "пәрдә+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "КАТНАШАЛАР", "analysis": "катнаш+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "КАТНАШАЛАР", "analysis": "катнаш+V+PRES(Й)+3PL(ЛАр);", "translations": ["участвовать", "участие"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;"}
+{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;", "translations": ["богатый", "богач"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "иске", "analysis": "иске+Adj;иске+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "фикерле", "analysis": "фикер+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "Казан", "analysis": "казан+N+Sg+Nom;казан+PROP+Sg+Nom;казан+V+IMP_SG();"}
-{"prefix": " ", "surface": "бае", "analysis": "бае+V+IMP_SG();бай+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": "", "surface": "иске", "analysis": "иске+Adj;иске+PROP+Sg+Nom;", "translations": ["старый"]}
+{"prefix": " ", "surface": "фикерле", "analysis": "фикер+N+ATTR_MUN(лЫ);", "translations": ["мнение"]}
+{"prefix": " ", "surface": "Казан", "analysis": "казан+N+Sg+Nom;казан+PROP+Sg+Nom;казан+V+IMP_SG();", "translations": ["казан"]}
+{"prefix": " ", "surface": "бае", "analysis": "бае+V+IMP_SG();бай+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["богатый", "богач"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "башында", "analysis": "баш+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
-{"prefix": " ", "surface": "ак", "analysis": "ак+Adj;ак+V+IMP_SG();"}
-{"prefix": " ", "surface": "бүрек", "analysis": "бүрек+N+Sg+Nom;"}
+{"prefix": " ", "surface": "башында", "analysis": "баш+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["голова"]}
+{"prefix": " ", "surface": "ак", "analysis": "ак+Adj;ак+V+IMP_SG();", "translations": ["белый"]}
+{"prefix": " ", "surface": "бүрек", "analysis": "бүрек+N+Sg+Nom;", "translations": ["шапка"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "яшел", "analysis": "яшел+Adj;яшел+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "яшел", "analysis": "яшел+Adj;яшел+PROP+Sg+Nom;", "translations": ["зелёный"]}
 {"prefix": " ", "surface": "кәләпүш", "analysis": "кәләпүш+N+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "өстендә", "analysis": "өс+N+Sg+POSS_3(СЫ)+LOC(ДА);өстен+Adj+Sg+LOC(ДА);өстендә+POST;"}
-{"prefix": " ", "surface": "намаз", "analysis": "намаз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "туны", "analysis": "тун+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "өстендә", "analysis": "өс+N+Sg+POSS_3(СЫ)+LOC(ДА);өстен+Adj+Sg+LOC(ДА);өстендә+POST;", "translations": ["господствующий", "превосходить"]}
+{"prefix": " ", "surface": "намаз", "analysis": "намаз+N+Sg+Nom;", "translations": ["намаз"]}
+{"prefix": " ", "surface": "туны", "analysis": "тун+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["шуба"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "эченнән", "analysis": "эч+N+Sg+POSS_3(СЫ)+ABL(ДАн);эченнән+POST;"}
-{"prefix": " ", "surface": "бишмәт", "analysis": "бишмәт+N+Sg+Nom;"}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "эченнән", "analysis": "эч+N+Sg+POSS_3(СЫ)+ABL(ДАн);эченнән+POST;", "translations": ["в", "в течение", "внутренность", "внутри", "выпить", "из", "пить"]}
+{"prefix": " ", "surface": "бишмәт", "analysis": "бишмәт+N+Sg+Nom;", "translations": ["бешмет"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "эченнән", "analysis": "эч+N+Sg+POSS_3(СЫ)+ABL(ДАн);эченнән+POST;"}
-{"prefix": " ", "surface": "кыска", "analysis": "кыска+Adj;кыска+Adv;"}
-{"prefix": " ", "surface": "җиңле", "analysis": "җиң+N+ATTR_MUN(лЫ);"}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "эченнән", "analysis": "эч+N+Sg+POSS_3(СЫ)+ABL(ДАн);эченнән+POST;", "translations": ["в", "в течение", "внутренность", "внутри", "выпить", "из", "пить"]}
+{"prefix": " ", "surface": "кыска", "analysis": "кыска+Adj;кыска+Adv;", "translations": ["короткий", "коротко"]}
+{"prefix": " ", "surface": "җиңле", "analysis": "җиң+N+ATTR_MUN(лЫ);", "translations": ["победить", "рукав"]}
 {"prefix": " ", "surface": "камзул", "analysis": "камзул+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кигән", "analysis": "ки+V+PCP_PS(ГАн);ки+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "кигән", "analysis": "ки+V+PCP_PS(ГАн);ки+V+PST_INDF(ГАн);", "translations": ["одеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чалбар", "analysis": "чалбар+N+Sg+Nom;"}
+{"prefix": " ", "surface": "чалбар", "analysis": "чалбар+N+Sg+Nom;", "translations": ["брюки"]}
 {"prefix": " ", "surface": "балагын", "analysis": "балак+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "ак", "analysis": "ак+Adj;ак+V+IMP_SG();"}
+{"prefix": " ", "surface": "ак", "analysis": "ак+Adj;ак+V+IMP_SG();", "translations": ["белый"]}
 {"prefix": " ", "surface": "тасма", "analysis": "тасма+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "бәйләгән", "analysis": "бәйлә+V+PCP_PS(ГАн);бәйлә+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "бәйләгән", "analysis": "бәйлә+V+PCP_PS(ГАн);бәйлә+V+PST_INDF(ГАн);", "translations": ["связать", "связывать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "кызы", "analysis": "кыз+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "кызы", "analysis": "кыз+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "кияве", "analysis": "кияү+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "кияве", "analysis": "кияү+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["жених", "зять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "улы", "analysis": "ул+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "улы", "analysis": "ул+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Хәбибрахманның", "analysis": "NR"}
-{"prefix": " ", "surface": "хатыны", "analysis": "хатын+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "хатыны", "analysis": "хатын+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["жена", "женщина"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "асравы", "analysis": "асра+V+VN_1(у/ү/в)+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "асравы", "analysis": "асра+V+VN_1(у/ү/в)+POSS_3(СЫ)+Nom;", "translations": ["содержать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кыз", "analysis": "кыз+N+Sg+Nom;кыз+V+IMP_SG();"}
+{"prefix": " ", "surface": "кыз", "analysis": "кыз+N+Sg+Nom;кыз+V+IMP_SG();", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);"}
+{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);", "translations": ["богатый", "богач"]}
 {"prefix": " ", "surface": "кибетчесе", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Вакыйга", "analysis": "вакыйга+N+Sg+Nom;"}
-{"prefix": " ", "surface": "Казанда", "analysis": "казан+N+Sg+LOC(ДА);казан+PROP+LOC(ДА);"}
+{"prefix": " ", "surface": "Вакыйга", "analysis": "вакыйга+N+Sg+Nom;", "translations": ["событие"]}
+{"prefix": " ", "surface": "Казанда", "analysis": "казан+N+Sg+LOC(ДА);казан+PROP+LOC(ДА);", "translations": ["казан"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "өендә", "analysis": "өй+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
+{"prefix": " ", "surface": "байның", "analysis": "бай+N+Sg+GEN(нЫң);", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "өендә", "analysis": "өй+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["дом"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бай", "analysis": "бай+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Бай", "analysis": "бай+N+Sg+Nom;", "translations": ["богатый", "богач"]}
 {"prefix": " ", "surface": "сымак", "analysis": "сымак+POST;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "өй", "analysis": "өй+N+Sg+Nom;өй+V+IMP_SG();"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "өй", "analysis": "өй+N+Sg+Nom;өй+V+IMP_SG();", "translations": ["дом"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ике", "analysis": "ике+Num;"}
-{"prefix": " ", "surface": "якта", "analysis": "як+N+Sg+LOC(ДА);як+V+CAUS(т)+PRES(Й);"}
-{"prefix": " ", "surface": "икешәр", "analysis": "ике+Num+NUM_DISR(шАр);"}
-{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Ике", "analysis": "ике+Num;", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "якта", "analysis": "як+N+Sg+LOC(ДА);як+V+CAUS(т)+PRES(Й);", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "икешәр", "analysis": "ике+Num+NUM_DISR(шАр);", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;", "translations": ["дверь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Түрдә", "analysis": "түр+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "тәрәзәләр", "analysis": "тәрәзә+N+PL(ЛАр)+Nom;"}
+{"prefix": " ", "surface": "тәрәзәләр", "analysis": "тәрәзә+N+PL(ЛАр)+Nom;", "translations": ["окно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тәрәзә", "analysis": "тәрәзә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "арасында", "analysis": "ара+N+Sg+POSS_3(СЫ)+LOC(ДА);арасында+POST;"}
-{"prefix": " ", "surface": "көзге", "analysis": "көзге+Adj;көзге+N+Sg+Nom;"}
+{"prefix": " ", "surface": "тәрәзә", "analysis": "тәрәзә+N+Sg+Nom;", "translations": ["окно"]}
+{"prefix": " ", "surface": "арасында", "analysis": "ара+N+Sg+POSS_3(СЫ)+LOC(ДА);арасында+POST;", "translations": ["между", "промежуток", "среди"]}
+{"prefix": " ", "surface": "көзге", "analysis": "көзге+Adj;көзге+N+Sg+Nom;", "translations": ["зеркало"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Стена", "analysis": "стена+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Стена", "analysis": "стена+N+Sg+Nom;", "translations": ["стена"]}
 {"prefix": " ", "surface": "буенда", "analysis": "буенда+POST;"}
-{"prefix": " ", "surface": "урындыклар", "analysis": "урындык+N+PL(ЛАр)+Nom;"}
+{"prefix": " ", "surface": "урындыклар", "analysis": "урындык+N+PL(ЛАр)+Nom;", "translations": ["стул"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сул", "analysis": "сул+Adj;"}
-{"prefix": " ", "surface": "тарафта", "analysis": "тараф+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "диван", "analysis": "диван+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Сул", "analysis": "сул+Adj;", "translations": ["левый"]}
+{"prefix": " ", "surface": "тарафта", "analysis": "тараф+N+Sg+LOC(ДА);", "translations": ["сторона"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "диван", "analysis": "диван+N+Sg+Nom;", "translations": ["диван"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "алдында", "analysis": "ал+N+Sg+POSS_3(СЫ)+LOC(ДА);алдында+POST;"}
-{"prefix": " ", "surface": "өстәл", "analysis": "өстә+V+PASS(Ыл)+IMP_SG();өстәл+N+Sg+Nom;өстәл+V+IMP_SG();"}
+{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "алдында", "analysis": "ал+N+Sg+POSS_3(СЫ)+LOC(ДА);алдында+POST;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "өстәл", "analysis": "өстә+V+PASS(Ыл)+IMP_SG();өстәл+N+Sg+Nom;өстәл+V+IMP_SG();", "translations": ["добавить", "добавлять", "стол"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Пәрдә", "analysis": "пәрдә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ачылганда", "analysis": "ач+V+PASS(Ыл)+PCP_PS(ГАн)+LOC(ДА);ачыл+V+PCP_PS(ГАн)+LOC(ДА);"}
+{"prefix": " ", "surface": "ачылганда", "analysis": "ач+V+PASS(Ыл)+PCP_PS(ГАн)+LOC(ДА);ачыл+V+PCP_PS(ГАн)+LOC(ДА);", "translations": ["открывать", "открыть", "открываться", "открыться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сәхнәдә", "analysis": "сәхнә+N+Sg+LOC(ДА);"}
+{"prefix": " ", "surface": "сәхнәдә", "analysis": "сәхнә+N+Sg+LOC(ДА);", "translations": ["сцена"]}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "күренә", "analysis": "күр+V+REFL(Ын)+PRES(Й);күрен+V+PRES(Й);"}
+{"prefix": " ", "surface": "күренә", "analysis": "күр+V+REFL(Ын)+PRES(Й);күрен+V+PRES(Й);", "translations": ["видеть"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
 {"prefix": " ", "surface": "өстенә", "analysis": "өс+N+Sg+POSS_3(СЫ)+DIR(ГА);өстенә+POST;"}
 {"prefix": " ", "surface": "пальтосын", "analysis": "пальто+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "кигән", "analysis": "ки+V+PCP_PS(ГАн);ки+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "кигән", "analysis": "ки+V+PCP_PS(ГАн);ки+V+PST_INDF(ГАн);", "translations": ["одеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "таяк", "analysis": "тай+V+HOR_PL(Йк);таяк+N+Sg+Nom;"}
-{"prefix": " ", "surface": "тоткан", "analysis": "тот+V+PCP_PS(ГАн);тот+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["рука"]}
+{"prefix": " ", "surface": "таяк", "analysis": "тай+V+HOR_PL(Йк);таяк+N+Sg+Nom;", "translations": ["жеребец", "палка"]}
+{"prefix": " ", "surface": "тоткан", "analysis": "тот+V+PCP_PS(ГАн);тот+V+PST_INDF(ГАн);", "translations": ["держать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "күңеле", "analysis": "күңел+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "шат", "analysis": "шат+Adj;"}
+{"prefix": " ", "surface": "күңеле", "analysis": "күңел+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["душа"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "шат", "analysis": "шат+Adj;", "translations": ["радостный", "счастливый"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "өйнең", "analysis": "өй+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "башыннан", "analysis": "баш+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
+{"prefix": " ", "surface": "өйнең", "analysis": "өй+N+Sg+GEN(нЫң);", "translations": ["дом"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "башыннан", "analysis": "баш+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["голова"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["голова"]}
 {"prefix": " ", "surface": "кызу-кызу", "analysis": "кызу-кызу+Adv;"}
-{"prefix": " ", "surface": "атлап", "analysis": "ат+N+DISTR(лАп);атла+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);"}
+{"prefix": " ", "surface": "атлап", "analysis": "ат+N+DISTR(лАп);атла+V+ADVV_ACC(Ып);", "translations": ["лошадь", "стрелять", "шагать", "шагнуть"]}
+{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);", "translations": ["походить", "ходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "кычкырып", "analysis": "кычкыр+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "кычкырып", "analysis": "кычкыр+V+ADVV_ACC(Ып);", "translations": ["крикнуть", "кричать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
@@ -156,622 +156,622 @@
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "бүлмәдән", "analysis": "бүлмә+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "сузыбрак", "analysis": "суз+V+ADVV_ACC(Ып)+COMP(рАк)+Sg+Nom;"}
+{"prefix": "", "surface": "бүлмәдән", "analysis": "бүлмә+N+Sg+ABL(ДАн);", "translations": ["комната"]}
+{"prefix": " ", "surface": "сузыбрак", "analysis": "суз+V+ADVV_ACC(Ып)+COMP(рАк)+Sg+Nom;", "translations": ["тянуть"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әү", "analysis": "әү+INTRJ;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Буласыңмы", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);бул+V+PRES(Й)+2SG(сЫң)+INT(мЫ);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Буласыңмы", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);бул+V+PRES(Й)+2SG(сЫң)+INT(мЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "Тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Халыкка", "analysis": "халык+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Халыкка", "analysis": "халык+N+Sg+DIR(ГА);", "translations": ["народ", "народный", "толпа"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
-{"prefix": " ", "surface": "дисәң", "analysis": "ди+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "дисәң", "analysis": "ди+V+COND(сА)+2SG(ң);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "җиргә", "analysis": "җир+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);"}
-{"prefix": " ", "surface": "башладың", "analysis": "башла+V+PST_DEF(ДЫ)+2SG(ң);"}
-{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "җиргә", "analysis": "җир+N+Sg+DIR(ГА);", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "башладың", "analysis": "башла+V+PST_DEF(ДЫ)+2SG(ң);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
+{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;", "translations": ["быть", "дуть", "запах"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "күрә", "analysis": "күр+V+PRES(Й);күрә+POST;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "коты", "analysis": "кот+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "күрә", "analysis": "күр+V+PRES(Й);күрә+POST;", "translations": ["видеть", "ввиду", "по"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "коты", "analysis": "кот+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["душа", "красота"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);"}
+{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "каршында", "analysis": "каршында+Adj;каршында+POST;"}
-{"prefix": " ", "surface": "ир", "analysis": "ир+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ерткыч", "analysis": "ерткыч+N+Sg+Nom;"}
-{"prefix": " ", "surface": "җанвар", "analysis": "җанвар+N+Sg+Nom;"}
-{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "икесе", "analysis": "ике+Num+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "ир", "analysis": "ир+N+Sg+Nom;", "translations": ["мужчина"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;", "translations": ["слово"]}
+{"prefix": " ", "surface": "ерткыч", "analysis": "ерткыч+N+Sg+Nom;", "translations": ["зверь", "хищник"]}
+{"prefix": " ", "surface": "җанвар", "analysis": "җанвар+N+Sg+Nom;", "translations": ["зверь"]}
+{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;", "translations": ["слово"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "икесе", "analysis": "ике+Num+POSS_3(СЫ)+Nom;", "translations": ["второй", "два", "оба"]}
 {"prefix": " ", "surface": "бертигез", "analysis": "бертигез+Adj;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бары", "analysis": "бар+N+Sg+POSS_3(СЫ)+Nom;бар+PN+POSS_3(СЫ)+Nom;бары+CNJ;бары+PN;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "Бары", "analysis": "бар+N+Sg+POSS_3(СЫ)+Nom;бар+PN+POSS_3(СЫ)+Nom;бары+CNJ;бары+PN;", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
-{"prefix": " ", "surface": "куркынычлы", "analysis": "куркыныч+Adj+Sg+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "җанвар", "analysis": "җанвар+N+Sg+Nom;"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
+{"prefix": " ", "surface": "куркынычлы", "analysis": "куркыныч+Adj+Sg+ATTR_MUN(лЫ);", "translations": ["опасно", "опасность", "опасный"]}
+{"prefix": " ", "surface": "җанвар", "analysis": "җанвар+N+Sg+Nom;", "translations": ["зверь"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Башта", "analysis": "баш+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "миннән", "analysis": "мин+PN+ABL(ДАн);"}
+{"prefix": " ", "surface": "Башта", "analysis": "баш+N+Sg+LOC(ДА);", "translations": ["голова"]}
+{"prefix": " ", "surface": "миннән", "analysis": "мин+PN+ABL(ДАн);", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "коты", "analysis": "кот+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "очты", "analysis": "оч+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "коты", "analysis": "кот+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["душа", "красота"]}
+{"prefix": " ", "surface": "очты", "analysis": "оч+V+PST_DEF(ДЫ);", "translations": ["лететь", "острие"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кияү", "analysis": "кияү+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Кияү", "analysis": "кияү+N+Sg+Nom;", "translations": ["жених", "зять"]}
+{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "куркуыннан", "analysis": "курк+V+VN_1(у/ү/в)+POSS_3(СЫ)+ABL(ДАн);курку+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
+{"prefix": " ", "surface": "куркуыннан", "analysis": "курк+V+VN_1(у/ү/в)+POSS_3(СЫ)+ABL(ДАн);курку+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["испугаться", "страх"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "куян", "analysis": "куян+N+Sg+Nom;"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
+{"prefix": " ", "surface": "куян", "analysis": "куян+N+Sg+Nom;", "translations": ["заяц"]}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "почмакка", "analysis": "почмак+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "почмакка", "analysis": "почмак+N+Sg+DIR(ГА);", "translations": ["угол", "уголок"]}
 {"prefix": " ", "surface": "посып", "analysis": "пос+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;", "translations": ["но", "только"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соңыннан", "analysis": "соң+N+Sg+POSS_3(СЫ)+ABL(ДАн);соңыннан+Adv;"}
+{"prefix": " ", "surface": "Соңыннан", "analysis": "соң+N+Sg+POSS_3(СЫ)+ABL(ДАн);соңыннан+Adv;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "тарафтан", "analysis": "тараф+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "яшенә", "analysis": "яшь+Adj+Sg+POSS_3(СЫ)+DIR(ГА);яшь+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "җиткәнгә", "analysis": "җит+V+PCP_PS(ГАн)+DIR(ГА);җиткән+Adj+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
+{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "тарафтан", "analysis": "тараф+N+Sg+ABL(ДАн);", "translations": ["сторона"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "яшенә", "analysis": "яшь+Adj+Sg+POSS_3(СЫ)+DIR(ГА);яшь+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["возраст", "год²", "молодой", "юный"]}
+{"prefix": " ", "surface": "җиткәнгә", "analysis": "җит+V+PCP_PS(ГАн)+DIR(ГА);җиткән+Adj+Sg+DIR(ГА);", "translations": ["дойти", "доходить"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
 {"prefix": " ", "surface": "ата-анасыннан", "analysis": "ата-ана+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "ишетмәгән", "analysis": "ишет+V+NEG(мА)+PCP_PS(ГАн);ишет+V+NEG(мА)+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "тәмле", "analysis": "тәм+N+ATTR_MUN(лЫ);тәмле+Adj;"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "ишетмәгән", "analysis": "ишет+V+NEG(мА)+PCP_PS(ГАн);ишет+V+NEG(мА)+PST_INDF(ГАн);", "translations": ["слышать", "услышать"]}
+{"prefix": " ", "surface": "тәмле", "analysis": "тәм+N+ATTR_MUN(лЫ);тәмле+Adj;", "translations": ["вкус", "вкусный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "татлы", "analysis": "тат+N+ATTR_MUN(лЫ);татлы+Adj;"}
-{"prefix": " ", "surface": "сүзләрне", "analysis": "сүз+N+PL(ЛАр)+ACC(нЫ);"}
-{"prefix": " ", "surface": "ишеткәч", "analysis": "ишет+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "сүзләрне", "analysis": "сүз+N+PL(ЛАр)+ACC(нЫ);", "translations": ["слово"]}
+{"prefix": " ", "surface": "ишеткәч", "analysis": "ишет+V+ADVV_ANT(ГАч);", "translations": ["слышать", "услышать"]}
 {"prefix": " ", "surface": "кенә", "analysis": "кенә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;"}
+{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;", "translations": ["немного"]}
 {"prefix": " ", "surface": "җайланды", "analysis": "җайла+V+REFL(Ын)+PST_DEF(ДЫ);җайлан+V+PST_DEF(ДЫ);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ян", "analysis": "ян+N+Sg+Nom;ян+V+IMP_SG();"}
-{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Ян", "analysis": "ян+N+Sg+Nom;ян+V+IMP_SG();", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
+{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
 {"prefix": " ", "surface": "тыгып", "analysis": "тык+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "һи", "analysis": "һи+INTRJ;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "тиз", "analysis": "тиз+Adj;тиз+Adv;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "тиз", "analysis": "тиз+Adj;тиз+Adv;", "translations": ["быстро", "быстрый"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "буласың", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бул+V+PRES(Й)+2SG(сЫң);"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "буласың", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бул+V+PRES(Й)+2SG(сЫң);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;"}
+{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;", "translations": ["пожалуйста"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
-{"prefix": " ", "surface": "күр", "analysis": "күр+V+IMP_SG();"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "күр", "analysis": "күр+V+IMP_SG();", "translations": ["видеть"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "әгәр", "analysis": "әгәр+CNJ;"}
 {"prefix": " ", "surface": "каенатай", "analysis": "NR"}
-{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "керсә", "analysis": "кер+V+COND(сА);"}
+{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "керсә", "analysis": "кер+V+COND(сА);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "ары", "analysis": "ар+N+Sg+POSS_3(СЫ)+Nom;ары+Adj;ары+V+IMP_SG();"}
+{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ары", "analysis": "ар+N+Sg+POSS_3(СЫ)+Nom;ары+Adj;ары+V+IMP_SG();", "translations": ["дальше", "после", "устать"]}
 {"prefix": " ", "surface": "харап", "analysis": "харап+Adj;"}
-{"prefix": " ", "surface": "эш", "analysis": "эш+N+Sg+Nom;"}
+{"prefix": " ", "surface": "эш", "analysis": "эш+N+Sg+Nom;", "translations": ["дело"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "итсә", "analysis": "и+V+CAUS(т)+COND(сА);ит+V+COND(сА);"}
-{"prefix": " ", "surface": "итәр", "analysis": "и+V+CAUS(т)+PCP_FUT(Ыр);ит+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "итсә", "analysis": "и+V+CAUS(т)+COND(сА);ит+V+COND(сА);", "translations": ["быть", "делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "итәр", "analysis": "и+V+CAUS(т)+PCP_FUT(Ыр);ит+V+PCP_FUT(Ыр);", "translations": ["быть", "делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "гомердә", "analysis": "гомер+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "җибәрмәс", "analysis": "җибәр+V+FUT_INDF_NEG(мАс);җибәр+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "гомердә", "analysis": "гомер+N+Sg+LOC(ДА);", "translations": ["жизнь"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "җибәрмәс", "analysis": "җибәр+V+FUT_INDF_NEG(мАс);җибәр+V+PCP_FUT(мАс);", "translations": ["пускать", "пустить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "бүлмә", "analysis": "бүл+V+NEG(мА)+IMP_SG();бүлмә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ишегеннән", "analysis": "ишек+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
+{"prefix": "", "surface": "Башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
+{"prefix": " ", "surface": "бүлмә", "analysis": "бүл+V+NEG(мА)+IMP_SG();бүлмә+N+Sg+Nom;", "translations": ["делить", "поделить", "комната"]}
+{"prefix": " ", "surface": "ишегеннән", "analysis": "ишек+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);", "translations": ["народ", "народный", "толпа"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "куллары", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "куллары", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["рука"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": " ", "surface": "хатын-кыз", "analysis": "хатын-кыз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "битенә", "analysis": "бит+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
+{"prefix": " ", "surface": "битенә", "analysis": "бит+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "пудра", "analysis": "пудра+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сөрткән", "analysis": "сөр+V+CAUS(т)+PCP_PS(ГАн);сөр+V+CAUS(т)+PST_INDF(ГАн);сөрт+V+PCP_PS(ГАн);сөрт+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "күрсәтеп", "analysis": "күрсәт+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "сөрткән", "analysis": "сөр+V+CAUS(т)+PCP_PS(ГАн);сөр+V+CAUS(т)+PST_INDF(ГАн);сөрт+V+PCP_PS(ГАн);сөрт+V+PST_INDF(ГАн);", "translations": ["вытереть", "вытирать"]}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "күрсәтеп", "analysis": "күрсәт+V+ADVV_ACC(Ып);", "translations": ["показать", "показывать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;"}
-{"prefix": " ", "surface": "көлебрәк", "analysis": "көл+V+ADVV_ACC(Ып)+COMP(рАк)+Sg+Nom;"}
+{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;", "translations": ["немного"]}
+{"prefix": " ", "surface": "көлебрәк", "analysis": "көл+V+ADVV_ACC(Ып)+COMP(рАк)+Sg+Nom;", "translations": ["засмеяться", "смеяться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Бизәнә", "analysis": "бизә+V+REFL(Ын)+PRES(Й);бизән+V+PRES(Й);"}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
-{"prefix": " ", "surface": "мич", "analysis": "мич+N+Sg+Nom;"}
+{"prefix": " ", "surface": "мич", "analysis": "мич+N+Sg+Nom;", "translations": ["печка", "печь"]}
 {"prefix": " ", "surface": "акшарлаган", "analysis": "акшарла+V+PCP_PS(ГАн);акшарла+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "битләрен", "analysis": "бит+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "битләрен", "analysis": "бит+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "буяп", "analysis": "буя+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "маташа", "analysis": "маташ+V+PRES(Й);"}
+{"prefix": " ", "surface": "маташа", "analysis": "маташ+V+PRES(Й);", "translations": ["попытаться", "пытаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "үзенә", "analysis": "үз+PN+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "килешеп", "analysis": "кил+V+RECP(Ыш)+ADVV_ACC(Ып);килеш+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
+{"prefix": " ", "surface": "үзенә", "analysis": "үз+PN+POSS_3(СЫ)+DIR(ГА);", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "килешеп", "analysis": "кил+V+RECP(Ыш)+ADVV_ACC(Ып);килеш+V+ADVV_ACC(Ып);", "translations": ["идти", "согласиться", "соглашаться"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Уйлап", "analysis": "уйла+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "карагыз", "analysis": "кара+Adj+Sg+POSS_2PL(ЫгЫз)+Nom;кара+N+Sg+POSS_2PL(ЫгЫз)+Nom;кара+V+IMP_PL(ЫгЫз);"}
+{"prefix": " ", "surface": "Уйлап", "analysis": "уйла+V+ADVV_ACC(Ып);", "translations": ["думать"]}
+{"prefix": " ", "surface": "карагыз", "analysis": "кара+Adj+Sg+POSS_2PL(ЫгЫз)+Nom;кара+N+Sg+POSS_2PL(ЫгЫз)+Nom;кара+V+IMP_PL(ЫгЫз);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "әгәр", "analysis": "әгәр+CNJ;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "битләремне", "analysis": "бит+N+PL(ЛАр)+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "битләремне", "analysis": "бит+N+PL(ЛАр)+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "буйый", "analysis": "буя+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булсам", "analysis": "бул+V+COND(сА)+1SG(м);"}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "булсам", "analysis": "бул+V+COND(сА)+1SG(м);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "һич", "analysis": "һич+PN;"}
-{"prefix": " ", "surface": "килешмәс", "analysis": "кил+V+RECP(Ыш)+FUT_INDF_NEG(мАс);кил+V+RECP(Ыш)+PCP_FUT(мАс);килеш+V+FUT_INDF_NEG(мАс);килеш+V+PCP_FUT(мАс);"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
+{"prefix": " ", "surface": "һич", "analysis": "һич+PN;", "translations": ["совсем"]}
+{"prefix": " ", "surface": "килешмәс", "analysis": "кил+V+RECP(Ыш)+FUT_INDF_NEG(мАс);кил+V+RECP(Ыш)+PCP_FUT(мАс);килеш+V+FUT_INDF_NEG(мАс);килеш+V+PCP_FUT(мАс);", "translations": ["идти", "согласиться", "соглашаться"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;", "translations": ["быть"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Онга", "analysis": "он+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "төшкән", "analysis": "төш+V+PCP_PS(ГАн);төш+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "Онга", "analysis": "он+N+Sg+DIR(ГА);", "translations": ["мука"]}
+{"prefix": " ", "surface": "төшкән", "analysis": "төш+V+PCP_PS(ГАн);төш+V+PST_INDF(ГАн);", "translations": ["опускаться", "опуститься", "сон"]}
 {"prefix": " ", "surface": "таракан", "analysis": "таракан+N+Sg+Nom;"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "асрау", "analysis": "асра+V+VN_1(у/ү/в)+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "асрау", "analysis": "асра+V+VN_1(у/ү/в)+Nom;", "translations": ["содержать"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "нәкъ", "analysis": "нәкъ+PART;"}
+{"prefix": " ", "surface": "йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;", "translations": ["лицо", "плавать", "сотый", "сто"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "нәкъ", "analysis": "нәкъ+PART;", "translations": ["именно"]}
 {"prefix": " ", "surface": "чуенның", "analysis": "чуен+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "ундүртенче", "analysis": "ундүрт+Num+NUM_ORD(ЫнчЫ);"}
-{"prefix": " ", "surface": "кичәсе", "analysis": "кич+V+OBL(ЙсЫ);кичә+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
+{"prefix": " ", "surface": "ундүртенче", "analysis": "ундүрт+Num+NUM_ORD(ЫнчЫ);", "translations": ["четырнадцатый", "четырнадцать"]}
+{"prefix": " ", "surface": "кичәсе", "analysis": "кич+V+OBL(ЙсЫ);кичә+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["вечер", "вечерний", "вечером", "перейти", "переходить", "вчера", "вчерашний"]}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
 {"prefix": " ", "surface": "кап-кара", "analysis": "ап-кара+Adj;кап-кара+Adj;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Беркөнне", "analysis": "беркөнне+Adv;"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "асрау", "analysis": "асра+V+VN_1(у/ү/в)+Nom;"}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "асрау", "analysis": "асра+V+VN_1(у/ү/в)+Nom;", "translations": ["содержать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "абысталары", "analysis": "абыста+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
-{"prefix": " ", "surface": "чагында", "analysis": "чагында+POST;чак+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
+{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);", "translations": ["дом"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
+{"prefix": " ", "surface": "чагында", "analysis": "чагында+POST;чак+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["время"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);"}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "Гафифәнең", "analysis": "NR"}
 {"prefix": " ", "surface": "пудырларын", "analysis": "NR"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ягынган", "analysis": "ягын+V+PCP_PS(ГАн);ягын+V+PST_INDF(ГАн);як+V+REFL(Ын)+PCP_PS(ГАн);як+V+REFL(Ын)+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "ягынган", "analysis": "ягын+V+PCP_PS(ГАн);ягын+V+PST_INDF(ГАн);як+V+REFL(Ын)+PCP_PS(ГАн);як+V+REFL(Ын)+PST_INDF(ГАн);", "translations": ["сжечь", "сторона"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;", "translations": ["совсем", "целиком"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бигайниһиБигайниһи", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "нәкъ", "analysis": "нәкъ+PART;"}
+{"prefix": "", "surface": "нәкъ", "analysis": "нәкъ+PART;", "translations": ["именно"]}
 {"prefix": " ", "surface": "үзе", "analysis": "үзе+PN;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "ком", "analysis": "ком+N+Sg+Nom;"}
-{"prefix": " ", "surface": "гарәбенең", "analysis": "гарәп+N+Sg+POSS_3(СЫ)+GEN(нЫң);"}
-{"prefix": " ", "surface": "битен", "analysis": "бит+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "акбурга", "analysis": "акбур+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "ком", "analysis": "ком+N+Sg+Nom;", "translations": ["песок"]}
+{"prefix": " ", "surface": "гарәбенең", "analysis": "гарәп+N+Sg+POSS_3(СЫ)+GEN(нЫң);", "translations": ["араб"]}
+{"prefix": " ", "surface": "битен", "analysis": "бит+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "акбурга", "analysis": "акбур+N+Sg+DIR(ГА);", "translations": ["мел"]}
 {"prefix": " ", "surface": "буяган", "analysis": "буя+V+PCP_PS(ГАн);буя+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
-{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
+{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Көлешә-көлешә", "analysis": "NR"}
 {"prefix": " ", "surface": "алҗып", "analysis": "алҗы+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "беттек", "analysis": "бет+V+PST_DEF(ДЫ)+1PL(к);"}
+{"prefix": " ", "surface": "беттек", "analysis": "бет+V+PST_DEF(ДЫ)+1PL(к);", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "җитди", "analysis": "җитди+Adj;"}
+{"prefix": "", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "җитди", "analysis": "җитди+Adj;", "translations": ["серьезный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Беләсезме", "analysis": "бел+V+PRES(Й)+2PL(сЫз)+INT(мЫ);"}
+{"prefix": " ", "surface": "Беләсезме", "analysis": "бел+V+PRES(Й)+2PL(сЫз)+INT(мЫ);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "пудыр", "analysis": "NR"}
-{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);", "translations": ["человек"]}
+{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);", "translations": ["идти", "согласиться", "соглашаться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "хосусәнХосусән", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "бигрәк", "analysis": "бигрәк+Adv;"}
+{"prefix": "", "surface": "бигрәк", "analysis": "бигрәк+Adv;", "translations": ["особенно", "слишком"]}
 {"prefix": " ", "surface": "тә", "analysis": "тә+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ирләргә", "analysis": "ир+N+PL(ЛАр)+DIR(ГА);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
+{"prefix": " ", "surface": "ирләргә", "analysis": "ир+N+PL(ЛАр)+DIR(ГА);", "translations": ["мужчина"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);", "translations": ["идти", "согласиться", "соглашаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "таныш", "analysis": "таны+V+RECP(Ыш)+IMP_SG();таны+V+VN_2(Ыш)+Nom;таныш+Adj;таныш+V+IMP_SG();"}
-{"prefix": " ", "surface": "егетем", "analysis": "егет+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "таныш", "analysis": "таны+V+RECP(Ыш)+IMP_SG();таны+V+VN_2(Ыш)+Nom;таныш+Adj;таныш+V+IMP_SG();", "translations": ["признавать", "признать", "знакомый"]}
+{"prefix": " ", "surface": "егетем", "analysis": "егет+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["молодец", "парень"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "әхмәтҗан", "analysis": "әхмәтҗан+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "һәр", "analysis": "һәр+PN;"}
-{"prefix": " ", "surface": "көнне", "analysis": "көн+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "өчәр", "analysis": "өч+Num+NUM_DISR(шАр);"}
-{"prefix": " ", "surface": "мәртәбә", "analysis": "мәртәбә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сакалларын", "analysis": "сакал+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "һәр", "analysis": "һәр+PN;", "translations": ["каждый"]}
+{"prefix": " ", "surface": "көнне", "analysis": "көн+N+Sg+ACC(нЫ);", "translations": ["день"]}
+{"prefix": " ", "surface": "өчәр", "analysis": "өч+Num+NUM_DISR(шАр);", "translations": ["третий", "три"]}
+{"prefix": " ", "surface": "мәртәбә", "analysis": "мәртәбә+N+Sg+Nom;", "translations": ["степень"]}
+{"prefix": " ", "surface": "сакалларын", "analysis": "сакал+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["борода"]}
 {"prefix": " ", "surface": "китәреп", "analysis": "китәр+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "пудырлар", "analysis": "NR"}
-{"prefix": " ", "surface": "сөртеп", "analysis": "сөр+V+CAUS(т)+ADVV_ACC(Ып);сөрт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);"}
+{"prefix": " ", "surface": "сөртеп", "analysis": "сөр+V+CAUS(т)+ADVV_ACC(Ып);сөрт+V+ADVV_ACC(Ып);", "translations": ["вытереть", "вытирать"]}
+{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);", "translations": ["походить", "ходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "килешә", "analysis": "кил+V+RECP(Ыш)+PRES(Й);килеш+V+PRES(Й);"}
+{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "килешә", "analysis": "кил+V+RECP(Ыш)+PRES(Й);килеш+V+PRES(Й);", "translations": ["идти", "согласиться", "соглашаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
+{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);", "translations": ["идти", "согласиться", "соглашаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": " ", "surface": "аксөяк", "analysis": "аксөяк+N+Sg+Nom;"}
-{"prefix": " ", "surface": "нәселдән", "analysis": "нәсел+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "яратылган", "analysis": "яра+V+CAUS(т)+PASS(Ыл)+PCP_PS(ГАн);яра+V+CAUS(т)+PASS(Ыл)+PST_INDF(ГАн);ярат+V+PASS(Ыл)+PCP_PS(ГАн);ярат+V+PASS(Ыл)+PST_INDF(ГАн);яратыл+V+PCP_PS(ГАн);яратыл+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "нәселдән", "analysis": "нәсел+N+Sg+ABL(ДАн);", "translations": ["род"]}
+{"prefix": " ", "surface": "яратылган", "analysis": "яра+V+CAUS(т)+PASS(Ыл)+PCP_PS(ГАн);яра+V+CAUS(т)+PASS(Ыл)+PST_INDF(ГАн);ярат+V+PASS(Ыл)+PCP_PS(ГАн);ярат+V+PASS(Ыл)+PST_INDF(ГАн);яратыл+V+PCP_PS(ГАн);яратыл+V+PST_INDF(ГАн);", "translations": ["годиться", "рана", "любить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
-{"prefix": " ", "surface": "безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
+{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "мужик", "analysis": "мужик+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom;", "translations": ["дед"]}
 {"prefix": " ", "surface": "сука", "analysis": "сука+N+Sg+Nom;"}
 {"prefix": " ", "surface": "сукалап", "analysis": "сука+N+DISTR(лАп);сукала+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "үскән", "analysis": "үс+V+PCP_PS(ГАн);үс+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "үскән", "analysis": "үс+V+PCP_PS(ГАн);үс+V+PST_INDF(ГАн);", "translations": ["вырасти", "расти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;"}
+{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;", "translations": ["отец", "папа"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "чабата", "analysis": "чабата+N+Sg+Nom;"}
-{"prefix": " ", "surface": "киеп", "analysis": "ки+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "киеп", "analysis": "ки+V+ADVV_ACC(Ып);", "translations": ["одеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "12", "analysis": "Num"}
-{"prefix": " ", "surface": "яшендә", "analysis": "яшен+N+Sg+LOC(ДА);яшь+Adj+Sg+POSS_3(СЫ)+LOC(ДА);яшь+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
-{"prefix": " ", "surface": "калага", "analysis": "кала+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "килгән", "analysis": "кил+V+PCP_PS(ГАн);кил+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "яшендә", "analysis": "яшен+N+Sg+LOC(ДА);яшь+Adj+Sg+POSS_3(СЫ)+LOC(ДА);яшь+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["молния", "возраст", "год²", "молодой", "юный"]}
+{"prefix": " ", "surface": "калага", "analysis": "кала+N+Sg+DIR(ГА);", "translations": ["город"]}
+{"prefix": " ", "surface": "килгән", "analysis": "кил+V+PCP_PS(ГАн);кил+V+PST_INDF(ГАн);", "translations": ["идти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
-{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "икмәк", "analysis": "икмәк+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ашап", "analysis": "аша+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "үскән", "analysis": "үс+V+PCP_PS(ГАн);үс+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "ак", "analysis": "ак+Adj;ак+V+IMP_SG();"}
-{"prefix": " ", "surface": "сөякле", "analysis": "сөяк+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "булу", "analysis": "бул+V+VN_1(у/ү/в)+Nom;"}
+{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
+{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "икмәк", "analysis": "икмәк+N+Sg+Nom;", "translations": ["хлеб"]}
+{"prefix": " ", "surface": "ашап", "analysis": "аша+V+ADVV_ACC(Ып);", "translations": ["есть", "кушать", "через"]}
+{"prefix": " ", "surface": "үскән", "analysis": "үс+V+PCP_PS(ГАн);үс+V+PST_INDF(ГАн);", "translations": ["вырасти", "расти"]}
+{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);", "translations": ["человек"]}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ак", "analysis": "ак+Adj;ак+V+IMP_SG();", "translations": ["белый"]}
+{"prefix": " ", "surface": "сөякле", "analysis": "сөяк+N+ATTR_MUN(лЫ);", "translations": ["кость"]}
+{"prefix": " ", "surface": "булу", "analysis": "бул+V+VN_1(у/ү/в)+Nom;", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ак", "analysis": "ак+Adj;ак+V+IMP_SG();"}
+{"prefix": " ", "surface": "Ак", "analysis": "ак+Adj;ак+V+IMP_SG();", "translations": ["белый"]}
 {"prefix": " ", "surface": "кына", "analysis": "кына+PART;"}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "карасы", "analysis": "кара+Adj+Sg+POSS_3(СЫ)+Nom;кара+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "карасы", "analysis": "кара+Adj+Sg+POSS_3(СЫ)+Nom;кара+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "килешми", "analysis": "кил+V+RECP(Ыш)+NEG(мА)+PRES(Й);килеш+V+NEG(мА)+PRES(Й);", "translations": ["идти", "согласиться", "соглашаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бервакыт", "analysis": "бервакыт+Adv;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ);хатын+N+Sg+Nom;"}
+{"prefix": " ", "surface": "хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ);хатын+N+Sg+Nom;", "translations": ["письмо", "жена", "женщина"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
+{"prefix": "", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;", "translations": ["красиво", "красивый"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);"}
+{"prefix": "", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "котырынып", "analysis": "котыр+V+REFL(Ын)+ADVV_ACC(Ып);котырын+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шушы", "analysis": "шушы+PN;"}
-{"prefix": " ", "surface": "мыегымны", "analysis": "мыек+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
-{"prefix": " ", "surface": "карага", "analysis": "кара+Adj+Sg+DIR(ГА);кара+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "шушы", "analysis": "шушы+PN;", "translations": ["этот"]}
+{"prefix": " ", "surface": "мыегымны", "analysis": "мыек+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["ус"]}
+{"prefix": " ", "surface": "карага", "analysis": "кара+Adj+Sg+DIR(ГА);кара+N+Sg+DIR(ГА);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": " ", "surface": "буяган", "analysis": "буя+V+PCP_PS(ГАн);буя+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничә", "analysis": "ничә+PN;"}
-{"prefix": " ", "surface": "көннәргә", "analysis": "көн+N+PL(ЛАр)+DIR(ГА);"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "күзенә", "analysis": "күз+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "күренергә", "analysis": "күр+V+REFL(Ын)+INF_1(ЫргА);күрен+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "Ничә", "analysis": "ничә+PN;", "translations": ["сколько"]}
+{"prefix": " ", "surface": "көннәргә", "analysis": "көн+N+PL(ЛАр)+DIR(ГА);", "translations": ["день"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "күзенә", "analysis": "күз+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["глаз"]}
+{"prefix": " ", "surface": "күренергә", "analysis": "күр+V+REFL(Ын)+INF_1(ЫргА);күрен+V+INF_1(ЫргА);", "translations": ["видеть"]}
 {"prefix": " ", "surface": "оялып", "analysis": "оял+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "яттым", "analysis": "ят+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "яттым", "analysis": "ят+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["лечь", "ложиться", "чужой"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "җитмәсә", "analysis": "җит+V+NEG(мА)+COND(сА);"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
+{"prefix": " ", "surface": "җитмәсә", "analysis": "җит+V+NEG(мА)+COND(сА);", "translations": ["дойти", "доходить"]}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мыекка", "analysis": "мыек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "сөртәм", "analysis": "сөр+V+CAUS(т)+HOR_SG(Йм);сөр+V+CAUS(т)+PRES(Й)+1SG(м);сөрт+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "дигәндә", "analysis": "ди+V+PCP_PS(ГАн)+LOC(ДА);дигәндә+CNJ;"}
+{"prefix": " ", "surface": "мыекка", "analysis": "мыек+N+Sg+DIR(ГА);", "translations": ["ус"]}
+{"prefix": " ", "surface": "сөртәм", "analysis": "сөр+V+CAUS(т)+HOR_SG(Йм);сөр+V+CAUS(т)+PRES(Й)+1SG(м);сөрт+V+PRES(Й)+1SG(м);", "translations": ["вытереть", "вытирать"]}
+{"prefix": " ", "surface": "дигәндә", "analysis": "ди+V+PCP_PS(ГАн)+LOC(ДА);дигәндә+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "битләрне", "analysis": "бит+N+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "битләрне", "analysis": "бит+N+PL(ЛАр)+ACC(нЫ);", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "буяп", "analysis": "буя+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетердем", "analysis": "бетер+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "бетердем", "analysis": "бетер+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["заканчивать", "кончать", "кончить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "карасы", "analysis": "кара+Adj+Sg+POSS_3(СЫ)+Nom;кара+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "тәннән", "analysis": "тән+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "һич", "analysis": "һич+PN;"}
-{"prefix": " ", "surface": "китми", "analysis": "кит+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "карасы", "analysis": "кара+Adj+Sg+POSS_3(СЫ)+Nom;кара+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "тәннән", "analysis": "тән+N+Sg+ABL(ДАн);", "translations": ["тело"]}
+{"prefix": " ", "surface": "һич", "analysis": "һич+PN;", "translations": ["совсем"]}
+{"prefix": " ", "surface": "китми", "analysis": "кит+V+NEG(мА)+PRES(Й);", "translations": ["уйти", "уходить"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "Тумыштан", "analysis": "тумыштан+Adv;"}
-{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;"}
-{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тумагач", "analysis": "ту+V+NEG(мА)+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;", "translations": ["красиво", "красивый"]}
+{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "тумагач", "analysis": "ту+V+NEG(мА)+ADVV_ANT(ГАч);", "translations": ["родиться", "рождаться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "спай-ланган", "analysis": "NR"}
-{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "маташу", "analysis": "маташ+V+VN_1(у/ү/в)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "маташу", "analysis": "маташ+V+VN_1(у/ү/в)+Nom;", "translations": ["попытаться", "пытаться"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ян", "analysis": "ян+N+Sg+Nom;ян+V+IMP_SG();"}
-{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "карый", "analysis": "кара+V+PRES(Й);карый+N+Sg+Nom;"}
+{"prefix": "", "surface": "Ян", "analysis": "ян+N+Sg+Nom;ян+V+IMP_SG();", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
+{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "карый", "analysis": "кара+V+PRES(Й);карый+N+Sg+Nom;", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "төсләрен", "analysis": "төс+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "бозып", "analysis": "боз+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "төсләрен", "analysis": "төс+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["цвет"]}
+{"prefix": " ", "surface": "бозып", "analysis": "боз+V+ADVV_ACC(Ып);", "translations": ["испортить", "лед/лёд", "лёд"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "нишләвең", "analysis": "NR"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
-{"prefix": " ", "surface": "кайчаннан", "analysis": "кайчан+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "кайчаннан", "analysis": "кайчан+PN+ABL(ДАн);", "translations": ["когда"]}
+{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;", "translations": ["с"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кайчан", "analysis": "кайчан+Adv;кайчан+PN;"}
-{"prefix": " ", "surface": "киенеп", "analysis": "ки+V+REFL(Ын)+ADVV_ACC(Ып);киен+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетерә", "analysis": "бетер+V+PRES(Й);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "кайчан", "analysis": "кайчан+Adv;кайчан+PN;", "translations": ["когда"]}
+{"prefix": " ", "surface": "киенеп", "analysis": "ки+V+REFL(Ын)+ADVV_ACC(Ып);киен+V+ADVV_ACC(Ып);", "translations": ["одеть", "одеваться", "одеться"]}
+{"prefix": " ", "surface": "бетерә", "analysis": "бетер+V+PRES(Й);", "translations": ["заканчивать", "кончать", "кончить"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "көтеп", "analysis": "көт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торам", "analysis": "тор+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "көтеп", "analysis": "көт+V+ADVV_ACC(Ып);", "translations": ["ждать", "подождать"]}
+{"prefix": " ", "surface": "торам", "analysis": "тор+V+PRES(Й)+1SG(м);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "бүлмәдән", "analysis": "бүлмә+N+Sg+ABL(ДАн);"}
+{"prefix": "", "surface": "бүлмәдән", "analysis": "бүлмә+N+Sg+ABL(ДАн);", "translations": ["комната"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "җә", "analysis": "җә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;"}
-{"prefix": " ", "surface": "ла", "analysis": "ла+PART;"}
+{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;", "translations": ["берег", "годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "ла", "analysis": "ла+PART;", "translations": ["бы", "же", "к сожалению"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "пудыр", "analysis": "NR"}
-{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;"}
-{"prefix": " ", "surface": "төшмәгән", "analysis": "төш+V+NEG(мА)+PCP_PS(ГАн);төш+V+NEG(мА)+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;", "translations": ["красиво", "красивый"]}
+{"prefix": " ", "surface": "төшмәгән", "analysis": "төш+V+NEG(мА)+PCP_PS(ГАн);төш+V+NEG(мА)+PST_INDF(ГАн);", "translations": ["опускаться", "опуститься", "сон"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "зинһар", "analysis": "зинһар+MOD;"}
+{"prefix": " ", "surface": "зинһар", "analysis": "зинһар+MOD;", "translations": ["пожалуйста"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "бүлмәдән", "analysis": "бүлмә+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
+{"prefix": "", "surface": "Башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
+{"prefix": " ", "surface": "бүлмәдән", "analysis": "бүлмә+N+Sg+ABL(ДАн);", "translations": ["комната"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ишекне", "analysis": "ишек+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "ябып", "analysis": "яп+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "ишекне", "analysis": "ишек+N+Sg+ACC(нЫ);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "ябып", "analysis": "яп+V+ADVV_ACC(Ып);", "translations": ["закрывать", "закрыть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);", "translations": ["народ", "народный", "толпа"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;", "translations": ["необходимый", "нужный"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": " ", "surface": "өстемә", "analysis": "өс+N+Sg+POSS_1SG(Ым)+DIR(ГА);"}
 {"prefix": " ", "surface": "пальтоларымны", "analysis": "пальто+N+PL(ЛАр)+POSS_1SG(Ым)+ACC(нЫ);"}
-{"prefix": " ", "surface": "кигәнгә", "analysis": "ки+V+PCP_PS(ГАн)+DIR(ГА);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "сәгать", "analysis": "сәгать+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "кигәнгә", "analysis": "ки+V+PCP_PS(ГАн)+DIR(ГА);", "translations": ["одеть"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "сәгать", "analysis": "сәгать+N+Sg+Nom;", "translations": ["час", "часы"]}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv;", "translations": ["всегда", "всё время"]}
 {"prefix": " ", "surface": "пудыр", "analysis": "NR"}
-{"prefix": " ", "surface": "ягынып", "analysis": "ягын+V+ADVV_ACC(Ып);як+V+REFL(Ын)+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетерә", "analysis": "бетер+V+PRES(Й);"}
-{"prefix": " ", "surface": "алмый", "analysis": "ал+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "ягынып", "analysis": "ягын+V+ADVV_ACC(Ып);як+V+REFL(Ын)+ADVV_ACC(Ып);", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "бетерә", "analysis": "бетер+V+PRES(Й);", "translations": ["заканчивать", "кончать", "кончить"]}
+{"prefix": " ", "surface": "алмый", "analysis": "ал+V+NEG(мА)+PRES(Й);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
 {"prefix": " ", "surface": "пудыр", "analysis": "NR"}
 {"prefix": " ", "surface": "ямьсез", "analysis": "ямь+N+ATTR_ABES(сЫз)+Nom;ямьсез+Adj;"}
-{"prefix": " ", "surface": "төште", "analysis": "төш+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "төште", "analysis": "төш+V+PST_DEF(ДЫ);", "translations": ["опускаться", "опуститься", "сон"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;"}
-{"prefix": " ", "surface": "битен", "analysis": "бит+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "юып", "analysis": "ю+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "ята", "analysis": "ят+V+PRES(Й);"}
+{"prefix": " ", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;", "translations": ["новый"]}
+{"prefix": " ", "surface": "битен", "analysis": "бит+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "юып", "analysis": "ю+V+ADVV_ACC(Ып);", "translations": ["мыть"]}
+{"prefix": " ", "surface": "ята", "analysis": "ят+V+PRES(Й);", "translations": ["лечь", "ложиться", "чужой"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "көзге", "analysis": "көзге+Adj;көзге+N+Sg+Nom;"}
+{"prefix": " ", "surface": "көзге", "analysis": "көзге+Adj;көзге+N+Sg+Nom;", "translations": ["зеркало"]}
 {"prefix": " ", "surface": "ямьсез", "analysis": "ямь+N+ATTR_ABES(сЫз)+Nom;ямьсез+Adj;"}
-{"prefix": " ", "surface": "күрсәтә", "analysis": "күрсәт+V+PRES(Й);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "күрсәтә", "analysis": "күрсәт+V+PRES(Й);", "translations": ["показать", "показывать"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "көзгене", "analysis": "көзге+Adj+Sg+ACC(нЫ);көзге+N+Sg+ACC(нЫ);"}
+{"prefix": " ", "surface": "көзгене", "analysis": "көзге+Adj+Sg+ACC(нЫ);көзге+N+Sg+ACC(нЫ);", "translations": ["зеркало"]}
 {"prefix": " ", "surface": "бәреп", "analysis": "бәр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "ватмаган", "analysis": "ват+V+NEG(мА)+PCP_PS(ГАн);ват+V+NEG(мА)+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "ватмаган", "analysis": "ват+V+NEG(мА)+PCP_PS(ГАн);ват+V+NEG(мА)+PST_INDF(ГАн);", "translations": ["ломать", "сломать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Уң", "analysis": "уң+Adj;уң+V+IMP_SG();"}
-{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();"}
-{"prefix": " ", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
+{"prefix": "", "surface": "Уң", "analysis": "уң+Adj;уң+V+IMP_SG();", "translations": ["правый"]}
+{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["рука"]}
 {"prefix": " ", "surface": "поднос", "analysis": "поднос+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "чынаяклар", "analysis": "чынаяк+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "чынаяклар", "analysis": "чынаяк+N+PL(ЛАр)+Nom;", "translations": ["чаша"]}
+{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);", "translations": ["поднимать", "поднять"]}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "узып", "analysis": "уз+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);"}
+{"prefix": " ", "surface": "узып", "analysis": "уз+V+ADVV_ACC(Ып);", "translations": ["пройти", "проходить"]}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Бибине", "analysis": "Rus"}
-{"prefix": " ", "surface": "күреп", "analysis": "күр+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "күреп", "analysis": "күр+V+ADVV_ACC(Ып);", "translations": ["видеть"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();", "translations": ["останавливаться", "остановиться", "остановка"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "дисең", "analysis": "ди+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "дисең", "analysis": "ди+V+PRES(Й)+2SG(сЫң);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Карыйм", "analysis": "кара+V+HOR_SG(Йм);кара+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Карыйм", "analysis": "кара+V+HOR_SG(Йм);кара+V+PRES(Й)+1SG(м);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "нәрсәдер", "analysis": "нәрсә+PN+PROB(ДЫр);"}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "нәрсәдер", "analysis": "нәрсә+PN+PROB(ДЫр);", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -779,224 +779,224 @@
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "чорт", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетергәнне", "analysis": "бетер+V+PCP_PS(ГАн)+ACC(нЫ);"}
-{"prefix": " ", "surface": "көт", "analysis": "көт+V+IMP_SG();"}
+{"prefix": " ", "surface": "Сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);", "translations": ["говорить", "рассказывать"]}
+{"prefix": " ", "surface": "бетергәнне", "analysis": "бетер+V+PCP_PS(ГАн)+ACC(нЫ);", "translations": ["заканчивать", "кончать", "кончить"]}
+{"prefix": " ", "surface": "көт", "analysis": "көт+V+IMP_SG();", "translations": ["ждать", "подождать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "көтәм", "analysis": "көт+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "көтәм", "analysis": "көт+V+PRES(Й)+1SG(м);", "translations": ["ждать", "подождать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ачуланып", "analysis": "ачулан+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "ачуланып", "analysis": "ачулан+V+ADVV_ACC(Ып);", "translations": ["ругать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тыңлап", "analysis": "тыңла+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тор", "analysis": "тор+N+Sg+Nom;тор+V+IMP_SG();"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
+{"prefix": " ", "surface": "Тыңлап", "analysis": "тыңла+V+ADVV_ACC(Ып);", "translations": ["слушать"]}
+{"prefix": " ", "surface": "тор", "analysis": "тор+N+Sg+Nom;тор+V+IMP_SG();", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тыңлыйм", "analysis": "тыңла+V+HOR_SG(Йм);тыңла+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Тыңлыйм", "analysis": "тыңла+V+HOR_SG(Йм);тыңла+V+PRES(Й)+1SG(м);", "translations": ["слушать"]}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тыңласаң", "analysis": "тыңла+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "Тыңласаң", "analysis": "тыңла+V+COND(сА)+2SG(ң);", "translations": ["слушать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "китәбез", "analysis": "ки+V+CAUS(т)+PRES(Й)+1PL(бЫз);кит+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "китәбез", "analysis": "ки+V+CAUS(т)+PRES(Й)+1PL(бЫз);кит+V+PRES(Й)+1PL(бЫз);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);", "translations": ["погрузить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Баш", "analysis": "баш+N+Sg+Nom;"}
-{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "Баш", "analysis": "баш+N+Sg+Nom;", "translations": ["голова"]}
+{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);", "translations": ["погрузить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "баш", "analysis": "баш+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "баш", "analysis": "баш+N+Sg+Nom;", "translations": ["голова"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Атаң", "analysis": "ата+N+Sg+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "башы", "analysis": "баш+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "Атаң", "analysis": "ата+N+Sg+POSS_2SG(Ың)+Nom;", "translations": ["назвать", "называть", "называться", "отец", "отчий"]}
+{"prefix": " ", "surface": "башы", "analysis": "баш+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["голова"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "димим", "analysis": "ди+V+NEG(мА)+HOR_SG(Йм);ди+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);", "translations": ["погрузить"]}
+{"prefix": " ", "surface": "димим", "analysis": "ди+V+NEG(мА)+HOR_SG(Йм);ди+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аңладыңмы", "analysis": "аңла+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);"}
+{"prefix": " ", "surface": "аңладыңмы", "analysis": "аңла+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);", "translations": ["понимать", "понять"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аңладым", "analysis": "аңла+V+PST_DEF(ДЫ)+1SG(м);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "аңладым", "analysis": "аңла+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["понимать", "понять"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "җир", "analysis": "җир+N+Sg+Nom;"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "җир", "analysis": "җир+N+Sg+Nom;", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Анысы", "analysis": "анысы+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;"}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;", "translations": ["необходимый", "нужный"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч);кит+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч);кит+V+ADVV_ANT(ГАч);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "каенатай", "analysis": "NR"}
-{"prefix": " ", "surface": "кайтыр", "analysis": "кайт+V+FUT_INDF(Ыр);кайт+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "кайтыр", "analysis": "кайт+V+FUT_INDF(Ыр);кайт+V+PCP_FUT(Ыр);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "сорар", "analysis": "сора+V+FUT_INDF(Ыр);сора+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "безне", "analysis": "без+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "сорар", "analysis": "сора+V+FUT_INDF(Ыр);сора+V+PCP_FUT(Ыр);", "translations": ["спрашивать", "спросить"]}
+{"prefix": " ", "surface": "безне", "analysis": "без+PN+ACC(нЫ);", "translations": ["мы", "наш"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Кайда", "analysis": "кай+PN+LOC(ДА);кайда+PN;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": "", "surface": "Кайда", "analysis": "кай+PN+LOC(ДА);кайда+PN;", "translations": ["какой", "где"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "аңа", "analysis": "ул+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
+{"prefix": " ", "surface": "Син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "аңа", "analysis": "ул+PN+DIR(ГА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "Кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": "", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтмә", "analysis": "әйт+V+NEG(мА)+IMP_SG();"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтмә", "analysis": "әйт+V+NEG(мА)+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сорамаса", "analysis": "сора+V+NEG(мА)+COND(сА);"}
+{"prefix": " ", "surface": "Сорамаса", "analysis": "сора+V+NEG(мА)+COND(сА);", "translations": ["спрашивать", "спросить"]}
 {"prefix": " ", "surface": "нишләрмен", "analysis": "нишлә+V+FUT_INDF(Ыр)+1SG(мЫн);нишлә+V+PCP_FUT(Ыр)+1SG(мЫн);"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тик", "analysis": "тик+CNJ;"}
-{"prefix": " ", "surface": "торырсың", "analysis": "тор+V+FUT_INDF(Ыр)+2SG(сЫң);тор+V+PCP_FUT(Ыр)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Тик", "analysis": "тик+CNJ;", "translations": ["но", "только"]}
+{"prefix": " ", "surface": "торырсың", "analysis": "тор+V+FUT_INDF(Ыр)+2SG(сЫң);тор+V+PCP_FUT(Ыр)+2SG(сЫң);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();", "translations": ["останавливаться", "остановиться", "остановка"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "туктый", "analysis": "тукта+V+PRES(Й);"}
+{"prefix": " ", "surface": "туктый", "analysis": "тукта+V+PRES(Й);", "translations": ["останавливаться", "остановиться", "остановка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Син", "analysis": "син+PN;"}
+{"prefix": " ", "surface": "Син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "рәтләп", "analysis": "рәт+N+DISTR(лАп);рәтлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);"}
+{"prefix": " ", "surface": "рәтләп", "analysis": "рәт+N+DISTR(лАп);рәтлә+V+ADVV_ACC(Ып);", "translations": ["ряд", "чинить"]}
+{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "белмәссең", "analysis": "бел+V+FUT_INDF_NEG(мАс)+2SG(сЫң);бел+V+PCP_FUT(мАс)+2SG(сЫң);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "белмәссең", "analysis": "бел+V+FUT_INDF_NEG(мАс)+2SG(сЫң);бел+V+PCP_FUT(мАс)+2SG(сЫң);", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Нишләп", "analysis": "нишлә+V+ADVV_ACC(Ып);нишләп+PN;"}
-{"prefix": " ", "surface": "белмәскә", "analysis": "бел+V+NEG(мА)+INF_1(скА);бел+V+PCP_FUT(мАс)+DIR(ГА);"}
+{"prefix": " ", "surface": "белмәскә", "analysis": "бел+V+NEG(мА)+INF_1(скА);бел+V+PCP_FUT(мАс)+DIR(ГА);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйтеп", "analysis": "әйт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "әйтеп", "analysis": "әйт+V+ADVV_ACC(Ып);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтерсең", "analysis": "әйт+V+FUT_INDF(Ыр)+2SG(сЫң);әйт+V+PCP_FUT(Ыр)+2SG(сЫң);әйтерсең+PART;"}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтерсең", "analysis": "әйт+V+FUT_INDF(Ыр)+2SG(сЫң);әйт+V+PCP_FUT(Ыр)+2SG(сЫң);әйтерсең+PART;", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "китмәделәр", "analysis": "ки+V+CAUS(т)+NEG(мА)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+NEG(мА)+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;", "translations": ["деверь"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "китмәделәр", "analysis": "ки+V+CAUS(т)+NEG(мА)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+NEG(мА)+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
@@ -1004,112 +1004,112 @@
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ачуланып", "analysis": "ачулан+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "ачуланып", "analysis": "ачулан+V+ADVV_ACC(Ып);", "translations": ["ругать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Иштең", "analysis": "иш+V+PST_DEF(ДЫ)+2SG(ң);"}
-{"prefix": " ", "surface": "ишәк", "analysis": "ишәк+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Иштең", "analysis": "иш+V+PST_DEF(ДЫ)+2SG(ң);", "translations": ["ровня"]}
+{"prefix": " ", "surface": "ишәк", "analysis": "ишәк+N+Sg+Nom;", "translations": ["ишак", "осёл"]}
 {"prefix": " ", "surface": "чумарын", "analysis": "чумар+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "алай", "analysis": "алай+PN;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйттеммени", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м)+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйттеммени", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м)+INT_MIR(мЫни);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "дидең", "analysis": "ди+V+PST_DEF(ДЫ)+2SG(ң);"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "дидең", "analysis": "ди+V+PST_DEF(ДЫ)+2SG(ң);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": "", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтмә", "analysis": "әйт+V+NEG(мА)+IMP_SG();"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтмә", "analysis": "әйт+V+NEG(мА)+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "Кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
-{"prefix": " ", "surface": "дидем", "analysis": "ди+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "дидем", "analysis": "ди+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": "", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "димәдем", "analysis": "ди+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "димәдем", "analysis": "ди+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фу", "analysis": "фу+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "җәфа", "analysis": "җәфа+N+Sg+Nom;"}
+{"prefix": " ", "surface": "җәфа", "analysis": "җәфа+N+Sg+Nom;", "translations": ["мука"]}
 {"prefix": " ", "surface": "икәнсең", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кайдан", "analysis": "кай+PN+ABL(ДАн);кайдан+Adv;кайдан+PN;"}
-{"prefix": " ", "surface": "башыма", "analysis": "баш+N+Sg+POSS_1SG(Ым)+DIR(ГА);"}
-{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;"}
-{"prefix": " ", "surface": "алдым", "analysis": "ал+N+Sg+POSS_1SG(Ым)+Nom;ал+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "кайдан", "analysis": "кай+PN+ABL(ДАн);кайдан+Adv;кайдан+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "башыма", "analysis": "баш+N+Sg+POSS_1SG(Ым)+DIR(ГА);", "translations": ["голова"]}
+{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;", "translations": ["беда"]}
+{"prefix": " ", "surface": "алдым", "analysis": "ал+N+Sg+POSS_1SG(Ым)+Nom;ал+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj;яхшы+Adv;"}
-{"prefix": " ", "surface": "тыңла", "analysis": "тыңла+V+IMP_SG();"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj;яхшы+Adv;", "translations": ["лучше", "лучший", "хороший", "хорошо"]}
+{"prefix": " ", "surface": "тыңла", "analysis": "тыңла+V+IMP_SG();", "translations": ["слушать"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": " ", "surface": "әгәр", "analysis": "әгәр+CNJ;"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": " ", "surface": "каенатай", "analysis": "NR"}
-{"prefix": " ", "surface": "безне", "analysis": "без+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "безне", "analysis": "без+PN+ACC(нЫ);", "translations": ["мы", "наш"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": "", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();"}
+{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "әйтмә", "analysis": "әйт+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "Башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;", "translations": ["слово"]}
+{"prefix": " ", "surface": "әйтмә", "analysis": "әйт+V+NEG(мА)+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "юлыңда", "analysis": "юл+N+Sg+POSS_2SG(Ың)+LOC(ДА);"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "юлыңда", "analysis": "юл+N+Sg+POSS_2SG(Ың)+LOC(ДА);", "translations": ["дорога", "путь", "строка", "строчка"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
@@ -1117,119 +1117,119 @@
 {"prefix": "", "surface": "үз-үзенә", "analysis": "үз-үз+PN+POSS_3(СЫ)+DIR(ГА);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;", "translations": ["беда"]}
 {"prefix": " ", "surface": "өстенә", "analysis": "өс+N+Sg+POSS_3(СЫ)+DIR(ГА);өстенә+POST;"}
-{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;"}
+{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;", "translations": ["беда"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": " ", "surface": "җүләр", "analysis": "җүләр+Adj;"}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшкә", "analysis": "эш+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшкә", "analysis": "эш+N+Sg+DIR(ГА);", "translations": ["дело"]}
+{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;", "translations": ["необходимый", "нужный"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;", "translations": ["быть"]}
 {"prefix": " ", "surface": "аңар", "analysis": "NR"}
-{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;", "translations": ["театр"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);", "translations": ["говорить", "рассказывать"]}
+{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "аңар", "analysis": "NR"}
-{"prefix": " ", "surface": "дәрес", "analysis": "дәрес+N+Sg+Nom;"}
-{"prefix": " ", "surface": "әйтәмме", "analysis": "әйт+V+PRES(Й)+1SG(м)+INT(мЫ);"}
+{"prefix": " ", "surface": "дәрес", "analysis": "дәрес+N+Sg+Nom;", "translations": ["занятие", "урок"]}
+{"prefix": " ", "surface": "әйтәмме", "analysis": "әйт+V+PRES(Й)+1SG(м)+INT(мЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
+{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Нихәл", "analysis": "нихәл+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "буласыңмы", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);бул+V+PRES(Й)+2SG(сЫң)+INT(мЫ);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "буласыңмы", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);бул+V+PRES(Й)+2SG(сЫң)+INT(мЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нәрсәгә", "analysis": "нәрсә+PN+DIR(ГА);"}
+{"prefix": " ", "surface": "Нәрсәгә", "analysis": "нәрсә+PN+DIR(ГА);", "translations": ["вещь", "что"]}
 {"prefix": " ", "surface": "шаулашасыз", "analysis": "шаула+V+RECP(Ыш)+PRES(Й)+2PL(сЫз);шаулаш+V+PRES(Й)+2PL(сЫз);"}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "карарга", "analysis": "кара+V+INF_1(ЫргА);карар+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "чыккан", "analysis": "чык+V+PCP_PS(ГАн);чык+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "карарга", "analysis": "кара+V+INF_1(ЫргА);карар+N+Sg+DIR(ГА);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный", "постановление"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "чыккан", "analysis": "чык+V+PCP_PS(ГАн);чык+V+PST_INDF(ГАн);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әнә", "analysis": "әнә+PN;"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "адәм", "analysis": "адәм+N+Sg+Nom;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "адәм", "analysis": "адәм+N+Sg+Nom;", "translations": ["человек"]}
 {"prefix": " ", "surface": "имгәге", "analysis": "имгәк+N+Sg+POSS_3(СЫ)+Nom;"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шуңа", "analysis": "шул+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "аңлата", "analysis": "аң+N+MSRE(лАтА);аңла+V+CAUS(т)+PRES(Й);аңлат+V+PRES(Й);"}
-{"prefix": " ", "surface": "алмыйча", "analysis": "ал+V+NEG(мА)+ADVV_NEG(ЙчА);"}
+{"prefix": " ", "surface": "шуңа", "analysis": "шул+PN+DIR(ГА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;", "translations": ["слово"]}
+{"prefix": " ", "surface": "аңлата", "analysis": "аң+N+MSRE(лАтА);аңла+V+CAUS(т)+PRES(Й);аңлат+V+PRES(Й);", "translations": ["сознание", "понимать", "понять", "объяснить", "объяснять"]}
+{"prefix": " ", "surface": "алмыйча", "analysis": "ал+V+NEG(мА)+ADVV_NEG(ЙчА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": " ", "surface": "аптырап", "analysis": "аптыра+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "беттем", "analysis": "бет+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "беттем", "analysis": "бет+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": "", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": "", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);"}
+{"prefix": "", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "төятергә", "analysis": "төя+V+CAUS(т)+INF_1(ЫргА);", "translations": ["погрузить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миннән", "analysis": "мин+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "сорап", "analysis": "сора+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "ята", "analysis": "ят+V+PRES(Й);"}
+{"prefix": " ", "surface": "миннән", "analysis": "мин+PN+ABL(ДАн);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сорап", "analysis": "сора+V+ADVV_ACC(Ып);", "translations": ["спрашивать", "спросить"]}
+{"prefix": " ", "surface": "ята", "analysis": "ят+V+PRES(Й);", "translations": ["лечь", "ложиться", "чужой"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "һәрвакыт", "analysis": "һәрвакыт+PN;"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "һәрвакыт", "analysis": "һәрвакыт+PN;", "translations": ["всегда"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "һич", "analysis": "һич+PN;"}
-{"prefix": " ", "surface": "аңламый", "analysis": "аңла+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "һич", "analysis": "һич+PN;", "translations": ["совсем"]}
+{"prefix": " ", "surface": "аңламый", "analysis": "аңла+V+NEG(мА)+PRES(Й);", "translations": ["понимать", "понять"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "беркөннәрне", "analysis": "NR"}
 {"prefix": " ", "surface": "Гарифәләргә", "analysis": "NR"}
-{"prefix": " ", "surface": "җибәрдем", "analysis": "җибәр+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "җибәрдем", "analysis": "җибәр+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["пускать", "пустить"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Абыстай", "analysis": "абыстай+N+Sg+Nom;"}
@@ -1237,159 +1237,159 @@
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "Гарифәнең", "analysis": "NR"}
-{"prefix": " ", "surface": "алдырган", "analysis": "ал+V+CAUS(ДЫр)+PCP_PS(ГАн);ал+V+CAUS(ДЫр)+PST_INDF(ГАн);алдыр+V+PCP_PS(ГАн);алдыр+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "алдырган", "analysis": "ал+V+CAUS(ДЫр)+PCP_PS(ГАн);ал+V+CAUS(ДЫр)+PST_INDF(ГАн);алдыр+V+PCP_PS(ГАн);алдыр+V+PST_INDF(ГАн);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": " ", "surface": "кислатасы", "analysis": "NR"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": " ", "surface": "микән", "analysis": "микән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "күңелләрем", "analysis": "күңел+N+PL(ЛАр)+POSS_1SG(Ым)+Nom;"}
+{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "күңелләрем", "analysis": "күңел+N+PL(ЛАр)+POSS_1SG(Ым)+Nom;", "translations": ["душа"]}
 {"prefix": " ", "surface": "болганып", "analysis": "болга+V+REFL(Ын)+ADVV_ACC(Ып);болган+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "үзебездә", "analysis": "үз+PN+POSS_1PL(ЫбЫз)+LOC(ДА);"}
+{"prefix": " ", "surface": "үзебездә", "analysis": "үз+PN+POSS_1PL(ЫбЫз)+LOC(ДА);", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "судысы", "analysis": "NR"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "барын", "analysis": "бар+N+Sg+POSS_3(СЫ)+ACC(нЫ);бар+PN+POSS_3(СЫ)+ACC(нЫ);бар+V+REFL(Ын)+IMP_SG();"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "барын", "analysis": "бар+N+Sg+POSS_3(СЫ)+ACC(нЫ);бар+PN+POSS_3(СЫ)+ACC(нЫ);бар+V+REFL(Ын)+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ирләр", "analysis": "ир+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);"}
+{"prefix": " ", "surface": "ирләр", "analysis": "ир+N+PL(ЛАр)+Nom;", "translations": ["мужчина"]}
+{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);", "translations": ["дом"]}
+{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);", "translations": ["время", "пора"]}
 {"prefix": " ", "surface": "кислата", "analysis": "NR"}
-{"prefix": " ", "surface": "алдырырга", "analysis": "ал+V+CAUS(ДЫр)+INF_1(ЫргА);алдыр+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "онытылган", "analysis": "оныт+V+PASS(Ыл)+PCP_PS(ГАн);оныт+V+PASS(Ыл)+PST_INDF(ГАн);онытыл+V+PCP_PS(ГАн);онытыл+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "алдырырга", "analysis": "ал+V+CAUS(ДЫр)+INF_1(ЫргА);алдыр+V+INF_1(ЫргА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "онытылган", "analysis": "оныт+V+PASS(Ыл)+PCP_PS(ГАн);оныт+V+PASS(Ыл)+PST_INDF(ГАн);онытыл+V+PCP_PS(ГАн);онытыл+V+PST_INDF(ГАн);", "translations": ["забывать", "забыть"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтте", "analysis": "әйт+V+PST_DEF(ДЫ);"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтте", "analysis": "әйт+V+PST_DEF(ДЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "сора", "analysis": "сора+V+IMP_SG();"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сора", "analysis": "сора+V+IMP_SG();", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": "", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "Абыстай", "analysis": "абыстай+N+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;"}
+{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;", "translations": ["войлок"]}
 {"prefix": " ", "surface": "каталарын", "analysis": "ката+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "биреп", "analysis": "бир+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торсыннар", "analysis": "тор+V+JUS_PL(сЫннАр);"}
-{"prefix": " ", "surface": "ла", "analysis": "ла+PART;"}
+{"prefix": " ", "surface": "биреп", "analysis": "бир+V+ADVV_ACC(Ып);", "translations": ["давать", "даваться", "дать"]}
+{"prefix": " ", "surface": "торсыннар", "analysis": "тор+V+JUS_PL(сЫннАр);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "ла", "analysis": "ла+PART;", "translations": ["бы", "же", "к сожалению"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "сорап", "analysis": "сора+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сорап", "analysis": "сора+V+ADVV_ACC(Ып);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "кислата", "analysis": "NR"}
-{"prefix": " ", "surface": "урынына", "analysis": "урын+N+POSS_3(СЫ)+DIR(ГА);урынына+POST;"}
-{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ката", "analysis": "кат+V+PRES(Й);ката+N+Sg+Nom;ката+POST;"}
-{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кайткан", "analysis": "кайт+V+PCP_PS(ГАн);кайт+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "урынына", "analysis": "урын+N+POSS_3(СЫ)+DIR(ГА);урынына+POST;", "translations": ["место"]}
+{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;", "translations": ["войлок"]}
+{"prefix": " ", "surface": "ката", "analysis": "кат+V+PRES(Й);ката+N+Sg+Nom;ката+POST;", "translations": ["слой", "этаж"]}
+{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);", "translations": ["поднимать", "поднять"]}
+{"prefix": " ", "surface": "кайткан", "analysis": "кайт+V+PCP_PS(ГАн);кайт+V+PST_INDF(ГАн);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гарифәдән", "analysis": "NR"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
 {"prefix": " ", "surface": "оялдым", "analysis": "оял+V+PST_DEF(ДЫ)+1SG(м);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "җир", "analysis": "җир+N+Sg+Nom;"}
-{"prefix": " ", "surface": "тишегенә", "analysis": "тишек+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "керерлек", "analysis": "кер+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;кер+V+PCP_FUT(Ыр)+PSBL(лЫк);"}
-{"prefix": " ", "surface": "булдым", "analysis": "бул+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;", "translations": ["совсем", "целиком"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "җир", "analysis": "җир+N+Sg+Nom;", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "тишегенә", "analysis": "тишек+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["отверстие"]}
+{"prefix": " ", "surface": "керерлек", "analysis": "кер+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;кер+V+PCP_FUT(Ыр)+PSBL(лЫк);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "булдым", "analysis": "бул+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;"}
+{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;", "translations": ["берег", "годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аларын", "analysis": "алар+PN+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "сөйләшербез", "analysis": "сөйлә+V+RECP(Ыш)+FUT_INDF(Ыр)+1PL(бЫз);сөйлә+V+RECP(Ыш)+PCP_FUT(Ыр)+1PL(бЫз);"}
+{"prefix": " ", "surface": "аларын", "analysis": "алар+PN+POSS_3(СЫ)+ACC(нЫ);", "translations": ["они"]}
+{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);", "translations": ["время", "пора"]}
+{"prefix": " ", "surface": "сөйләшербез", "analysis": "сөйлә+V+RECP(Ыш)+FUT_INDF(Ыр)+1PL(бЫз);сөйлә+V+RECP(Ыш)+PCP_FUT(Ыр)+1PL(бЫз);", "translations": ["говорить", "рассказывать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "соңга", "analysis": "соң+N+Sg+DIR(ГА);соңга+Adv;"}
-{"prefix": " ", "surface": "калабыз", "analysis": "кал+V+PRES(Й)+1PL(бЫз);кала+N+Sg+1PL(бЫз);кала+N+Sg+POSS_1PL(ЫбЫз)+Nom;"}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "соңга", "analysis": "соң+N+Sg+DIR(ГА);соңга+Adv;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "калабыз", "analysis": "кал+V+PRES(Й)+1PL(бЫз);кала+N+Sg+1PL(бЫз);кала+N+Sg+POSS_1PL(ЫбЫз)+Nom;", "translations": ["оставаться", "остаться", "город"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "синнән", "analysis": "син+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "синнән", "analysis": "син+PN+ABL(ДАн);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);", "translations": ["спрашивать", "спросить"]}
+{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "театрда", "analysis": "театр+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "театрда", "analysis": "театр+N+Sg+LOC(ДА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "микән", "analysis": "микән+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "һу", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "булмыймы", "analysis": "бул+V+NEG(мА)+PRES(Й)+INT(мЫ);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "Күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "булмыймы", "analysis": "бул+V+NEG(мА)+PRES(Й)+INT(мЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Беләсең", "analysis": "бел+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бел+V+PRES(Й)+2SG(сЫң);"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
+{"prefix": " ", "surface": "Беләсең", "analysis": "бел+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бел+V+PRES(Й)+2SG(сЫң);", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бүген", "analysis": "бүген+Adv;"}
-{"prefix": " ", "surface": "мөселманча", "analysis": "мөселман+N+EQU(чА);мөселманча+Adv;"}
-{"prefix": " ", "surface": "театрның", "analysis": "театр+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "беренче", "analysis": "бер+Num+NUM_ORD(ЫнчЫ);"}
-{"prefix": " ", "surface": "башлана", "analysis": "башла+V+REFL(Ын)+PRES(Й);башлан+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "көне", "analysis": "көн+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "бүген", "analysis": "бүген+Adv;", "translations": ["сегодня", "сегодняшний"]}
+{"prefix": " ", "surface": "мөселманча", "analysis": "мөселман+N+EQU(чА);мөселманча+Adv;", "translations": ["мусульманин"]}
+{"prefix": " ", "surface": "театрның", "analysis": "театр+N+Sg+GEN(нЫң);", "translations": ["театр"]}
+{"prefix": " ", "surface": "беренче", "analysis": "бер+Num+NUM_ORD(ЫнчЫ);", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "башлана", "analysis": "башла+V+REFL(Ын)+PRES(Й);башлан+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "көне", "analysis": "көн+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["день"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "бөтен", "analysis": "бөтен+PN;"}
-{"prefix": " ", "surface": "шәһәр", "analysis": "шәһәр+N+Sg+Nom;"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "бөтен", "analysis": "бөтен+PN;", "translations": ["целый"]}
+{"prefix": " ", "surface": "шәһәр", "analysis": "шәһәр+N+Sg+Nom;", "translations": ["город"]}
 {"prefix": " ", "surface": "халкы", "analysis": "халкы+N+Sg+Nom;"}
-{"prefix": " ", "surface": "агылыр", "analysis": "агыл+V+FUT_INDF(Ыр);агыл+V+PCP_FUT(Ыр);ак+V+PASS(Ыл)+FUT_INDF(Ыр);ак+V+PASS(Ыл)+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "агылыр", "analysis": "агыл+V+FUT_INDF(Ыр);агыл+V+PCP_FUT(Ыр);ак+V+PASS(Ыл)+FUT_INDF(Ыр);ак+V+PASS(Ыл)+PCP_FUT(Ыр);", "translations": ["течь", "белый"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "борыннарын", "analysis": "борын+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": "", "surface": "борыннарын", "analysis": "борын+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["древний", "нос", "прежде", "прежний"]}
 {"prefix": " ", "surface": "җыерып", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "иркәләнгән", "analysis": "иркәлә+V+REFL(Ын)+PCP_PS(ГАн);иркәлә+V+REFL(Ын)+PST_INDF(ГАн);иркәлән+V+PCP_PS(ГАн);иркәлән+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "бала", "analysis": "бала+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кыяфәтендә", "analysis": "кыяфәт+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
+{"prefix": " ", "surface": "бала", "analysis": "бала+N+Sg+Nom;", "translations": ["ребёнок"]}
+{"prefix": " ", "surface": "кыяфәтендә", "analysis": "кыяфәт+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["вид"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
@@ -1397,18 +1397,18 @@
 {"prefix": " ", "surface": "әем", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Алай", "analysis": "алай+PN;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "ла", "analysis": "ла+PART;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "ла", "analysis": "ла+PART;", "translations": ["бы", "же", "к сожалению"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "оялам", "analysis": "оял+V+HOR_SG(Йм);оял+V+PRES(Й)+1SG(м);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
@@ -1416,512 +1416,512 @@
 {"prefix": "", "surface": "үз-үзенә", "analysis": "үз-үз+PN+POSS_3(СЫ)+DIR(ГА);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;", "translations": ["необходимый", "нужный"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Алдына", "analysis": "ал+N+Sg+POSS_3(СЫ)+DIR(ГА);алдына+POST;"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Алдына", "analysis": "ал+N+Sg+POSS_3(СЫ)+DIR(ГА);алдына+POST;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;"}
+{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
+{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;", "translations": ["немного"]}
 {"prefix": " ", "surface": "кашып", "analysis": "кашы+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "минемчә", "analysis": "мин+PN+POSS_1SG(Ым)+EQU(чА);"}
+{"prefix": " ", "surface": "минемчә", "analysis": "мин+PN+POSS_1SG(Ым)+EQU(чА);", "translations": ["мой", "я"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;", "translations": ["день"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
 {"prefix": " ", "surface": "үк", "analysis": "үк+PART;"}
-{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "булмас", "analysis": "бул+V+FUT_INDF_NEG(мАс);бул+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "булмас", "analysis": "бул+V+FUT_INDF_NEG(мАс);бул+V+PCP_FUT(мАс);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Күбесенең", "analysis": "күбе+N+Sg+POSS_3(СЫ)+GEN(нЫң);күбесе+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "картлары", "analysis": "карт+Adj+PL(ЛАр)+POSS_3(СЫ)+Nom;карт+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "җибәрмәс", "analysis": "җибәр+V+FUT_INDF_NEG(мАс);җибәр+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "Күбесенең", "analysis": "күбе+N+Sg+POSS_3(СЫ)+GEN(нЫң);күбесе+N+Sg+GEN(нЫң);", "translations": ["большинство"]}
+{"prefix": " ", "surface": "картлары", "analysis": "карт+Adj+PL(ЛАр)+POSS_3(СЫ)+Nom;карт+N+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["старик", "старый"]}
+{"prefix": " ", "surface": "җибәрмәс", "analysis": "җибәр+V+FUT_INDF_NEG(мАс);җибәр+V+PCP_FUT(мАс);", "translations": ["пускать", "пустить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Кайсы-берсе", "analysis": "NR"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сөйләүдән", "analysis": "сөйлә+V+VN_1(у/ү/в)+ABL(ДАн);"}
-{"prefix": " ", "surface": "куркып", "analysis": "курк+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "сөйләүдән", "analysis": "сөйлә+V+VN_1(у/ү/в)+ABL(ДАн);", "translations": ["говорить", "рассказывать"]}
+{"prefix": " ", "surface": "куркып", "analysis": "курк+V+ADVV_ACC(Ып);", "translations": ["испугаться"]}
+{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);", "translations": ["оставаться", "остаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "янә", "analysis": "янә+Adv;"}
+{"prefix": "", "surface": "янә", "analysis": "янә+Adv;", "translations": ["опять"]}
 {"prefix": " ", "surface": "әүвәлгечә", "analysis": "әүвәлге+Adj+EQU(чА);әүвәлгечә+Adv;"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Алай", "analysis": "алай+PN;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;"}
+{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бармыйк", "analysis": "бар+V+NEG(мА)+HOR_PL(Йк);"}
+{"prefix": " ", "surface": "бармыйк", "analysis": "бар+V+NEG(мА)+HOR_PL(Йк);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сөйләүдән", "analysis": "сөйлә+V+VN_1(у/ү/в)+ABL(ДАн);"}
-{"prefix": " ", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "сөйләүдән", "analysis": "сөйлә+V+VN_1(у/ү/в)+ABL(ДАн);", "translations": ["говорить", "рассказывать"]}
+{"prefix": " ", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);", "translations": ["испугаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белсә", "analysis": "бел+V+COND(сА);"}
+{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;", "translations": ["отец", "папа"]}
+{"prefix": " ", "surface": "белсә", "analysis": "бел+V+COND(сА);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "ачуланыр", "analysis": "ачулан+V+FUT_INDF(Ыр);ачулан+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "ачуланыр", "analysis": "ачулан+V+FUT_INDF(Ыр);ачулан+V+PCP_FUT(Ыр);", "translations": ["ругать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "тирән", "analysis": "тирән+Adj;"}
-{"prefix": " ", "surface": "уйга", "analysis": "уй+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "калып", "analysis": "кал+V+ADVV_ACC(Ып);калып+N+Sg+Nom;"}
+{"prefix": "", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "тирән", "analysis": "тирән+Adj;", "translations": ["глубокий", "глубоко"]}
+{"prefix": " ", "surface": "уйга", "analysis": "уй+N+Sg+DIR(ГА);", "translations": ["мысль"]}
+{"prefix": " ", "surface": "калып", "analysis": "кал+V+ADVV_ACC(Ып);калып+N+Sg+Nom;", "translations": ["оставаться", "остаться", "форма", "шаблон"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
+{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);", "translations": ["поднимать", "поднять"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);", "translations": ["народ", "народный", "толпа"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Уттан", "analysis": "ут+N+Sg+ABL(ДАн);"}
+{"prefix": " ", "surface": "Уттан", "analysis": "ут+N+Sg+ABL(ДАн);", "translations": ["огонь"]}
 {"prefix": " ", "surface": "котылдым", "analysis": "котыл+V+PST_DEF(ДЫ)+1SG(м);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "суга", "analysis": "су+N+Sg+DIR(ГА);сук+V+PRES(Й);"}
-{"prefix": " ", "surface": "төштем", "analysis": "төш+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "суга", "analysis": "су+N+Sg+DIR(ГА);сук+V+PRES(Й);", "translations": ["вода", "бить", "побить"]}
+{"prefix": " ", "surface": "төштем", "analysis": "төш+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["опускаться", "опуститься", "сон"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Моннан", "analysis": "бу+PN+ABL(ДАн);моннан+PN;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
+{"prefix": " ", "surface": "Моннан", "analysis": "бу+PN+ABL(ДАн);моннан+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
 {"prefix": " ", "surface": "котылырга", "analysis": "котыл+V+INF_1(ЫргА);"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Гафифәгә", "analysis": "NR"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "билет", "analysis": "билет+N+Sg+Nom;"}
+{"prefix": " ", "surface": "билет", "analysis": "билет+N+Sg+Nom;", "translations": ["билет"]}
 {"prefix": " ", "surface": "та", "analysis": "та+PART;"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайткан", "analysis": "кайт+V+PCP_PS(ГАн);кайт+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кайткан", "analysis": "кайт+V+PCP_PS(ГАн);кайт+V+PST_INDF(ГАн);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кайтсаң", "analysis": "кайт+V+COND(сА)+2SG(ң);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
+{"prefix": " ", "surface": "Кайтсаң", "analysis": "кайт+V+COND(сА)+2SG(ң);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "калган", "analysis": "кал+V+PCP_PS(ГАн);кал+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "калган", "analysis": "кал+V+PCP_PS(ГАн);кал+V+PST_INDF(ГАн);", "translations": ["оставаться", "остаться"]}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "акчаңны", "analysis": "ак+Adj+EQU(чА)+POSS_2SG(Ың)+ACC(нЫ);акча+N+Sg+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "кире", "analysis": "кире+Adj;кире+Adv;"}
-{"prefix": " ", "surface": "кайтарып", "analysis": "кайтар+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "алырсың", "analysis": "ал+V+FUT_INDF(Ыр)+2SG(сЫң);ал+V+PCP_FUT(Ыр)+2SG(сЫң);"}
+{"prefix": " ", "surface": "акчаңны", "analysis": "ак+Adj+EQU(чА)+POSS_2SG(Ың)+ACC(нЫ);акча+N+Sg+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["белый", "деньги"]}
+{"prefix": " ", "surface": "кире", "analysis": "кире+Adj;кире+Adv;", "translations": ["обратно", "обратный", "упрямый"]}
+{"prefix": " ", "surface": "кайтарып", "analysis": "кайтар+V+ADVV_ACC(Ып);", "translations": ["возвращение"]}
+{"prefix": " ", "surface": "алырсың", "analysis": "ал+V+FUT_INDF(Ыр)+2SG(сЫң);ал+V+PCP_FUT(Ыр)+2SG(сЫң);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "алган", "analysis": "ал+V+PCP_PS(ГАн);ал+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "алган", "analysis": "ал+V+PCP_PS(ГАн);ал+V+PST_INDF(ГАн);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кире", "analysis": "кире+Adj;кире+Adv;"}
-{"prefix": " ", "surface": "кайтармыйлар", "analysis": "кайтар+V+NEG(мА)+PRES(Й)+3PL(ЛАр);"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "кире", "analysis": "кире+Adj;кире+Adv;", "translations": ["обратно", "обратный", "упрямый"]}
+{"prefix": " ", "surface": "кайтармыйлар", "analysis": "кайтар+V+NEG(мА)+PRES(Й)+3PL(ЛАр);", "translations": ["возвращение"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();"}
+{"prefix": " ", "surface": "Теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);", "translations": ["желать", "пожелать"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);", "translations": ["испугаться"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "ерткыч", "analysis": "ерткыч+N+Sg+Nom;"}
-{"prefix": " ", "surface": "җанварлар", "analysis": "җанвар+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ерткыч", "analysis": "ерткыч+N+Sg+Nom;", "translations": ["зверь", "хищник"]}
+{"prefix": " ", "surface": "җанварлар", "analysis": "җанвар+N+PL(ЛАр)+Nom;", "translations": ["зверь"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "ашамаслар", "analysis": "аша+V+FUT_INDF_NEG(мАс)+3PL(ЛАр);аша+V+PCP_FUT(мАс)+3PL(ЛАр);аша+V+PCP_FUT(мАс)+PL(ЛАр)+Nom;"}
+{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "ашамаслар", "analysis": "аша+V+FUT_INDF_NEG(мАс)+3PL(ЛАр);аша+V+PCP_FUT(мАс)+3PL(ЛАр);аша+V+PCP_FUT(мАс)+PL(ЛАр)+Nom;", "translations": ["есть", "кушать", "через"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ашамасалар", "analysis": "аша+V+NEG(мА)+COND(сА)+3PL(ЛАр);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "Ашамасалар", "analysis": "аша+V+NEG(мА)+COND(сА)+3PL(ЛАр);", "translations": ["есть", "кушать", "через"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "кирәкми", "analysis": "кирәкми+MOD;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "калырга", "analysis": "кал+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;"}
+{"prefix": " ", "surface": "бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "калырга", "analysis": "кал+V+INF_1(ЫргА);", "translations": ["оставаться", "остаться"]}
+{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "күңелле", "analysis": "күңел+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "күңелле", "analysis": "күңел+N+ATTR_MUN(лЫ);", "translations": ["душа"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "үзеңнең", "analysis": "үз+PN+POSS_2SG(Ың)+GEN(нЫң);"}
+{"prefix": " ", "surface": "үзеңнең", "analysis": "үз+PN+POSS_2SG(Ың)+GEN(нЫң);", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": " ", "surface": "көлә-көлә", "analysis": "NR"}
-{"prefix": " ", "surface": "эчләрең", "analysis": "эч+N+PL(ЛАр)+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "катып", "analysis": "кат+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетәр", "analysis": "бет+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "эчләрең", "analysis": "эч+N+PL(ЛАр)+POSS_2SG(Ың)+Nom;", "translations": ["в", "в течение", "внутренность", "внутри", "выпить", "из", "пить"]}
+{"prefix": " ", "surface": "катып", "analysis": "кат+V+ADVV_ACC(Ып);", "translations": ["слой", "этаж"]}
+{"prefix": " ", "surface": "бетәр", "analysis": "бет+V+PCP_FUT(Ыр);", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Андый", "analysis": "андый+Adj;андый+PN;"}
-{"prefix": " ", "surface": "көлкеләрне", "analysis": "көлке+N+PL(ЛАр)+ACC(нЫ);"}
-{"prefix": " ", "surface": "ат", "analysis": "ат+N+Sg+Nom;ат+V+IMP_SG();"}
+{"prefix": " ", "surface": "көлкеләрне", "analysis": "көлке+N+PL(ЛАр)+ACC(нЫ);", "translations": ["смех"]}
+{"prefix": " ", "surface": "ат", "analysis": "ат+N+Sg+Nom;ат+V+IMP_SG();", "translations": ["лошадь", "стрелять"]}
 {"prefix": " ", "surface": "кәмитендә", "analysis": "кәмит+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "күргән", "analysis": "күр+V+PCP_PS(ГАн);күр+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "күргән", "analysis": "күр+V+PCP_PS(ГАн);күр+V+PST_INDF(ГАн);", "translations": ["видеть"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "Монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "артык", "analysis": "артык+Adj;"}
-{"prefix": " ", "surface": "җире", "analysis": "җир+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "булмас", "analysis": "бул+V+FUT_INDF_NEG(мАс);бул+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "артык", "analysis": "артык+Adj;", "translations": ["лишний"]}
+{"prefix": " ", "surface": "җире", "analysis": "җир+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "булмас", "analysis": "бул+V+FUT_INDF_NEG(мАс);бул+V+PCP_FUT(мАс);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "кирәкми", "analysis": "кирәкми+MOD;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ихтыярың", "analysis": "ихтыяр+N+Sg+POSS_2SG(Ың)+Nom;"}
+{"prefix": " ", "surface": "Ихтыярың", "analysis": "ихтыяр+N+Sg+POSS_2SG(Ың)+Nom;", "translations": ["воля"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();"}
+{"prefix": " ", "surface": "теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);", "translations": ["желать", "пожелать"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барасың", "analysis": "бар+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бар+V+PRES(Й)+2SG(сЫң);"}
-{"prefix": " ", "surface": "килмәсә", "analysis": "кил+V+NEG(мА)+COND(сА);"}
+{"prefix": " ", "surface": "барасың", "analysis": "бар+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бар+V+PRES(Й)+2SG(сЫң);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "килмәсә", "analysis": "кил+V+NEG(мА)+COND(сА);", "translations": ["идти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "көчләмим", "analysis": "көчлә+V+NEG(мА)+HOR_SG(Йм);көчлә+V+NEG(мА)+PRES(Й)+1SG(м);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;", "translations": ["берег", "годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барыр", "analysis": "бар+V+FUT_INDF(Ыр);бар+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "идең", "analysis": "и+V+PST_DEF(ДЫ)+2SG(ң);"}
+{"prefix": " ", "surface": "барыр", "analysis": "бар+V+FUT_INDF(Ыр);бар+V+PCP_FUT(Ыр);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "идең", "analysis": "и+V+PST_DEF(ДЫ)+2SG(ң);", "translations": ["быть"]}
 {"prefix": " ", "surface": "бугай", "analysis": "бугай+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "ялгыз", "analysis": "ялгыз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "кызлар", "analysis": "кыз+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "карарга", "analysis": "кара+V+INF_1(ЫргА);карар+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "бармакчы", "analysis": "бар+V+DESID(мАкчЫ);бармак+N+PROF(чЫ)+Sg+Nom;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ялгыз", "analysis": "ялгыз+N+Sg+Nom;", "translations": ["одинокий"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "кызлар", "analysis": "кыз+N+PL(ЛАр)+Nom;", "translations": ["девушка", "дочь"]}
+{"prefix": " ", "surface": "карарга", "analysis": "кара+V+INF_1(ЫргА);карар+N+Sg+DIR(ГА);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный", "постановление"]}
+{"prefix": " ", "surface": "бармакчы", "analysis": "бар+V+DESID(мАкчЫ);бармак+N+PROF(чЫ)+Sg+Nom;", "translations": ["бар", "быть", "весь", "идти", "пойти", "палец"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "җибәрәмме", "analysis": "җибәр+V+PRES(Й)+1SG(м)+INT(мЫ);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "җибәрәмме", "analysis": "җибәр+V+PRES(Й)+1SG(м)+INT(мЫ);", "translations": ["пускать", "пустить"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Алла", "analysis": "алла+N+Sg+Nom;"}
 {"prefix": " ", "surface": "боерса", "analysis": "боер+V+COND(сА);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "гомеремдә", "analysis": "гомер+N+Sg+POSS_1SG(Ым)+LOC(ДА);"}
-{"prefix": " ", "surface": "ялгыз", "analysis": "ялгыз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "җибәрмим", "analysis": "җибәр+V+NEG(мА)+HOR_SG(Йм);җибәр+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "гомеремдә", "analysis": "гомер+N+Sg+POSS_1SG(Ым)+LOC(ДА);", "translations": ["жизнь"]}
+{"prefix": " ", "surface": "ялгыз", "analysis": "ялгыз+N+Sg+Nom;", "translations": ["одинокий"]}
+{"prefix": " ", "surface": "җибәрмим", "analysis": "җибәр+V+NEG(мА)+HOR_SG(Йм);җибәр+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["пускать", "пустить"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();"}
+{"prefix": " ", "surface": "Теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);", "translations": ["желать", "пожелать"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "бармыйча", "analysis": "бар+V+NEG(мА)+ADVV_NEG(ЙчА);"}
-{"prefix": " ", "surface": "калмыйм", "analysis": "кал+V+NEG(мА)+HOR_SG(Йм);кал+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бармыйча", "analysis": "бар+V+NEG(мА)+ADVV_NEG(ЙчА);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "калмыйм", "analysis": "кал+V+NEG(мА)+HOR_SG(Йм);кал+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["оставаться", "остаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "бармыйсың", "analysis": "бар+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бар+V+NEG(мА)+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "бармыйсың", "analysis": "бар+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бар+V+NEG(мА)+PRES(Й)+2SG(сЫң);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "тотам", "analysis": "тот+V+PRES(Й)+1SG(м);тотам+N+Sg+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "тотам", "analysis": "тот+V+PRES(Й)+1SG(м);тотам+N+Sg+Nom;", "translations": ["держать"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хуш", "analysis": "хуш+Adj;хуш+INTRJ;"}
+{"prefix": " ", "surface": "Хуш", "analysis": "хуш+Adj;хуш+INTRJ;", "translations": ["бодрый", "приятно", "приятный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сау", "analysis": "сау+Adj;сау+V+IMP_SG();"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "сау", "analysis": "сау+Adj;сау+V+IMP_SG();", "translations": ["здорово", "здоровый"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "киттем", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+1SG(м);кит+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "киттем", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+1SG(м);кит+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чыга", "analysis": "чык+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": "", "surface": "Чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "тиз", "analysis": "тиз+Adj;тиз+Adv;"}
+{"prefix": "", "surface": "тиз", "analysis": "тиз+Adj;тиз+Adv;", "translations": ["быстро", "быстрый"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
 {"prefix": " ", "surface": "Вәлинең", "analysis": "вәли+PROP+GEN(нЫң);"}
-{"prefix": " ", "surface": "артыннан", "analysis": "арт+Adj+Sg+POSS_3(СЫ)+ABL(ДАн);артыннан+POST;"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "артыннан", "analysis": "арт+Adj+Sg+POSS_3(СЫ)+ABL(ДАн);артыннан+POST;", "translations": ["за", "зад", "из-за", "позади", "увеличиваться", "увеличиться"]}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);", "translations": ["держать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "җә", "analysis": "җә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "җә", "analysis": "җә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бетте", "analysis": "бет+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "бетте", "analysis": "бет+V+PST_DEF(ДЫ);", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "юри", "analysis": "юри+Adv;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "юри", "analysis": "юри+Adv;", "translations": ["нарочно"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "әйттем", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "әйттем", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "кире", "analysis": "кире+Adj;кире+Adv;"}
-{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "кире", "analysis": "кире+Adj;кире+Adv;", "translations": ["обратно", "обратный", "упрямый"]}
+{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ну", "analysis": "ну+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
-{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
+{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;", "translations": ["в таком случае", "если так", "тогда"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барсаң", "analysis": "бар+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "барсаң", "analysis": "бар+V+COND(сА)+2SG(ң);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "киен", "analysis": "ки+V+REFL(Ын)+IMP_SG();киен+V+IMP_SG();кий+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "киен", "analysis": "ки+V+REFL(Ын)+IMP_SG();киен+V+IMP_SG();кий+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["одеть", "одеваться", "одеться"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "киенәм", "analysis": "ки+V+REFL(Ын)+PRES(Й)+1SG(м);киен+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "киенәм", "analysis": "ки+V+REFL(Ын)+PRES(Й)+1SG(м);киен+V+PRES(Й)+1SG(м);", "translations": ["одеть", "одеваться", "одеться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Бүлмәгә", "analysis": "бүлмә+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": "", "surface": "Бүлмәгә", "analysis": "бүлмә+N+Sg+DIR(ГА);", "translations": ["комната"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Соңра", "analysis": "соңра+Adv;"}
-{"prefix": " ", "surface": "янә", "analysis": "янә+Adv;"}
-{"prefix": " ", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "янә", "analysis": "янә+Adv;", "translations": ["опять"]}
+{"prefix": " ", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "өскә", "analysis": "өс+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "киенгән", "analysis": "ки+V+REFL(Ын)+PCP_PS(ГАн);ки+V+REFL(Ын)+PST_INDF(ГАн);киен+V+PCP_PS(ГАн);киен+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "көенчә", "analysis": "көенчә+POST;көй+N+Sg+POSS_3(СЫ)+EQU(чА);"}
+{"prefix": " ", "surface": "киенгән", "analysis": "ки+V+REFL(Ын)+PCP_PS(ГАн);ки+V+REFL(Ын)+PST_INDF(ГАн);киен+V+PCP_PS(ГАн);киен+V+PST_INDF(ГАн);", "translations": ["одеть", "одеваться", "одеться"]}
+{"prefix": " ", "surface": "көенчә", "analysis": "көенчә+POST;көй+N+Sg+POSS_3(СЫ)+EQU(чА);", "translations": ["лад", "мелодия"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "утыралармы", "analysis": "утыр+V+PRES(Й)+3PL(ЛАр)+INT(мЫ);"}
+{"prefix": " ", "surface": "утыралармы", "analysis": "утыр+V+PRES(Й)+3PL(ЛАр)+INT(мЫ);", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "салып", "analysis": "сал+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "утыралар", "analysis": "утыр+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "салып", "analysis": "сал+V+ADVV_ACC(Ып);", "translations": ["класть", "положить"]}
+{"prefix": " ", "surface": "утыралар", "analysis": "утыр+V+PRES(Й)+3PL(ЛАр);", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Алай", "analysis": "алай+PN;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "читен", "analysis": "чит+Adj+Sg+POSS_3(СЫ)+ACC(нЫ);чит+N+Sg+POSS_3(СЫ)+ACC(нЫ);читен+Adj;"}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "читен", "analysis": "чит+Adj+Sg+POSS_3(СЫ)+ACC(нЫ);чит+N+Sg+POSS_3(СЫ)+ACC(нЫ);читен+Adj;", "translations": ["чужой"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Кирәкми", "analysis": "кирәкми+MOD;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "сөйләмә", "analysis": "сөйлә+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "Бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сөйләмә", "analysis": "сөйлә+V+NEG(мА)+IMP_SG();", "translations": ["говорить", "рассказывать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "киттем", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+1SG(м);кит+V+PST_DEF(ДЫ)+1SG(м);"}
-{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;"}
+{"prefix": " ", "surface": "киттем", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+1SG(м);кит+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;", "translations": ["в таком случае", "если так", "тогда"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чыга", "analysis": "чык+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": "", "surface": "Чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "мыскыл", "analysis": "мыскыл+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": "", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": " ", "surface": "үзе", "analysis": "үзе+PN;"}
-{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv;"}
+{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv;", "translations": ["всегда", "всё время"]}
 {"prefix": " ", "surface": "терәлеп", "analysis": "терә+V+PASS(Ыл)+ADVV_ACC(Ып);терәл+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Сәгатен", "analysis": "сәгать+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "чыгарып", "analysis": "чыгар+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Сәгатен", "analysis": "сәгать+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["час", "часы"]}
+{"prefix": " ", "surface": "чыгарып", "analysis": "чыгар+V+ADVV_ACC(Ып);", "translations": ["вывести", "выводить"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Син", "analysis": "син+PN;"}
+{"prefix": " ", "surface": "Син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "маташып", "analysis": "маташ+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "маташып", "analysis": "маташ+V+ADVV_ACC(Ып);", "translations": ["попытаться", "пытаться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "уеннан", "analysis": "уен+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "калдырмакчы", "analysis": "калдыр+V+DESID(мАкчЫ);"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
-{"prefix": " ", "surface": "торгансыңдыр", "analysis": "тор+V+PCP_PS(ГАн)+2SG(сЫң)+PROB(ДЫр);тор+V+PST_INDF(ГАн)+2SG(сЫң)+PROB(ДЫр);"}
+{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;", "translations": ["мозг", "мой", "я"]}
+{"prefix": " ", "surface": "уеннан", "analysis": "уен+N+Sg+ABL(ДАн);", "translations": ["игра"]}
+{"prefix": " ", "surface": "калдырмакчы", "analysis": "калдыр+V+DESID(мАкчЫ);", "translations": ["оставить", "оставлять"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "торгансыңдыр", "analysis": "тор+V+PCP_PS(ГАн)+2SG(сЫң)+PROB(ДЫр);тор+V+PST_INDF(ГАн)+2SG(сЫң)+PROB(ДЫр);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": " ", "surface": "ахры", "analysis": "ахры+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Уен", "analysis": "уен+N+Sg+Nom;уй+N+Sg+POSS_3(СЫ)+ACC(нЫ);уй+V+REFL(Ын)+IMP_SG();"}
-{"prefix": " ", "surface": "башланырга", "analysis": "башла+V+REFL(Ын)+INF_1(ЫргА);башлан+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "бары", "analysis": "бар+N+Sg+POSS_3(СЫ)+Nom;бар+PN+POSS_3(СЫ)+Nom;бары+CNJ;бары+PN;"}
-{"prefix": " ", "surface": "ярты", "analysis": "ярты+N+Sg+Nom;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "сәгать", "analysis": "сәгать+N+Sg+Nom;"}
-{"prefix": " ", "surface": "калган", "analysis": "кал+V+PCP_PS(ГАн);кал+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "Уен", "analysis": "уен+N+Sg+Nom;уй+N+Sg+POSS_3(СЫ)+ACC(нЫ);уй+V+REFL(Ын)+IMP_SG();", "translations": ["игра", "мысль"]}
+{"prefix": " ", "surface": "башланырга", "analysis": "башла+V+REFL(Ын)+INF_1(ЫргА);башлан+V+INF_1(ЫргА);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
+{"prefix": " ", "surface": "бары", "analysis": "бар+N+Sg+POSS_3(СЫ)+Nom;бар+PN+POSS_3(СЫ)+Nom;бары+CNJ;бары+PN;", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "ярты", "analysis": "ярты+N+Sg+Nom;", "translations": ["половина"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "сәгать", "analysis": "сәгать+N+Sg+Nom;", "translations": ["час", "часы"]}
+{"prefix": " ", "surface": "калган", "analysis": "кал+V+PCP_PS(ГАн);кал+V+PST_INDF(ГАн);", "translations": ["оставаться", "остаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "булам", "analysis": "бул+V+PRES(Й)+1SG(м);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "өстемә", "analysis": "өс+N+Sg+POSS_1SG(Ым)+DIR(ГА);"}
-{"prefix": " ", "surface": "күлмәк", "analysis": "күлмәк+N+Sg+Nom;"}
+{"prefix": " ", "surface": "күлмәк", "analysis": "күлмәк+N+Sg+Nom;", "translations": ["платье", "рубашка"]}
 {"prefix": " ", "surface": "кенә", "analysis": "кенә+PART;"}
-{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ну", "analysis": "ну+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "зинһар", "analysis": "зинһар+MOD;"}
+{"prefix": " ", "surface": "зинһар", "analysis": "зинһар+MOD;", "translations": ["пожалуйста"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": "", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "янә", "analysis": "янә+Adv;"}
-{"prefix": " ", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "янә", "analysis": "янә+Adv;", "translations": ["опять"]}
+{"prefix": " ", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["платье", "рубашка"]}
 {"prefix": " ", "surface": "киим", "analysis": "NR"}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "асылмы", "analysis": "ас+V+PASS(Ыл)+INT(мЫ);асыл+N+Sg+Nom+INT(мЫ);"}
+{"prefix": " ", "surface": "асылмы", "analysis": "ас+V+PASS(Ыл)+INT(мЫ);асыл+N+Sg+Nom+INT(мЫ);", "translations": ["благородный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "җонмы", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
@@ -1930,33 +1930,33 @@
 {"prefix": "", "surface": "үз-үзенә", "analysis": "үз-үз+PN+POSS_3(СЫ)+DIR(ГА);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Асыласың", "analysis": "ас+V+PASS(Ыл)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;ас+V+PASS(Ыл)+PRES(Й)+2SG(сЫң);асыл+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;асыл+V+PRES(Й)+2SG(сЫң);"}
-{"prefix": " ", "surface": "килсә", "analysis": "кил+V+COND(сА);"}
+{"prefix": " ", "surface": "Асыласың", "analysis": "ас+V+PASS(Ыл)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;ас+V+PASS(Ыл)+PRES(Й)+2SG(сЫң);асыл+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;асыл+V+PRES(Й)+2SG(сЫң);", "translations": ["благородный"]}
+{"prefix": " ", "surface": "килсә", "analysis": "кил+V+COND(сА);", "translations": ["идти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "асыл", "analysis": "ас+V+PASS(Ыл)+IMP_SG();асыл+N+Sg+Nom;асыл+V+IMP_SG();"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "асыл", "analysis": "ас+V+PASS(Ыл)+IMP_SG();асыл+N+Sg+Nom;асыл+V+IMP_SG();", "translations": ["благородный"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Гафифәгә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;"}
+{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;", "translations": ["пожалуйста"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;", "translations": ["мозг", "мой", "я"]}
 {"prefix": " ", "surface": "йөдәтмә", "analysis": "йөдә+V+CAUS(т)+NEG(мА)+IMP_SG();йөдәт+V+NEG(мА)+IMP_SG();"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Эстәдең", "analysis": "эстә+V+PST_DEF(ДЫ)+2SG(ң);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
 {"prefix": " ", "surface": "киЭстәдең", "analysis": "NR"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
+{"prefix": "", "surface": "теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);", "translations": ["желать", "пожелать"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
-{"prefix": " ", "surface": "асылмы", "analysis": "ас+V+PASS(Ыл)+INT(мЫ);асыл+N+Sg+Nom+INT(мЫ);"}
+{"prefix": " ", "surface": "асылмы", "analysis": "ас+V+PASS(Ыл)+INT(мЫ);асыл+N+Sg+Nom+INT(мЫ);", "translations": ["благородный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "җонмы", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
@@ -1966,697 +1966,697 @@
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "ситсымы", "analysis": "ситсы+N+Sg+Nom+INT(мЫ);"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
+{"prefix": "", "surface": "минем", "analysis": "мин+PN+GEN(нЫң);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;", "translations": ["для", "за"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
-{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;", "translations": ["в таком случае", "если так", "тогда"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "зәңгәр", "analysis": "зәңгәр+Adj;"}
-{"prefix": " ", "surface": "асылымны", "analysis": "ас+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ)+Sg+POSS_1SG(Ым)+ACC(нЫ);асыл+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
-{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "зәңгәр", "analysis": "зәңгәр+Adj;", "translations": ["голубой", "синий"]}
+{"prefix": " ", "surface": "асылымны", "analysis": "ас+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ)+Sg+POSS_1SG(Ым)+ACC(нЫ);асыл+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["благородный"]}
+{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": "", "surface": "Китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();", "translations": ["останавливаться", "остановиться", "остановка"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "зәңгәр", "analysis": "зәңгәр+Adj;"}
-{"prefix": " ", "surface": "асылыңны", "analysis": "ас+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ)+Sg+POSS_2SG(Ың)+ACC(нЫ);асыл+N+Sg+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "кимә", "analysis": "ки+V+NEG(мА)+IMP_SG();кимә+N+Sg+Nom;"}
+{"prefix": " ", "surface": "зәңгәр", "analysis": "зәңгәр+Adj;", "translations": ["голубой", "синий"]}
+{"prefix": " ", "surface": "асылыңны", "analysis": "ас+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ)+Sg+POSS_2SG(Ың)+ACC(нЫ);асыл+N+Sg+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["благородный"]}
+{"prefix": " ", "surface": "кимә", "analysis": "ки+V+NEG(мА)+IMP_SG();кимә+N+Sg+Nom;", "translations": ["одеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "берәр", "analysis": "бер+Num+NUM_DISR(шАр);"}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "берәр", "analysis": "бер+Num+NUM_DISR(шАр);", "translations": ["один", "первый"]}
 {"prefix": " ", "surface": "җон", "analysis": "NR"}
-{"prefix": " ", "surface": "күлмәгеңне", "analysis": "күлмәк+N+Sg+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
+{"prefix": " ", "surface": "күлмәгеңне", "analysis": "күлмәк+N+Sg+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сезнең", "analysis": "сез+PN+GEN(нЫң);"}
+{"prefix": " ", "surface": "Сезнең", "analysis": "сез+PN+GEN(нЫң);", "translations": ["ваш", "вы"]}
 {"prefix": " ", "surface": "андый", "analysis": "андый+Adj;андый+PN;"}
 {"prefix": " ", "surface": "чачаклы-чуклы", "analysis": "чачаклы-чуклы+Adj;"}
-{"prefix": " ", "surface": "карават", "analysis": "карават+N+Sg+Nom;"}
+{"prefix": " ", "surface": "карават", "analysis": "карават+N+Sg+Nom;", "translations": ["кровать"]}
 {"prefix": " ", "surface": "чаршавы", "analysis": "чаршау+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
-{"prefix": " ", "surface": "асыл", "analysis": "ас+V+PASS(Ыл)+IMP_SG();асыл+N+Sg+Nom;асыл+V+IMP_SG();"}
-{"prefix": " ", "surface": "күлмәкләрегез", "analysis": "күлмәк+N+PL(ЛАр)+POSS_2PL(ЫгЫз)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "көлкегә", "analysis": "көлке+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "хәлем", "analysis": "хәл+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
+{"prefix": " ", "surface": "асыл", "analysis": "ас+V+PASS(Ыл)+IMP_SG();асыл+N+Sg+Nom;асыл+V+IMP_SG();", "translations": ["благородный"]}
+{"prefix": " ", "surface": "күлмәкләрегез", "analysis": "күлмәк+N+PL(ЛАр)+POSS_2PL(ЫгЫз)+Nom;", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);", "translations": ["человек"]}
+{"prefix": " ", "surface": "көлкегә", "analysis": "көлке+N+Sg+DIR(ГА);", "translations": ["смех"]}
+{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);", "translations": ["оставаться", "остаться"]}
+{"prefix": " ", "surface": "хәлем", "analysis": "хәл+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["состояние"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;"}
+{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
 {"prefix": " ", "surface": "андабүләк", "analysis": "NR"}
 {"prefix": " ", "surface": "багаргаБүләк", "analysis": "NR"}
 {"prefix": " ", "surface": "багу", "analysis": "бак+V+VN_1(у/ү/в)+Nom;"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "туйга", "analysis": "туй+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "әзерләнгән", "analysis": "әзерлә+V+REFL(Ын)+PCP_PS(ГАн);әзерлә+V+REFL(Ын)+PST_INDF(ГАн);әзерлән+V+PCP_PS(ГАн);әзерлән+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "бүләкләрне", "analysis": "бүләк+N+PL(ЛАр)+ACC(нЫ);"}
-{"prefix": " ", "surface": "карау", "analysis": "кара+V+VN_1(у/ү/в)+Nom;"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;"}
+{"prefix": "", "surface": "туйга", "analysis": "туй+N+Sg+DIR(ГА);", "translations": ["свадьба"]}
+{"prefix": " ", "surface": "әзерләнгән", "analysis": "әзерлә+V+REFL(Ын)+PCP_PS(ГАн);әзерлә+V+REFL(Ын)+PST_INDF(ГАн);әзерлән+V+PCP_PS(ГАн);әзерлән+V+PST_INDF(ГАн);", "translations": ["готовить", "приготовить", "готовиться"]}
+{"prefix": " ", "surface": "бүләкләрне", "analysis": "бүләк+N+PL(ЛАр)+ACC(нЫ);", "translations": ["подарок"]}
+{"prefix": " ", "surface": "карау", "analysis": "кара+V+VN_1(у/ү/в)+Nom;", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;", "translations": ["для", "за"]}
 {"prefix": " ", "surface": "җыелу", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "уен", "analysis": "уен+N+Sg+Nom;уй+N+Sg+POSS_3(СЫ)+ACC(нЫ);уй+V+REFL(Ын)+IMP_SG();"}
-{"prefix": " ", "surface": "карарга", "analysis": "кара+V+INF_1(ЫргА);карар+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "уен", "analysis": "уен+N+Sg+Nom;уй+N+Sg+POSS_3(СЫ)+ACC(нЫ);уй+V+REFL(Ын)+IMP_SG();", "translations": ["игра", "мысль"]}
+{"prefix": " ", "surface": "карарга", "analysis": "кара+V+INF_1(ЫргА);карар+N+Sg+DIR(ГА);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный", "постановление"]}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Алай", "analysis": "алай+PN;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
 {"prefix": " ", "surface": "җон", "analysis": "NR"}
-{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["платье", "рубашка"]}
 {"prefix": " ", "surface": "киим", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теләгәнеңне", "analysis": "телә+V+PCP_PS(ГАн)+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
+{"prefix": " ", "surface": "Теләгәнеңне", "analysis": "телә+V+PCP_PS(ГАн)+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["желать", "пожелать"]}
+{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теге", "analysis": "теге+PN;"}
+{"prefix": " ", "surface": "Теге", "analysis": "теге+PN;", "translations": ["там", "тот"]}
 {"prefix": " ", "surface": "гармун", "analysis": "гармун+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итәкле", "analysis": "итәк+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;"}
+{"prefix": " ", "surface": "итәкле", "analysis": "итәк+N+ATTR_MUN(лЫ);", "translations": ["подол"]}
+{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;", "translations": ["красно", "красный"]}
 {"prefix": " ", "surface": "җон", "analysis": "NR"}
-{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шәп", "analysis": "шәп+Adj;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Шәп", "analysis": "шәп+Adj;", "translations": ["замечательно", "замечательный"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "буе", "analysis": "буе+POST;буй+N+Sg+POSS_3(СЫ)+Nom;буй+PROP+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "озын", "analysis": "озын+Adj;озын+Adv;"}
-{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "буе", "analysis": "буе+POST;буй+N+Sg+POSS_3(СЫ)+Nom;буй+PROP+POSS_3(СЫ)+Nom;", "translations": ["в течение", "по", "длина", "рост"]}
+{"prefix": " ", "surface": "озын", "analysis": "озын+Adj;озын+Adv;", "translations": ["длинный"]}
+{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Чәнчелеп", "analysis": "чәнче+V+PASS(Ыл)+ADVV_ACC(Ып);чәнчел+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "беткән", "analysis": "бет+V+PCP_PS(ГАн);бет+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "Чәнчелеп", "analysis": "чәнче+V+PASS(Ыл)+ADVV_ACC(Ып);чәнчел+V+ADVV_ACC(Ып);", "translations": ["колоть"]}
+{"prefix": " ", "surface": "беткән", "analysis": "бет+V+PCP_PS(ГАн);бет+V+PST_INDF(ГАн);", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": " ", "surface": "җөйче", "analysis": "җөй+N+PROF(чЫ)+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
-{"prefix": " ", "surface": "әйттем", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
+{"prefix": " ", "surface": "әйттем", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "Факиһәнеке", "analysis": "NR"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
-{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;"}
-{"prefix": " ", "surface": "булсын", "analysis": "бул+V+JUS_SG(сЫн);"}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
+{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;", "translations": ["красиво", "красивый"]}
+{"prefix": " ", "surface": "булсын", "analysis": "бул+V+JUS_SG(сЫн);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj;яхшы+Adv;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj;яхшы+Adv;", "translations": ["лучше", "лучший", "хороший", "хорошо"]}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
 {"prefix": " ", "surface": "тек", "analysis": "тек+N+Sg+Nom;тек+V+IMP_SG();"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бозып", "analysis": "боз+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Бозып", "analysis": "боз+V+ADVV_ACC(Ып);", "translations": ["испортить", "лед/лёд", "лёд"]}
 {"prefix": " ", "surface": "кына", "analysis": "кына+PART;"}
-{"prefix": " ", "surface": "бирде", "analysis": "бир+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "бирде", "analysis": "бир+V+PST_DEF(ДЫ);", "translations": ["давать", "даваться", "дать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Юкка", "analysis": "юкка+Adv;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;"}
-{"prefix": " ", "surface": "тәңкә", "analysis": "тәңкә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;"}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;", "translations": ["четвёртый", "четыре"]}
+{"prefix": " ", "surface": "тәңкә", "analysis": "тәңкә+N+Sg+Nom;", "translations": ["монета"]}
+{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;", "translations": ["деньги"]}
 {"prefix": " ", "surface": "әрәм", "analysis": "әрәм+Adj;"}
-{"prefix": " ", "surface": "иттем", "analysis": "и+V+CAUS(т)+PST_DEF(ДЫ)+1SG(м);ит+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "иттем", "analysis": "и+V+CAUS(т)+PST_DEF(ДЫ)+1SG(м);ит+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть", "делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Моннан", "analysis": "бу+PN+ABL(ДАн);моннан+PN;"}
-{"prefix": " ", "surface": "ары", "analysis": "ар+N+Sg+POSS_3(СЫ)+Nom;ары+Adj;ары+V+IMP_SG();"}
+{"prefix": " ", "surface": "Моннан", "analysis": "бу+PN+ABL(ДАн);моннан+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "ары", "analysis": "ар+N+Sg+POSS_3(СЫ)+Nom;ары+Adj;ары+V+IMP_SG();", "translations": ["дальше", "после", "устать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Алла", "analysis": "алла+N+Sg+Nom;"}
 {"prefix": " ", "surface": "боерса", "analysis": "боер+V+COND(сА);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "гомердә", "analysis": "гомер+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "хатынга", "analysis": "хатын+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "гомердә", "analysis": "гомер+N+Sg+LOC(ДА);", "translations": ["жизнь"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "хатынга", "analysis": "хатын+N+Sg+DIR(ГА);", "translations": ["жена", "женщина"]}
 {"prefix": " ", "surface": "тектермәм", "analysis": "тек+V+CAUS(ДЫр)+FUT_INDF_NEG(мАс)+1SG(м);тектер+V+FUT_INDF_NEG(мАс)+1SG(м);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "итәрсең", "analysis": "и+V+CAUS(т)+PCP_FUT(Ыр)+2SG(сЫң);ит+V+PCP_FUT(Ыр)+2SG(сЫң);"}
+{"prefix": " ", "surface": "итәрсең", "analysis": "и+V+CAUS(т)+PCP_FUT(Ыр)+2SG(сЫң);ит+V+PCP_FUT(Ыр)+2SG(сЫң);", "translations": ["быть", "делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": " ", "surface": "кайсын", "analysis": "NR"}
 {"prefix": " ", "surface": "киим", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Башкасын", "analysis": "башка+Adj+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Башкасын", "analysis": "башка+Adj+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["другой", "кроме"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теге", "analysis": "теге+PN;"}
+{"prefix": " ", "surface": "Теге", "analysis": "теге+PN;", "translations": ["там", "тот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "буйга", "analysis": "буй+N+Sg+DIR(ГА);буй+PROP+DIR(ГА);буйга+Adv;"}
+{"prefix": " ", "surface": "буйга", "analysis": "буй+N+Sg+DIR(ГА);буй+PROP+DIR(ГА);буйга+Adv;", "translations": ["длина", "рост"]}
 {"prefix": " ", "surface": "буф", "analysis": "Rus"}
 {"prefix": " ", "surface": "бөргәнсирыйСирый", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "серый", "analysis": "Rus"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "көрән", "analysis": "көрә+V+REFL(Ын)+IMP_SG();көрән+Adj;"}
+{"prefix": "", "surface": "көрән", "analysis": "көрә+V+REFL(Ын)+IMP_SG();көрән+Adj;", "translations": ["коричневый"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["платье", "рубашка"]}
 {"prefix": " ", "surface": "киимме", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
+{"prefix": " ", "surface": "Ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "килешеп", "analysis": "кил+V+RECP(Ыш)+ADVV_ACC(Ып);килеш+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетми", "analysis": "бет+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "килешеп", "analysis": "кил+V+RECP(Ыш)+ADVV_ACC(Ып);килеш+V+ADVV_ACC(Ып);", "translations": ["идти", "согласиться", "соглашаться"]}
+{"prefix": " ", "surface": "бетми", "analysis": "бет+V+NEG(мА)+PRES(Й);", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чабулары", "analysis": "чабу+N+PL(ЛАр)+POSS_3(СЫ)+Nom;чап+V+VN_1(у/ү/в)+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "тар", "analysis": "тар+Adj;"}
-{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "чабулары", "analysis": "чабу+N+PL(ЛАр)+POSS_3(СЫ)+Nom;чап+V+VN_1(у/ү/в)+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["бегать", "побежать"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "тар", "analysis": "тар+Adj;", "translations": ["узкий"]}
+{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD;"}
-{"prefix": " ", "surface": "бүтәнне", "analysis": "бүтән+Adj+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
+{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD;", "translations": ["в таком случае", "если так", "тогда"]}
+{"prefix": " ", "surface": "бүтәнне", "analysis": "бүтән+Adj+Sg+ACC(нЫ);", "translations": ["другой", "кроме"]}
+{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ал", "analysis": "ал+Adj;ал+N+Sg+Nom;ал+PN;ал+V+IMP_SG();"}
+{"prefix": " ", "surface": "Ал", "analysis": "ал+Adj;ал+N+Sg+Nom;ал+PN;ал+V+IMP_SG();", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": " ", "surface": "җон", "analysis": "NR"}
-{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "ал", "analysis": "ал+Adj;ал+N+Sg+Nom;ал+PN;ал+V+IMP_SG();"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "ал", "analysis": "ал+Adj;ал+N+Sg+Nom;ал+PN;ал+V+IMP_SG();", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кызылы", "analysis": "кыз+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ);кызыл+Adj+Sg+POSS_3(СЫ)+Nom;кызыл+PROP+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "Кызылы", "analysis": "кыз+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ);кызыл+Adj+Sg+POSS_3(СЫ)+Nom;кызыл+PROP+POSS_3(СЫ)+Nom;", "translations": ["девушка", "дочь", "красно", "красный"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;", "translations": ["красно", "красный"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Яшеле", "analysis": "яшел+Adj+Sg+POSS_3(СЫ)+Nom;яшел+PROP+POSS_3(СЫ)+Nom;яшь+Adj+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ);яшь+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ);"}
+{"prefix": " ", "surface": "Яшеле", "analysis": "яшел+Adj+Sg+POSS_3(СЫ)+Nom;яшел+PROP+POSS_3(СЫ)+Nom;яшь+Adj+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ);яшь+N+Sg+POSS_3(СЫ)+ATTR_MUN(лЫ);", "translations": ["зелёный", "возраст", "год²", "молодой", "юный"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "яшел", "analysis": "яшел+Adj;яшел+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "яшел", "analysis": "яшел+Adj;яшел+PROP+Sg+Nom;", "translations": ["зелёный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "ниндине", "analysis": "нинди+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "ниндине", "analysis": "нинди+PN+ACC(нЫ);", "translations": ["какой"]}
 {"prefix": " ", "surface": "киим", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Матурракны", "analysis": "матур+Adj+COMP(рАк)+Sg+ACC(нЫ);"}
+{"prefix": " ", "surface": "Матурракны", "analysis": "матур+Adj+COMP(рАк)+Sg+ACC(нЫ);", "translations": ["красиво", "красивый"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теге", "analysis": "теге+PN;"}
+{"prefix": " ", "surface": "Теге", "analysis": "теге+PN;", "translations": ["там", "тот"]}
 {"prefix": " ", "surface": "шикалат", "analysis": "NR"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тоташ", "analysis": "тоташ+Adj;тоташ+V+IMP_SG();"}
-{"prefix": " ", "surface": "буйлы", "analysis": "буй+N+ATTR_MUN(лЫ);буй+PROP+ATTR_MUN(лЫ);буйлы+Adj;"}
+{"prefix": " ", "surface": "тоташ", "analysis": "тоташ+Adj;тоташ+V+IMP_SG();", "translations": ["сплошной"]}
+{"prefix": " ", "surface": "буйлы", "analysis": "буй+N+ATTR_MUN(лЫ);буй+PROP+ATTR_MUN(лЫ);буйлы+Adj;", "translations": ["длина", "рост", "полосатый"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бантикле", "analysis": "бантик+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
-{"prefix": " ", "surface": "кисәм", "analysis": "ки+V+COND(сА)+1SG(м);кис+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "кисәм", "analysis": "ки+V+COND(сА)+1SG(м);кис+V+PRES(Й)+1SG(м);", "translations": ["одеть", "резать"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "шатланган", "analysis": "шатлан+V+PCP_PS(ГАн);шатлан+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "шатланган", "analysis": "шатлан+V+PCP_PS(ГАн);шатлан+V+PST_INDF(ГАн);", "translations": ["обрадоваться", "радоваться"]}
+{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "һу", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "эзли", "analysis": "эзлә+V+PRES(Й);"}
-{"prefix": " ", "surface": "торгач", "analysis": "тор+V+ADVV_ANT(ГАч);"}
-{"prefix": " ", "surface": "таптың", "analysis": "тап+V+PST_DEF(ДЫ)+2SG(ң);"}
+{"prefix": " ", "surface": "эзли", "analysis": "эзлә+V+PRES(Й);", "translations": ["искать"]}
+{"prefix": " ", "surface": "торгач", "analysis": "тор+V+ADVV_ANT(ГАч);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "таптың", "analysis": "тап+V+PST_DEF(ДЫ)+2SG(ң);", "translations": ["найти", "находить", "пятно"]}
 {"prefix": " ", "surface": "ахры", "analysis": "ахры+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
 {"prefix": " ", "surface": "һәйбәт", "analysis": "NR"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "үзе", "analysis": "үзе+PN;"}
 {"prefix": " ", "surface": "шикалат", "analysis": "NR"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бигрәк", "analysis": "бигрәк+Adv;"}
-{"prefix": " ", "surface": "шәп", "analysis": "шәп+Adj;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "бигрәк", "analysis": "бигрәк+Adv;", "translations": ["особенно", "слишком"]}
+{"prefix": " ", "surface": "шәп", "analysis": "шәп+Adj;", "translations": ["замечательно", "замечательный"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Чөнки", "analysis": "чөнки+CNJ;"}
 {"prefix": " ", "surface": "шикалат", "analysis": "NR"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "тәмле", "analysis": "тәм+N+ATTR_MUN(лЫ);тәмле+Adj;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "тәмле", "analysis": "тәм+N+ATTR_MUN(лЫ);тәмле+Adj;", "translations": ["вкус", "вкусный"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "кияр", "analysis": "NR"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
-{"prefix": " ", "surface": "киюен", "analysis": "ки+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);кию+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
+{"prefix": " ", "surface": "киюен", "analysis": "ки+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);кию+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["одеть"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": " ", "surface": "җиңнәресак", "analysis": "NR"}
 {"prefix": " ", "surface": "жиңСак", "analysis": "NR"}
-{"prefix": " ", "surface": "җиң", "analysis": "җиң+N+Sg+Nom;җиң+V+IMP_SG();"}
+{"prefix": " ", "surface": "җиң", "analysis": "җиң+N+Sg+Nom;җиң+V+IMP_SG();", "translations": ["победить", "рукав"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "кыска", "analysis": "кыска+Adj;кыска+Adv;"}
-{"prefix": " ", "surface": "җиңле", "analysis": "җиң+N+ATTR_MUN(лЫ);"}
+{"prefix": "", "surface": "кыска", "analysis": "кыска+Adj;кыска+Adv;", "translations": ["короткий", "коротко"]}
+{"prefix": " ", "surface": "җиңле", "analysis": "җиң+N+ATTR_MUN(лЫ);", "translations": ["победить", "рукав"]}
 {"prefix": " ", "surface": "хатын-кыз", "analysis": "хатын-кыз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "күлмәге", "analysis": "күлмәк+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "күлмәге", "analysis": "күлмәк+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["платье", "рубашка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Килешмәс", "analysis": "кил+V+RECP(Ыш)+FUT_INDF_NEG(мАс);кил+V+RECP(Ыш)+PCP_FUT(мАс);килеш+V+FUT_INDF_NEG(мАс);килеш+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "Килешмәс", "analysis": "кил+V+RECP(Ыш)+FUT_INDF_NEG(мАс);кил+V+RECP(Ыш)+PCP_FUT(мАс);килеш+V+FUT_INDF_NEG(мАс);килеш+V+PCP_FUT(мАс);", "translations": ["идти", "согласиться", "соглашаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "үзең", "analysis": "үз+PN+POSS_2SG(Ың)+Nom;"}
+{"prefix": " ", "surface": "үзең", "analysis": "үз+PN+POSS_2SG(Ың)+Nom;", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "ичмаса", "analysis": "ичмаса+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;"}
-{"prefix": " ", "surface": "чибәр", "analysis": "чибәр+Adj;"}
-{"prefix": " ", "surface": "күлмәклек", "analysis": "күлмәк+N+NMLZ(лЫк)+Sg+Nom;күлмәк+N+PSBL(лЫк);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "биргәнең", "analysis": "бир+V+PCP_PS(ГАн)+POSS_2SG(Ың)+Nom;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "төсле", "analysis": "төс+N+ATTR_MUN(лЫ);төсле+Adj;төсле+POST;", "translations": ["цвет", "цветной"]}
+{"prefix": " ", "surface": "чибәр", "analysis": "чибәр+Adj;", "translations": ["красиво", "красивый"]}
+{"prefix": " ", "surface": "күлмәклек", "analysis": "күлмәк+N+NMLZ(лЫк)+Sg+Nom;күлмәк+N+PSBL(лЫк);", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "биргәнең", "analysis": "бир+V+PCP_PS(ГАн)+POSS_2SG(Ың)+Nom;", "translations": ["давать", "даваться", "дать"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "җиргә", "analysis": "җир+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);"}
-{"prefix": " ", "surface": "башладың", "analysis": "башла+V+PST_DEF(ДЫ)+2SG(ң);"}
-{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;"}
+{"prefix": " ", "surface": "Бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "җиргә", "analysis": "җир+N+Sg+DIR(ГА);", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "башладың", "analysis": "башла+V+PST_DEF(ДЫ)+2SG(ң);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
+{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;", "translations": ["быть", "дуть", "запах"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "киеп", "analysis": "ки+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "барырлык", "analysis": "бар+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;бар+V+PCP_FUT(Ыр)+PSBL(лЫк);"}
-{"prefix": " ", "surface": "һичбер", "analysis": "һичбер+PN;"}
+{"prefix": " ", "surface": "киеп", "analysis": "ки+V+ADVV_ACC(Ып);", "translations": ["одеть"]}
+{"prefix": " ", "surface": "барырлык", "analysis": "бар+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;бар+V+PCP_FUT(Ыр)+PSBL(лЫк);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "һичбер", "analysis": "һичбер+PN;", "translations": ["никакой>"]}
 {"prefix": " ", "surface": "җүнле", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;"}
-{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "матур", "analysis": "матур+Adj;", "translations": ["красиво", "красивый"]}
+{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
 {"prefix": " ", "surface": "тегеп", "analysis": "тек+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "лабаса", "analysis": "лабаса+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уф", "analysis": "уф+INTRJ;"}
 {"prefix": " ", "surface": "Алла", "analysis": "алла+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "кылыну", "analysis": "кыл+V+REFL(Ын)+VN_1(у/ү/в)+Nom;"}
+{"prefix": " ", "surface": "кылыну", "analysis": "кыл+V+REFL(Ын)+VN_1(у/ү/в)+Nom;", "translations": ["делать", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "ансы", "analysis": "анысы+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "монсы", "analysis": "Rus"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "боларга", "analysis": "бу+PN+PL(ЛАр)+DIR(ГА);"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "боларга", "analysis": "бу+PN+PL(ЛАр)+DIR(ГА);", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
-{"prefix": " ", "surface": "торгандыр", "analysis": "тор+V+PCP_PS(ГАн)+3SG(ДЫр);тор+V+PCP_PS(ГАн)+PROB(ДЫр);тор+V+PST_INDF(ГАн)+PROB(ДЫр);"}
+{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "торгандыр", "analysis": "тор+V+PCP_PS(ГАн)+3SG(ДЫр);тор+V+PCP_PS(ГАн)+PROB(ДЫр);тор+V+PST_INDF(ГАн)+PROB(ДЫр);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чәнчелеп", "analysis": "чәнче+V+PASS(Ыл)+ADVV_ACC(Ып);чәнчел+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетегез", "analysis": "бет+N+Sg+POSS_2PL(ЫгЫз)+Nom;бет+V+IMP_PL(ЫгЫз);"}
-{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "чәнчелеп", "analysis": "чәнче+V+PASS(Ыл)+ADVV_ACC(Ып);чәнчел+V+ADVV_ACC(Ып);", "translations": ["колоть"]}
+{"prefix": " ", "surface": "бетегез", "analysis": "бет+N+Sg+POSS_2PL(ЫгЫз)+Nom;бет+V+IMP_PL(ЫгЫз);", "translations": ["вошь", "кончаться", "кончиться"]}
+{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сезне", "analysis": "сез+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "көтеп", "analysis": "көт+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Сезне", "analysis": "сез+PN+ACC(нЫ);", "translations": ["ваш", "вы"]}
+{"prefix": " ", "surface": "көтеп", "analysis": "көт+V+ADVV_ACC(Ып);", "translations": ["ждать", "подождать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "уеннан", "analysis": "уен+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "хәлем", "analysis": "хәл+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "уеннан", "analysis": "уен+N+Sg+ABL(ДАн);", "translations": ["игра"]}
+{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);", "translations": ["оставаться", "остаться"]}
+{"prefix": " ", "surface": "хәлем", "analysis": "хәл+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["состояние"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "артыннан", "analysis": "арт+Adj+Sg+POSS_3(СЫ)+ABL(ДАн);артыннан+POST;"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "җитеп", "analysis": "җит+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "артыннан", "analysis": "арт+Adj+Sg+POSS_3(СЫ)+ABL(ДАн);артыннан+POST;", "translations": ["за", "зад", "из-за", "позади", "увеличиваться", "увеличиться"]}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "җитеп", "analysis": "җит+V+ADVV_ACC(Ып);", "translations": ["дойти", "доходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Вәлинең", "analysis": "вәли+PROP+GEN(нЫң);"}
-{"prefix": " ", "surface": "җиңеннән", "analysis": "җиң+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "җиңеннән", "analysis": "җиң+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["победить", "рукав"]}
+{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);", "translations": ["держать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ялынган", "analysis": "ялын+V+PCP_PS(ГАн);ялын+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "рәвештә", "analysis": "рәвеш+N+Sg+LOC(ДА);"}
+{"prefix": " ", "surface": "ялынган", "analysis": "ялын+V+PCP_PS(ГАн);ялын+V+PST_INDF(ГАн);", "translations": ["умолять"]}
+{"prefix": " ", "surface": "рәвештә", "analysis": "рәвеш+N+Sg+LOC(ДА);", "translations": ["образ¹"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "җә", "analysis": "җә+INTRJ;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
+{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
 {"prefix": " ", "surface": "эшләвең", "analysis": "NR"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Торасың", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тор+V+PRES(Й)+2SG(сЫң);тора+N+Sg+2SG(сЫң);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "Торасың", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тор+V+PRES(Й)+2SG(сЫң);тора+N+Sg+2SG(сЫң);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китәм", "analysis": "ки+V+CAUS(т)+HOR_SG(Йм);ки+V+CAUS(т)+PRES(Й)+1SG(м);кит+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "куркыта", "analysis": "куркыт+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлыйсың", "analysis": "башла+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;башла+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китәм", "analysis": "ки+V+CAUS(т)+HOR_SG(Йм);ки+V+CAUS(т)+PRES(Й)+1SG(м);кит+V+PRES(Й)+1SG(м);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "куркыта", "analysis": "куркыт+V+PRES(Й);", "translations": ["напугать", "пугать"]}
+{"prefix": " ", "surface": "башлыйсың", "analysis": "башла+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;башла+V+PRES(Й)+2SG(сЫң);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтмим", "analysis": "әйт+V+NEG(мА)+HOR_SG(Йм);әйт+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтмим", "analysis": "әйт+V+NEG(мА)+HOR_SG(Йм);әйт+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйткәч", "analysis": "әйт+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "әйткәч", "analysis": "әйт+V+ADVV_ANT(ГАч);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "синнән", "analysis": "син+PN+ABL(ДАн);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "синнән", "analysis": "син+PN+ABL(ДАн);", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "сорамыйм", "analysis": "сора+V+NEG(мА)+HOR_SG(Йм);сора+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "сорамыйм", "analysis": "сора+V+NEG(мА)+HOR_SG(Йм);сора+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["спрашивать", "спросить"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бары", "analysis": "бар+N+Sg+POSS_3(СЫ)+Nom;бар+PN+POSS_3(СЫ)+Nom;бары+CNJ;бары+PN;"}
-{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "бары", "analysis": "бар+N+Sg+POSS_3(СЫ)+Nom;бар+PN+POSS_3(СЫ)+Nom;бары+CNJ;бары+PN;", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;", "translations": ["но", "только"]}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "күлмәгемне", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["платье", "рубашка"]}
 {"prefix": " ", "surface": "киим", "analysis": "NR"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "кенә", "analysis": "кенә+PART;"}
-{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "әйттем", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м);"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "әйттем", "analysis": "әйт+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "Теләсәң", "analysis": "телә+V+COND(сА)+2SG(ң);", "translations": ["желать", "пожелать"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "дисәң", "analysis": "ди+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "дисәң", "analysis": "ди+V+COND(сА)+2SG(ң);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;"}
-{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;"}
+{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;", "translations": ["совсем", "целиком"]}
+{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;", "translations": ["ничто"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "кимә", "analysis": "ки+V+NEG(мА)+IMP_SG();кимә+N+Sg+Nom;"}
+{"prefix": " ", "surface": "кимә", "analysis": "ки+V+NEG(мА)+IMP_SG();кимә+N+Sg+Nom;", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Яхшылап", "analysis": "яхшы+Adj+DISTR(лАп);яхшылап+Adv;"}
+{"prefix": " ", "surface": "Яхшылап", "analysis": "яхшы+Adj+DISTR(лАп);яхшылап+Adv;", "translations": ["лучше", "лучший", "хороший", "хорошо"]}
 {"prefix": " ", "surface": "кына", "analysis": "кына+PART;"}
-{"prefix": " ", "surface": "сораганда", "analysis": "сора+V+PCP_PS(ГАн)+LOC(ДА);"}
+{"prefix": " ", "surface": "сораганда", "analysis": "сора+V+PCP_PS(ГАн)+LOC(ДА);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тотасың", "analysis": "тот+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тот+V+PRES(Й)+2SG(сЫң);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "ачулана", "analysis": "ачулан+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлыйсың", "analysis": "башла+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;башла+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "тотасың", "analysis": "тот+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тот+V+PRES(Й)+2SG(сЫң);", "translations": ["держать"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "ачулана", "analysis": "ачулан+V+PRES(Й);", "translations": ["ругать"]}
+{"prefix": " ", "surface": "башлыйсың", "analysis": "башла+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;башла+V+PRES(Й)+2SG(сЫң);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Алай", "analysis": "алай+PN;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
+{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;", "translations": ["ничто"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "кимим", "analysis": "ки+V+NEG(мА)+HOR_SG(Йм);ки+V+NEG(мА)+PRES(Й)+1SG(м);киме+V+HOR_SG(Йм);киме+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "кимим", "analysis": "ки+V+NEG(мА)+HOR_SG(Йм);ки+V+NEG(мА)+PRES(Й)+1SG(м);киме+V+HOR_SG(Йм);киме+V+PRES(Й)+1SG(м);", "translations": ["одеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шушы", "analysis": "шушы+PN;"}
+{"prefix": " ", "surface": "шушы", "analysis": "шушы+PN;", "translations": ["этот"]}
 {"prefix": " ", "surface": "өстемдәге", "analysis": "өс+N+Sg+POSS_1SG(Ым)+ATTR_LOC(ДАгЫ);"}
-{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "күлмәгем", "analysis": "күлмәк+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["платье", "рубашка"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "йөзләре", "analysis": "йөз+N+PL(ЛАр)+POSS_3(СЫ)+Nom;йөз+Num+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "яктырып", "analysis": "як+V+CAUS(ДЫр)+ADVV_ACC(Ып);яктыр+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "йөзләре", "analysis": "йөз+N+PL(ЛАр)+POSS_3(СЫ)+Nom;йөз+Num+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["лицо", "плавать", "сотый", "сто"]}
+{"prefix": " ", "surface": "яктырып", "analysis": "як+V+CAUS(ДЫр)+ADVV_ACC(Ып);яктыр+V+ADVV_ACC(Ып);", "translations": ["сжечь", "сторона"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "һай", "analysis": "һай+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Бәрәкалла", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj;яхшы+Adv;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj;яхшы+Adv;", "translations": ["лучше", "лучший", "хороший", "хорошо"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;"}
+{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;", "translations": ["пожалуйста"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "өстеңә", "analysis": "өс+N+Sg+POSS_2SG(Ың)+DIR(ГА);"}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();"}
+{"prefix": " ", "surface": "ки", "analysis": "ки+CNJ;ки+V+IMP_SG();", "translations": ["одеть"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "китәбез", "analysis": "ки+V+CAUS(т)+PRES(Й)+1PL(бЫз);кит+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "китәбез", "analysis": "ки+V+CAUS(т)+PRES(Й)+1PL(бЫз);кит+V+PRES(Й)+1PL(бЫз);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Гафифә", "analysis": "NR"}
-{"prefix": " ", "surface": "ашыгып", "analysis": "ашык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "ашыгып", "analysis": "ашык+V+ADVV_ACC(Ып);", "translations": ["спешить"]}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Уф", "analysis": "уф+INTRJ;"}
 {"prefix": " ", "surface": "Алла", "analysis": "алла+N+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "җаным", "analysis": "җан+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
-{"prefix": " ", "surface": "язды", "analysis": "яз+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "җаным", "analysis": "җан+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["душа"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "язды", "analysis": "яз+V+PST_DEF(ДЫ);", "translations": ["весна", "написать", "писать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;"}
+{"prefix": " ", "surface": "Яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;", "translations": ["новый"]}
 {"prefix": " ", "surface": "тагы", "analysis": "так+Adj+Sg+POSS_3(СЫ)+Nom;"}
 {"prefix": " ", "surface": "бер-бер", "analysis": "бер-бер+Adj;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "тапкан", "analysis": "тап+V+PCP_PS(ГАн);тап+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
-{"prefix": " ", "surface": "күрмәсен", "analysis": "күр+V+NEG(мА)+JUS_SG(сЫн);"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "тапкан", "analysis": "тап+V+PCP_PS(ГАн);тап+V+PST_INDF(ГАн);", "translations": ["найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "күрмәсен", "analysis": "күр+V+NEG(мА)+JUS_SG(сЫн);", "translations": ["видеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": "", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишекне", "analysis": "ишек+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "яба", "analysis": "яп+V+PRES(Й);"}
+{"prefix": "", "surface": "Ишекне", "analysis": "ишек+N+Sg+ACC(нЫ);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "яба", "analysis": "яп+V+PRES(Й);", "translations": ["закрывать", "закрыть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Киенә", "analysis": "ки+V+REFL(Ын)+PRES(Й);киен+V+PRES(Й);кий+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
+{"prefix": " ", "surface": "Киенә", "analysis": "ки+V+REFL(Ын)+PRES(Й);киен+V+PRES(Й);кий+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["одеть", "одеваться", "одеться"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ахырында", "analysis": "ахыр+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
-{"prefix": " ", "surface": "мең", "analysis": "мең+Num;"}
-{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "көчкә", "analysis": "көч+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "җиңдем", "analysis": "җиң+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "ахырында", "analysis": "ахыр+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["конец"]}
+{"prefix": " ", "surface": "мең", "analysis": "мең+Num;", "translations": ["тысяча", "тысячный"]}
+{"prefix": " ", "surface": "бәла", "analysis": "бәла+N+Sg+Nom;", "translations": ["беда"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "көчкә", "analysis": "көч+N+Sg+DIR(ГА);", "translations": ["сила"]}
+{"prefix": " ", "surface": "җиңдем", "analysis": "җиң+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["победить", "рукав"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "үзенә", "analysis": "үз+PN+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "күрә", "analysis": "күр+V+PRES(Й);күрә+POST;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "кечкенә", "analysis": "кечкенә+Adj;"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "үзенә", "analysis": "үз+PN+POSS_3(СЫ)+DIR(ГА);", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "күрә", "analysis": "күр+V+PRES(Й);күрә+POST;", "translations": ["видеть", "ввиду", "по"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "кечкенә", "analysis": "кечкенә+Adj;", "translations": ["маленький"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармак", "analysis": "бар+V+INF_2(мАк);бармак+N+Sg+Nom;"}
-{"prefix": " ", "surface": "башы", "analysis": "баш+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
+{"prefix": " ", "surface": "бармак", "analysis": "бар+V+INF_2(мАк);бармак+N+Sg+Nom;", "translations": ["бар", "быть", "весь", "идти", "пойти", "палец"]}
+{"prefix": " ", "surface": "башы", "analysis": "баш+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["голова"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "революция", "analysis": "революция+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "революция", "analysis": "революция+N+Sg+Nom;", "translations": ["революция"]}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "минеммаксудымМаксуд", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "теләк", "analysis": "теләк+N+Sg+Nom;"}
+{"prefix": "", "surface": "теләк", "analysis": "теләк+N+Sg+Nom;", "translations": ["желание"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": "", "surface": "Кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["рука"]}
 {"prefix": " ", "surface": "угалап", "analysis": "у+V+RAR_1(ГАлА)+ADVV_ACC(Ып);угала+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Их", "analysis": "их+INTRJ;"}
 {"prefix": " ", "surface": "хозур", "analysis": "хозур+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "китәбез", "analysis": "ки+V+CAUS(т)+PRES(Й)+1PL(бЫз);кит+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "китәбез", "analysis": "ки+V+CAUS(т)+PRES(Й)+1PL(бЫз);кит+V+PRES(Й)+1PL(бЫз);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Таягын", "analysis": "таяк+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "ике", "analysis": "ике+Num;"}
-{"prefix": " ", "surface": "кулының", "analysis": "ку+N+ATTR_MUN(лЫ)+Sg+GEN(нЫң);кул+N+Sg+POSS_3(СЫ)+GEN(нЫң);"}
-{"prefix": " ", "surface": "бармак", "analysis": "бар+V+INF_2(мАк);бармак+N+Sg+Nom;"}
-{"prefix": " ", "surface": "очлары", "analysis": "оч+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": "", "surface": "Таягын", "analysis": "таяк+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["палка"]}
+{"prefix": " ", "surface": "ике", "analysis": "ике+Num;", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "кулының", "analysis": "ку+N+ATTR_MUN(лЫ)+Sg+GEN(нЫң);кул+N+Sg+POSS_3(СЫ)+GEN(нЫң);", "translations": ["рука"]}
+{"prefix": " ", "surface": "бармак", "analysis": "бар+V+INF_2(мАк);бармак+N+Sg+Nom;", "translations": ["бар", "быть", "весь", "идти", "пойти", "палец"]}
+{"prefix": " ", "surface": "очлары", "analysis": "оч+N+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["лететь", "острие"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);", "translations": ["держать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "арасында", "analysis": "ара+N+Sg+POSS_3(СЫ)+LOC(ДА);арасында+POST;"}
-{"prefix": " ", "surface": "төрле", "analysis": "төр+N+ATTR_MUN(лЫ);төрле+Adj;"}
-{"prefix": " ", "surface": "шатланган", "analysis": "шатлан+V+PCP_PS(ГАн);шатлан+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "һәм", "analysis": "һәм+CNJ;"}
+{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;", "translations": ["слово"]}
+{"prefix": " ", "surface": "арасында", "analysis": "ара+N+Sg+POSS_3(СЫ)+LOC(ДА);арасында+POST;", "translations": ["между", "промежуток", "среди"]}
+{"prefix": " ", "surface": "төрле", "analysis": "төр+N+ATTR_MUN(лЫ);төрле+Adj;", "translations": ["вид", "завернуть", "разный"]}
+{"prefix": " ", "surface": "шатланган", "analysis": "шатлан+V+PCP_PS(ГАн);шатлан+V+PST_INDF(ГАн);", "translations": ["обрадоваться", "радоваться"]}
+{"prefix": " ", "surface": "һәм", "analysis": "һәм+CNJ;", "translations": ["и"]}
 {"prefix": " ", "surface": "мәсхәрә", "analysis": "мәсхәрә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кылган", "analysis": "кыл+V+PCP_PS(ГАн);кыл+V+PST_INDF(ГАн);кылган+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кыяфәтләргә", "analysis": "кыяфәт+N+PL(ЛАр)+DIR(ГА);"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й);"}
+{"prefix": " ", "surface": "кылган", "analysis": "кыл+V+PCP_PS(ГАн);кыл+V+PST_INDF(ГАн);кылган+N+Sg+Nom;", "translations": ["делать", "сделать", "ковыль"]}
+{"prefix": " ", "surface": "кыяфәтләргә", "analysis": "кыяфәт+N+PL(ЛАр)+DIR(ГА);", "translations": ["вид"]}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й);", "translations": ["петь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Бүген", "analysis": "бүген+Adv;"}
-{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
+{"prefix": " ", "surface": "Бүген", "analysis": "бүген+Adv;", "translations": ["сегодня", "сегодняшний"]}
+{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;", "translations": ["театр"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шатлыктан", "analysis": "шат+Adj+NMLZ(лЫк)+Sg+ABL(ДАн);шат+Adj+PSBL(лЫк)+ABL(ДАн);"}
+{"prefix": " ", "surface": "Шатлыктан", "analysis": "шат+Adj+NMLZ(лЫк)+Sg+ABL(ДАн);шат+Adj+PSBL(лЫк)+ABL(ДАн);", "translations": ["радостный", "счастливый"]}
 {"prefix": " ", "surface": "күңлем", "analysis": "NR"}
 {"prefix": " ", "surface": "тула", "analysis": "тул+V+PRES(Й);тула+N+Sg+Nom;тула+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
@@ -2664,71 +2664,71 @@
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Картның", "analysis": "карт+Adj+Sg+GEN(нЫң);карт+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "кәефе", "analysis": "кәеф+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "Картның", "analysis": "карт+Adj+Sg+GEN(нЫң);карт+N+Sg+GEN(нЫң);", "translations": ["старик", "старый"]}
+{"prefix": " ", "surface": "кәефе", "analysis": "кәеф+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["настроение"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Уйнаучыларны", "analysis": "уйна+V+VN_1(у/ү/в)+PROF(чЫ)+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Уйнаучыларны", "analysis": "уйна+V+VN_1(у/ү/в)+PROF(чЫ)+PL(ЛАр)+ACC(нЫ);", "translations": ["игра", "играть"]}
 {"prefix": " ", "surface": "тетә", "analysis": "тет+V+PRES(Й);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хатыным", "analysis": "хатын+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "бергә", "analysis": "бер+Num+DIR(ГА);бер+PN+DIR(ГА);бергә+Adv;"}
+{"prefix": " ", "surface": "Хатыным", "analysis": "хатын+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["жена", "женщина"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "бергә", "analysis": "бер+Num+DIR(ГА);бер+PN+DIR(ГА);бергә+Adv;", "translations": ["один", "первый", "вместе"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Кайнатай", "analysis": "NR"}
-{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "киткәнне", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+ACC(нЫ);кит+V+PCP_PS(ГАн)+ACC(нЫ);"}
-{"prefix": " ", "surface": "күргәч", "analysis": "күр+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Безнең", "analysis": "без+N+Sg+GEN(нЫң);без+PN+GEN(нЫң);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "киткәнне", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+ACC(нЫ);кит+V+PCP_PS(ГАн)+ACC(нЫ);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "күргәч", "analysis": "күр+V+ADVV_ANT(ГАч);", "translations": ["видеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ачуланса", "analysis": "ачулан+V+COND(сА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "Ачуланса", "analysis": "ачулан+V+COND(сА);", "translations": ["ругать"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": " ", "surface": "курыкмыйм", "analysis": "курык+V+NEG(мА)+HOR_SG(Йм);курык+V+NEG(мА)+PRES(Й)+1SG(м);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Барыбер", "analysis": "барыбер+Adv;"}
-{"prefix": " ", "surface": "сүзен", "analysis": "сүз+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "тотмыйм", "analysis": "тот+V+NEG(мА)+HOR_SG(Йм);тот+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Барыбер", "analysis": "барыбер+Adv;", "translations": ["всё равно"]}
+{"prefix": " ", "surface": "сүзен", "analysis": "сүз+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["слово"]}
+{"prefix": " ", "surface": "тотмыйм", "analysis": "тот+V+NEG(мА)+HOR_SG(Йм);тот+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["держать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": " ", "surface": "кергәчтен", "analysis": "NR"}
 {"prefix": " ", "surface": "тузар", "analysis": "туз+V+PCP_FUT(Ыр);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
@@ -2736,25 +2736,25 @@
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бөтен", "analysis": "бөтен+PN;"}
-{"prefix": " ", "surface": "кәефне", "analysis": "кәеф+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "бозар", "analysis": "боз+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Бөтен", "analysis": "бөтен+PN;", "translations": ["целый"]}
+{"prefix": " ", "surface": "кәефне", "analysis": "кәеф+N+Sg+ACC(нЫ);", "translations": ["настроение"]}
+{"prefix": " ", "surface": "бозар", "analysis": "боз+V+PCP_FUT(Ыр);", "translations": ["испортить", "лед/лёд", "лёд"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "уйуйуй", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бозса", "analysis": "боз+V+COND(сА);"}
-{"prefix": " ", "surface": "бозар", "analysis": "боз+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "кәефне", "analysis": "кәеф+N+Sg+ACC(нЫ);"}
+{"prefix": " ", "surface": "Бозса", "analysis": "боз+V+COND(сА);", "translations": ["испортить", "лед/лёд", "лёд"]}
+{"prefix": " ", "surface": "бозар", "analysis": "боз+V+PCP_FUT(Ыр);", "translations": ["испортить", "лед/лёд", "лёд"]}
+{"prefix": " ", "surface": "кәефне", "analysis": "кәеф+N+Sg+ACC(нЫ);", "translations": ["настроение"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хәзергә", "analysis": "хәзергә+Adv;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "кәефле", "analysis": "кәеф+N+ATTR_MUN(лЫ);кәефле+Adj;"}
+{"prefix": " ", "surface": "Хәзергә", "analysis": "хәзергә+Adv;", "translations": ["пока"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "кәефле", "analysis": "кәеф+N+ATTR_MUN(лЫ);кәефле+Adj;", "translations": ["настроение"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "траттата", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
@@ -2762,26 +2762,26 @@
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
+{"prefix": "", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
 {"prefix": " ", "surface": "өстенә", "analysis": "өс+N+Sg+POSS_3(СЫ)+DIR(ГА);өстенә+POST;"}
-{"prefix": " ", "surface": "киенгән", "analysis": "ки+V+REFL(Ын)+PCP_PS(ГАн);ки+V+REFL(Ын)+PST_INDF(ГАн);киен+V+PCP_PS(ГАн);киен+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "көенчә", "analysis": "көенчә+POST;көй+N+Sg+POSS_3(СЫ)+EQU(чА);"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "киенгән", "analysis": "ки+V+REFL(Ын)+PCP_PS(ГАн);ки+V+REFL(Ын)+PST_INDF(ГАн);киен+V+PCP_PS(ГАн);киен+V+PST_INDF(ГАн);", "translations": ["одеть", "одеваться", "одеться"]}
+{"prefix": " ", "surface": "көенчә", "analysis": "көенчә+POST;көй+N+Sg+POSS_3(СЫ)+EQU(чА);", "translations": ["лад", "мелодия"]}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йа", "analysis": "йа+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": " ", "surface": "Ходаем", "analysis": "ходай+N+Sg+POSS_1SG(Ым)+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "тагы", "analysis": "так+Adj+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": " ", "surface": "җүләрләнәсең", "analysis": "NR"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "дәкәмиттә", "analysis": "NR"}
 {"prefix": " ", "surface": "паязКәмиттә", "analysis": "NR"}
 {"prefix": " ", "surface": "паяз", "analysis": "NR"}
@@ -2789,74 +2789,74 @@
 {"prefix": "", "surface": "паяц", "analysis": "паяц+N+Sg+Nom;"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "циркта", "analysis": "цирк+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "уенчы", "analysis": "уен+N+PROF(чЫ)+Sg+Nom;уй+V+REFL(Ын)+PREC_1(чЫ);"}
+{"prefix": "", "surface": "циркта", "analysis": "цирк+N+Sg+LOC(ДА);", "translations": ["цирк"]}
+{"prefix": " ", "surface": "уенчы", "analysis": "уен+N+PROF(чЫ)+Sg+Nom;уй+V+REFL(Ын)+PREC_1(чЫ);", "translations": ["игра", "мысль"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шамакай", "analysis": "шамакай+N+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "булмакчы", "analysis": "бул+V+DESID(мАкчЫ);"}
-{"prefix": " ", "surface": "буласыңмы", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);бул+V+PRES(Й)+2SG(сЫң)+INT(мЫ);"}
+{"prefix": " ", "surface": "булмакчы", "analysis": "бул+V+DESID(мАкчЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "буласыңмы", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);бул+V+PRES(Й)+2SG(сЫң)+INT(мЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әһә", "analysis": "әһә+INTRJ;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Булдыңмы", "analysis": "бул+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
+{"prefix": " ", "surface": "Булдыңмы", "analysis": "бул+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "аппагым", "analysis": "аппагым+N+Sg+Nom;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
-{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
+{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;", "translations": ["в таком случае", "если так", "тогда"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "киттек", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+1PL(к);кит+V+PST_DEF(ДЫ)+1PL(к);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "киттек", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+1PL(к);кит+V+PST_DEF(ДЫ)+1PL(к);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "былбылым", "analysis": "былбыл+N+Sg+POSS_1SG(Ым)+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Гафифәнең", "analysis": "NR"}
-{"prefix": " ", "surface": "култыгыннан", "analysis": "култык+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "култыклап", "analysis": "култык+N+DISTR(лАп);култыкла+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китәләр", "analysis": "ки+V+CAUS(т)+PRES(Й)+3PL(ЛАр);кит+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "култыгыннан", "analysis": "култык+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["подмышка"]}
+{"prefix": " ", "surface": "култыклап", "analysis": "култык+N+DISTR(лАп);култыкла+V+ADVV_ACC(Ып);", "translations": ["подмышка"]}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китәләр", "analysis": "ки+V+CAUS(т)+PRES(Й)+3PL(ЛАр);кит+V+PRES(Й)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сәхнә", "analysis": "сәхнә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "буш", "analysis": "буш+Adj;"}
-{"prefix": " ", "surface": "кала", "analysis": "кал+V+PRES(Й);кала+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Сәхнә", "analysis": "сәхнә+N+Sg+Nom;", "translations": ["сцена"]}
+{"prefix": " ", "surface": "буш", "analysis": "буш+Adj;", "translations": ["пусто", "пустой"]}
+{"prefix": " ", "surface": "кала", "analysis": "кал+V+PRES(Й);кала+N+Sg+Nom;", "translations": ["оставаться", "остаться", "город"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бераздан", "analysis": "бераздан+Adv;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
 {"prefix": " ", "surface": "кызуланып", "analysis": "кызула+V+REFL(Ын)+ADVV_ACC(Ып);кызулан+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "уң", "analysis": "уң+Adj;уң+V+IMP_SG();"}
-{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();"}
-{"prefix": " ", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
+{"prefix": " ", "surface": "уң", "analysis": "уң+Adj;уң+V+IMP_SG();", "translations": ["правый"]}
+{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "як-ягына", "analysis": "як-ягым+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "Монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Болар", "analysis": "бу+PN+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киткәннәр", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+PL(ЛАр)+Nom;ки+V+CAUS(т)+PST_INDF(ГАн)+3PL(ЛАр);кит+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;кит+V+PST_INDF(ГАн)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "Болар", "analysis": "бу+PN+PL(ЛАр)+Nom;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киткәннәр", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+PL(ЛАр)+Nom;ки+V+CAUS(т)+PST_INDF(ГАн)+3PL(ЛАр);кит+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;кит+V+PST_INDF(ГАн)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишекне", "analysis": "ишек+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "ачып", "analysis": "ач+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кычкыра", "analysis": "кычкыр+V+PRES(Й);"}
+{"prefix": "", "surface": "Ишекне", "analysis": "ишек+N+Sg+ACC(нЫ);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "ачып", "analysis": "ач+V+ADVV_ACC(Ып);", "translations": ["открывать", "открыть"]}
+{"prefix": " ", "surface": "кычкыра", "analysis": "кычкыр+V+PRES(Й);", "translations": ["крикнуть", "кричать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
@@ -2865,362 +2865,362 @@
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "беләсеңме", "analysis": "бел+V+PRES(Й)+2SG(сЫң)+INT(мЫ);"}
+{"prefix": " ", "surface": "Син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "беләсеңме", "analysis": "бел+V+PRES(Й)+2SG(сЫң)+INT(мЫ);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Беләм", "analysis": "бел+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Беләм", "analysis": "бел+V+PRES(Й)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Беләсең", "analysis": "бел+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бел+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Беләсең", "analysis": "бел+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бел+V+PRES(Й)+2SG(сЫң);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
-{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;"}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD;", "translations": ["в таком случае", "если так", "тогда"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
-{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;"}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;", "translations": ["деверь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алар", "analysis": "алар+PN;"}
+{"prefix": " ", "surface": "Алар", "analysis": "алар+PN;", "translations": ["они"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "сорасаң", "analysis": "сора+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "сорасаң", "analysis": "сора+V+COND(сА)+2SG(ң);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "икәнен", "analysis": "икән+MOD+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "әйтмәделәр", "analysis": "әйт+V+NEG(мА)+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "әйтмәделәр", "analysis": "әйт+V+NEG(мА)+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "кенә", "analysis": "кенә+PART;"}
-{"prefix": " ", "surface": "әйттеләр", "analysis": "әйт+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "әйттеләр", "analysis": "әйт+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);"}
+{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
+{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтерсең", "analysis": "әйт+V+FUT_INDF(Ыр)+2SG(сЫң);әйт+V+PCP_FUT(Ыр)+2SG(сЫң);әйтерсең+PART;"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтерсең", "analysis": "әйт+V+FUT_INDF(Ыр)+2SG(сЫң);әйт+V+PCP_FUT(Ыр)+2SG(сЫң);әйтерсең+PART;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "диделәр", "analysis": "ди+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "диделәр", "analysis": "ди+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
-{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кем", "analysis": "кем+PN;"}
-{"prefix": " ", "surface": "сорасын", "analysis": "сора+V+JUS_SG(сЫн);"}
+{"prefix": " ", "surface": "Башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "кем", "analysis": "кем+PN;", "translations": ["кто"]}
+{"prefix": " ", "surface": "сорасын", "analysis": "сора+V+JUS_SG(сЫн);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сораган", "analysis": "сора+V+PCP_PS(ГАн);сора+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;"}
+{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom;", "translations": ["брат", "дядя"]}
+{"prefix": " ", "surface": "сораган", "analysis": "сора+V+PCP_PS(ГАн);сора+V+PST_INDF(ГАн);", "translations": ["спрашивать", "спросить"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;", "translations": ["быть"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "аңар", "analysis": "NR"}
-{"prefix": " ", "surface": "әйтмәдем", "analysis": "әйт+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "әйтмәдем", "analysis": "әйт+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "кешемени", "analysis": "кеш+N+Sg+POSS_3(СЫ)+Nom+INT_MIR(мЫни);кеше+N+Sg+Nom+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "Син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "кешемени", "analysis": "кеш+N+Sg+POSS_3(СЫ)+Nom+INT_MIR(мЫни);кеше+N+Sg+Nom+INT_MIR(мЫни);", "translations": ["соболь", "человек"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
 {"prefix": " ", "surface": "лә", "analysis": "лә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйтмим", "analysis": "әйт+V+NEG(мА)+HOR_SG(Йм);әйт+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "әйтмим", "analysis": "әйт+V+NEG(мА)+HOR_SG(Йм);әйт+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Театргамы", "analysis": "театр+N+Sg+DIR(ГА)+INT(мЫ);"}
+{"prefix": " ", "surface": "Театргамы", "analysis": "театр+N+Sg+DIR(ГА)+INT(мЫ);", "translations": ["театр"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "үзе", "analysis": "үзе+PN;"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "белә", "analysis": "бел+V+PRES(Й);"}
+{"prefix": " ", "surface": "белә", "analysis": "бел+V+PRES(Й);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "кем", "analysis": "кем+PN;"}
-{"prefix": " ", "surface": "әйтте", "analysis": "әйт+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "кем", "analysis": "кем+PN;", "translations": ["кто"]}
+{"prefix": " ", "surface": "әйтте", "analysis": "әйт+V+PST_DEF(ДЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алдыңа", "analysis": "ал+N+Sg+POSS_2SG(Ың)+DIR(ГА);"}
-{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
+{"prefix": " ", "surface": "Алдыңа", "analysis": "ал+N+Sg+POSS_2SG(Ың)+DIR(ГА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "эшеңне", "analysis": "эш+N+Sg+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();"}
+{"prefix": " ", "surface": "эшеңне", "analysis": "эш+N+Sg+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["дело"]}
+{"prefix": " ", "surface": "эшлә", "analysis": "эшлә+V+IMP_SG();", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "Шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "киткәннәр", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+PL(ЛАр)+Nom;ки+V+CAUS(т)+PST_INDF(ГАн)+3PL(ЛАр);кит+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;кит+V+PST_INDF(ГАн)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "киткәннәр", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+PL(ЛАр)+Nom;ки+V+CAUS(т)+PST_INDF(ГАн)+3PL(ЛАр);кит+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;кит+V+PST_INDF(ГАн)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "сизгән", "analysis": "сиз+V+PCP_PS(ГАн);сиз+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "сизүен", "analysis": "сиз+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "сизгән", "analysis": "сиз+V+PCP_PS(ГАн);сиз+V+PST_INDF(ГАн);", "translations": ["чуять"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "сизүен", "analysis": "сиз+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["чуять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "җизни", "analysis": "җизни+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "безнеке", "analysis": "без+N+Sg+ATTR_GEN(нЫкЫ);без+PN+ATTR_GEN(нЫкЫ);"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
+{"prefix": " ", "surface": "җизни", "analysis": "җизни+N+Sg+Nom;", "translations": ["деверь"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "безнеке", "analysis": "без+N+Sg+ATTR_GEN(нЫкЫ);без+PN+ATTR_GEN(нЫкЫ);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
 {"prefix": " ", "surface": "җебегән", "analysis": "җебе+V+PCP_PS(ГАн);җебе+V+PST_INDF(ГАн);җебегән+Adj;"}
-{"prefix": " ", "surface": "авыз", "analysis": "авыз+N+Sg+Nom;"}
+{"prefix": " ", "surface": "авыз", "analysis": "авыз+N+Sg+Nom;", "translations": ["рот"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Исенә", "analysis": "ис+N+Sg+POSS_3(СЫ)+DIR(ГА);ис+V+REFL(Ын)+PRES(Й);"}
-{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;"}
-{"prefix": " ", "surface": "төште", "analysis": "төш+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;"}
+{"prefix": " ", "surface": "Исенә", "analysis": "ис+N+Sg+POSS_3(СЫ)+DIR(ГА);ис+V+REFL(Ын)+PRES(Й);", "translations": ["дуть", "запах"]}
+{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;", "translations": ["ничто"]}
+{"prefix": " ", "surface": "төште", "analysis": "төш+V+PST_DEF(ДЫ);", "translations": ["опускаться", "опуститься", "сон"]}
+{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;", "translations": ["быть", "дуть", "запах"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "минут", "analysis": "минут+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;"}
-{"prefix": " ", "surface": "эшли", "analysis": "эшлә+V+PRES(Й);"}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "минут", "analysis": "минут+N+Sg+Nom;", "translations": ["минута"]}
+{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;", "translations": ["же", "стрела"]}
+{"prefix": " ", "surface": "эшли", "analysis": "эшлә+V+PRES(Й);", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "ала", "analysis": "ал+V+PRES(Й);ала+Adj;"}
+{"prefix": " ", "surface": "ала", "analysis": "ал+V+PRES(Й);ала+Adj;", "translations": ["алый", "брать", "браться", "взять", "мочь", "пегий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Безнеке", "analysis": "без+N+Sg+ATTR_GEN(нЫкЫ);без+PN+ATTR_GEN(нЫкЫ);"}
+{"prefix": " ", "surface": "Безнеке", "analysis": "без+N+Sg+ATTR_GEN(нЫкЫ);без+PN+ATTR_GEN(нЫкЫ);", "translations": ["мы", "наш"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "тегермән", "analysis": "тегермән+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ташы", "analysis": "таш+N+Sg+POSS_3(СЫ)+Nom;ташы+V+IMP_SG();"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "тегермән", "analysis": "тегермән+N+Sg+Nom;", "translations": ["мельница"]}
+{"prefix": " ", "surface": "ташы", "analysis": "таш+N+Sg+POSS_3(СЫ)+Nom;ташы+V+IMP_SG();", "translations": ["каменный", "камень", "таскать"]}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "һич", "analysis": "һич+PN;"}
-{"prefix": " ", "surface": "кузгатыр", "analysis": "кузгат+V+FUT_INDF(Ыр);кузгат+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "хәл", "analysis": "хәл+N+Sg+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "һич", "analysis": "һич+PN;", "translations": ["совсем"]}
+{"prefix": " ", "surface": "кузгатыр", "analysis": "кузгат+V+FUT_INDF(Ыр);кузгат+V+PCP_FUT(Ыр);", "translations": ["трогать", "тронуть"]}
+{"prefix": " ", "surface": "хәл", "analysis": "хәл+N+Sg+Nom;", "translations": ["состояние"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();", "translations": ["останавливаться", "остановиться", "остановка"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бардырыйм", "analysis": "бар+V+CAUS(ДЫр)+HOR_SG(Йм);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "бардырыйм", "analysis": "бар+V+CAUS(ДЫр)+HOR_SG(Йм);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "җирдән", "analysis": "җир+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "җирдән", "analysis": "җир+N+Sg+ABL(ДАн);", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшләп", "analysis": "эш+N+DISTR(лАп);эшлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "калып", "analysis": "кал+V+ADVV_ACC(Ып);калып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшләп", "analysis": "эш+N+DISTR(лАп);эшлә+V+ADVV_ACC(Ып);", "translations": ["дело", "делать", "поступать", "поступить", "работать", "сделать"]}
+{"prefix": " ", "surface": "калып", "analysis": "кал+V+ADVV_ACC(Ып);калып+N+Sg+Nom;", "translations": ["оставаться", "остаться", "форма", "шаблон"]}
+{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Бик", "analysis": "бик+Adv;"}
+{"prefix": "", "surface": "Бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
 {"prefix": " ", "surface": "кызуланып", "analysis": "кызула+V+REFL(Ын)+ADVV_ACC(Ып);кызулан+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сул", "analysis": "сул+Adj;"}
-{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();"}
-{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "сул", "analysis": "сул+Adj;", "translations": ["левый"]}
+{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сәхнә", "analysis": "сәхнә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;"}
-{"prefix": " ", "surface": "буш", "analysis": "буш+Adj;"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "Сәхнә", "analysis": "сәхнә+N+Sg+Nom;", "translations": ["сцена"]}
+{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;", "translations": ["немного"]}
+{"prefix": " ", "surface": "буш", "analysis": "буш+Adj;", "translations": ["пусто", "пустой"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бераздан", "analysis": "бераздан+Adv;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кычкырышып", "analysis": "кычкыр+V+RECP(Ыш)+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "кычкырышып", "analysis": "кычкыр+V+RECP(Ыш)+ADVV_ACC(Ып);", "translations": ["крикнуть", "кричать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыгалар", "analysis": "чык+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "чыгалар", "analysis": "чык+V+PRES(Й)+3PL(ЛАр);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": "", "surface": "кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["рука"]}
 {"prefix": " ", "surface": "селтәп", "analysis": "селтә+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Иң", "analysis": "иң+N+Sg+Nom;иң+PART;иң+V+IMP_SG();"}
-{"prefix": " ", "surface": "әүвәл", "analysis": "әүвәл+Adv;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
+{"prefix": " ", "surface": "Иң", "analysis": "иң+N+Sg+Nom;иң+PART;иң+V+IMP_SG();", "translations": ["самый"]}
+{"prefix": " ", "surface": "әүвәл", "analysis": "әүвәл+Adv;", "translations": ["прежний", "раньше"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "театрның", "analysis": "театр+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "кайда", "analysis": "кай+PN+LOC(ДА);кайда+PN;"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "театрның", "analysis": "театр+N+Sg+GEN(нЫң);", "translations": ["театр"]}
+{"prefix": " ", "surface": "кайда", "analysis": "кай+PN+LOC(ДА);кайда+PN;", "translations": ["какой", "где"]}
 {"prefix": " ", "surface": "икәнен", "analysis": "икән+MOD+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "мыскыл", "analysis": "мыскыл+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармакларын", "analysis": "бармак+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "бармакларын", "analysis": "бармак+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["палец"]}
 {"prefix": " ", "surface": "бөкләп", "analysis": "бөклә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "санарга", "analysis": "сана+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "керешә", "analysis": "кер+V+RECP(Ыш)+PRES(Й);"}
+{"prefix": " ", "surface": "санарга", "analysis": "сана+V+INF_1(ЫргА);", "translations": ["считать"]}
+{"prefix": " ", "surface": "керешә", "analysis": "кер+V+RECP(Ыш)+PRES(Й);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Икенчеләй", "analysis": "икенчеләй+Adv;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кайдан", "analysis": "кай+PN+ABL(ДАн);кайдан+Adv;кайдан+PN;"}
+{"prefix": " ", "surface": "кайдан", "analysis": "кай+PN+ABL(ДАн);кайдан+Adv;кайдан+PN;", "translations": ["какой"]}
 {"prefix": " ", "surface": "керәсен", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
 {"prefix": " ", "surface": "керәсен", "analysis": "NR"}
-{"prefix": " ", "surface": "белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ике", "analysis": "ике+Num;"}
+{"prefix": " ", "surface": "Ике", "analysis": "ике+Num;", "translations": ["второй", "два", "оба"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "өч", "analysis": "өч+Num;"}
+{"prefix": " ", "surface": "өч", "analysis": "өч+Num;", "translations": ["третий", "три"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": " ", "surface": "тә", "analysis": "тә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "урынга", "analysis": "урын+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "утырырга", "analysis": "утыр+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "урынга", "analysis": "урын+N+Sg+DIR(ГА);", "translations": ["место"]}
+{"prefix": " ", "surface": "утырырга", "analysis": "утыр+V+INF_1(ЫргА);", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шуның", "analysis": "шул+PN+GEN(нЫң);шул+PN+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
-{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;"}
+{"prefix": " ", "surface": "Шуның", "analysis": "шул+PN+GEN(нЫң);шул+PN+POSS_2SG(Ың)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;", "translations": ["четвёртый", "четыре"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;"}
+{"prefix": " ", "surface": "Зинһар", "analysis": "зинһар+MOD;", "translations": ["пожалуйста"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "ичмаса", "analysis": "ичмаса+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "эчеңдәге", "analysis": "эч+N+Sg+POSS_2SG(Ың)+ATTR_LOC(ДАгЫ);"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "серләреңне", "analysis": "сер+N+PL(ЛАр)+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетереп", "analysis": "бетер+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "эчеңдәге", "analysis": "эч+N+Sg+POSS_2SG(Ың)+ATTR_LOC(ДАгЫ);", "translations": ["в", "в течение", "внутренность", "внутри", "выпить", "из", "пить"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "серләреңне", "analysis": "сер+N+PL(ЛАр)+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["секрет", "тайна"]}
+{"prefix": " ", "surface": "сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);", "translations": ["говорить", "рассказывать"]}
+{"prefix": " ", "surface": "бетереп", "analysis": "бетер+V+ADVV_ACC(Ып);", "translations": ["заканчивать", "кончать", "кончить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кешене", "analysis": "кеше+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "көлдермә", "analysis": "көл+V+CAUS(ДЫр)+NEG(мА)+IMP_SG();көлдер+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "кешене", "analysis": "кеше+N+Sg+ACC(нЫ);", "translations": ["человек"]}
+{"prefix": " ", "surface": "көлдермә", "analysis": "көл+V+CAUS(ДЫр)+NEG(мА)+IMP_SG();көлдер+V+NEG(мА)+IMP_SG();", "translations": ["засмеяться", "смеяться"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ишетсә", "analysis": "ишет+V+COND(сА);"}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "ишетсә", "analysis": "ишет+V+COND(сА);", "translations": ["слышать", "услышать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "моның", "analysis": "бу+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "белгән", "analysis": "бел+V+PCP_PS(ГАн);бел+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "нәрсәсе", "analysis": "нәрсә+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": "", "surface": "моның", "analysis": "бу+PN+GEN(нЫң);", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "белгән", "analysis": "бел+V+PCP_PS(ГАн);бел+V+PST_INDF(ГАн);", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "нәрсәсе", "analysis": "нәрсә+PN+POSS_3(СЫ)+Nom;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "микән", "analysis": "микән+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);"}
-{"prefix": " ", "surface": "башларлар", "analysis": "башла+V+FUT_INDF(Ыр)+3PL(ЛАр);башла+V+PCP_FUT(Ыр)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "башларлар", "analysis": "башла+V+FUT_INDF(Ыр)+3PL(ЛАр);башла+V+PCP_FUT(Ыр)+3PL(ЛАр);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
 {"prefix": " ", "surface": "җаен", "analysis": "җай+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "тапканны", "analysis": "тап+V+PCP_PS(ГАн)+ACC(нЫ);"}
+{"prefix": " ", "surface": "тапканны", "analysis": "тап+V+PCP_PS(ГАн)+ACC(нЫ);", "translations": ["найти", "находить", "пятно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;"}
+{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "табарбыз", "analysis": "тап+V+PCP_FUT(Ыр)+1PL(бЫз);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "табарбыз", "analysis": "тап+V+PCP_FUT(Ыр)+1PL(бЫз);", "translations": ["найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Кирәкми", "analysis": "кирәкми+MOD;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "бармыйбыз", "analysis": "бар+V+NEG(мА)+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);", "translations": ["испугаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -3229,612 +3229,612 @@
 {"prefix": " ", "surface": "чү", "analysis": "чү+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "тагы", "analysis": "так+Adj+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "куркуыңнан", "analysis": "курк+V+VN_1(у/ү/в)+POSS_2SG(Ың)+ABL(ДАн);курку+N+Sg+POSS_2SG(Ың)+ABL(ДАн);"}
+{"prefix": " ", "surface": "куркуыңнан", "analysis": "курк+V+VN_1(у/ү/в)+POSS_2SG(Ың)+ABL(ДАн);курку+N+Sg+POSS_2SG(Ың)+ABL(ДАн);", "translations": ["испугаться", "страх"]}
 {"prefix": " ", "surface": "җыгылып", "analysis": "NR"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
-{"prefix": " ", "surface": "күрмә", "analysis": "күр+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "күрмә", "analysis": "күр+V+NEG(мА)+IMP_SG();", "translations": ["видеть"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Шулкадәр", "analysis": "шулкадәр+Adv;"}
-{"prefix": " ", "surface": "зур", "analysis": "зур+Adj;"}
-{"prefix": " ", "surface": "гәүдәң", "analysis": "гәүдә+N+Sg+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "зур", "analysis": "зур+Adj;", "translations": ["большой"]}
+{"prefix": " ", "surface": "гәүдәң", "analysis": "гәүдә+N+Sg+POSS_2SG(Ың)+Nom;", "translations": ["тело"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);"}
+{"prefix": "", "surface": "куркам", "analysis": "курк+V+PRES(Й)+1SG(м);", "translations": ["испугаться"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "кешедән", "analysis": "кеше+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "оят", "analysis": "оят+N+Sg+Nom;"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "кешедән", "analysis": "кеше+N+Sg+ABL(ДАн);", "translations": ["человек"]}
+{"prefix": " ", "surface": "оят", "analysis": "оят+N+Sg+Nom;", "translations": ["стыд"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Кирәкми", "analysis": "кирәкми+MOD;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "бармаган", "analysis": "бар+V+NEG(мА)+PCP_PS(ГАн);бар+V+NEG(мА)+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;"}
+{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "бармаган", "analysis": "бар+V+NEG(мА)+PCP_PS(ГАн);бар+V+NEG(мА)+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
 {"prefix": " ", "surface": "нитмәгән", "analysis": "нит+V+NEG(мА)+PCP_PS(ГАн);нит+V+NEG(мА)+PST_INDF(ГАн);"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "җирдән", "analysis": "җир+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;"}
+{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "җирдән", "analysis": "җир+N+Sg+ABL(ДАн);", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "калып", "analysis": "кал+V+ADVV_ACC(Ып);калып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "калып", "analysis": "кал+V+ADVV_ACC(Ып);калып+N+Sg+Nom;", "translations": ["оставаться", "остаться", "форма", "шаблон"]}
+{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "алар", "analysis": "алар+PN;"}
-{"prefix": " ", "surface": "үткән", "analysis": "үт+V+PCP_PS(ГАн);үт+V+PST_INDF(ГАн);үткән+Adj;"}
+{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;", "translations": ["деверь"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "алар", "analysis": "алар+PN;", "translations": ["они"]}
+{"prefix": " ", "surface": "үткән", "analysis": "үт+V+PCP_PS(ГАн);үт+V+PST_INDF(ГАн);үткән+Adj;", "translations": ["пройти", "проходить"]}
 {"prefix": " ", "surface": "атнаныплашкигә", "analysis": "NR"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": " ", "surface": "чыктыларПлашкига", "analysis": "NR"}
-{"prefix": " ", "surface": "чыгу", "analysis": "чыгу+N+Sg+Nom;чык+V+VN_1(у/ү/в)+Nom;"}
+{"prefix": " ", "surface": "чыгу", "analysis": "чыгу+N+Sg+Nom;чык+V+VN_1(у/ү/в)+Nom;", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "электә", "analysis": "электә+Adv;"}
-{"prefix": " ", "surface": "шәһәрдә", "analysis": "шәһәр+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "күңел", "analysis": "күңел+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ачарга", "analysis": "ач+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "чыгу", "analysis": "чыгу+N+Sg+Nom;чык+V+VN_1(у/ү/в)+Nom;"}
+{"prefix": " ", "surface": "шәһәрдә", "analysis": "шәһәр+N+Sg+LOC(ДА);", "translations": ["город"]}
+{"prefix": " ", "surface": "күңел", "analysis": "күңел+N+Sg+Nom;", "translations": ["душа"]}
+{"prefix": " ", "surface": "ачарга", "analysis": "ач+V+INF_1(ЫргА);", "translations": ["открывать", "открыть"]}
+{"prefix": " ", "surface": "чыгу", "analysis": "чыгу+N+Sg+Nom;чык+V+VN_1(у/ү/в)+Nom;", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "авызыбызны", "analysis": "авыз+N+Sg+POSS_1PL(ЫбЫз)+ACC(нЫ);"}
-{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "калдык", "analysis": "кал+V+PST_DEF(ДЫ)+1PL(к);калдык+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "авызыбызны", "analysis": "авыз+N+Sg+POSS_1PL(ЫбЫз)+ACC(нЫ);", "translations": ["рот"]}
+{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);", "translations": ["поднимать", "поднять"]}
+{"prefix": " ", "surface": "калдык", "analysis": "кал+V+PST_DEF(ДЫ)+1PL(к);калдык+N+Sg+Nom;", "translations": ["оставаться", "остаться", "остаток"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кияве", "analysis": "кияү+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "кызы", "analysis": "кыз+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "кияве", "analysis": "кияү+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["жених", "зять"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "кызы", "analysis": "кыз+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["девушка", "дочь"]}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "әткәй", "analysis": "әткәй+N+Sg+Nom;"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "сүз", "analysis": "сүз+N+Sg+Nom;", "translations": ["слово"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);"}
-{"prefix": " ", "surface": "алмас", "analysis": "ал+V+FUT_INDF_NEG(мАс);ал+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "алмас", "analysis": "ал+V+FUT_INDF_NEG(мАс);ал+V+PCP_FUT(мАс);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тотабыз", "analysis": "тот+V+PRES(Й)+1PL(бЫз);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "тотабыз", "analysis": "тот+V+PRES(Й)+1PL(бЫз);", "translations": ["держать"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нәрсәгә", "analysis": "нәрсә+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;"}
+{"prefix": " ", "surface": "Нәрсәгә", "analysis": "нәрсә+PN+DIR(ГА);", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
-{"prefix": " ", "surface": "куркып", "analysis": "курк+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
+{"prefix": " ", "surface": "куркып", "analysis": "курк+V+ADVV_ACC(Ып);", "translations": ["испугаться"]}
+{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "җумаларга", "analysis": "NR"}
-{"prefix": " ", "surface": "керешеп", "analysis": "кер+V+RECP(Ыш)+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "керешеп", "analysis": "кер+V+RECP(Ыш)+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "җә", "analysis": "җә+INTRJ;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Барыйксана", "analysis": "NR"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Харап", "analysis": "харап+Adj;"}
-{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн);бул+V+PST_INDF(ГАн);", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Гомеремә", "analysis": "гомер+N+Sg+POSS_1SG(Ым)+DIR(ГА);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "мәртәбә", "analysis": "мәртәбә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "җиргә", "analysis": "җир+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барыйк", "analysis": "бар+V+HOR_PL(Йк);"}
-{"prefix": " ", "surface": "дигәнмен", "analysis": "ди+V+PCP_PS(ГАн)+1SG(мЫн);ди+V+PST_INDF(ГАн)+1SG(мЫн);"}
+{"prefix": " ", "surface": "Гомеремә", "analysis": "гомер+N+Sg+POSS_1SG(Ым)+DIR(ГА);", "translations": ["жизнь"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "мәртәбә", "analysis": "мәртәбә+N+Sg+Nom;", "translations": ["степень"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "җиргә", "analysis": "җир+N+Sg+DIR(ГА);", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "барыйк", "analysis": "бар+V+HOR_PL(Йк);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дигәнмен", "analysis": "ди+V+PCP_PS(ГАн)+1SG(мЫн);ди+V+PST_INDF(ГАн)+1SG(мЫн);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "тыңламыйсың", "analysis": "тыңла+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тыңла+V+NEG(мА)+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "тыңламыйсың", "analysis": "тыңла+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тыңла+V+NEG(мА)+PRES(Й)+2SG(сЫң);", "translations": ["слушать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әткәйдән", "analysis": "әткәй+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "куркып", "analysis": "курк+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "кечкенә", "analysis": "кечкенә+Adj;"}
-{"prefix": " ", "surface": "сабый", "analysis": "сабый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бала", "analysis": "бала+N+Sg+Nom;"}
+{"prefix": " ", "surface": "куркып", "analysis": "курк+V+ADVV_ACC(Ып);", "translations": ["испугаться"]}
+{"prefix": " ", "surface": "торырга", "analysis": "тор+V+INF_1(ЫргА);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "кечкенә", "analysis": "кечкенә+Adj;", "translations": ["маленький"]}
+{"prefix": " ", "surface": "сабый", "analysis": "сабый+N+Sg+Nom;", "translations": ["младенец"]}
+{"prefix": " ", "surface": "бала", "analysis": "бала+N+Sg+Nom;", "translations": ["ребёнок"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART;"}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Хәбибрахман", "analysis": "NR"}
-{"prefix": " ", "surface": "эндәшми", "analysis": "эндәш+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "эндәшми", "analysis": "эндәш+V+NEG(мА)+PRES(Й);", "translations": ["обратиться", "обращаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "җә", "analysis": "җә+INTRJ;"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нигә", "analysis": "ни+PN+DIR(ГА);нигә+PN;"}
-{"prefix": " ", "surface": "эндәшмисең", "analysis": "эндәш+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;эндәш+V+NEG(мА)+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "нигә", "analysis": "ни+PN+DIR(ГА);нигә+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эндәшмисең", "analysis": "эндәш+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;эндәш+V+NEG(мА)+PRES(Й)+2SG(сЫң);", "translations": ["обратиться", "обращаться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Орышса", "analysis": "ор+V+RECP(Ыш)+COND(сА);орыш+V+COND(сА);"}
+{"prefix": " ", "surface": "Орышса", "analysis": "ор+V+RECP(Ыш)+COND(сА);орыш+V+COND(сА);", "translations": ["битва"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кайткач", "analysis": "кайт+V+ADVV_ANT(ГАч);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "орышыр", "analysis": "ор+V+RECP(Ыш)+FUT_INDF(Ыр);ор+V+RECP(Ыш)+PCP_FUT(Ыр);орыш+V+FUT_INDF(Ыр);орыш+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "бетәр", "analysis": "бет+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "кайткач", "analysis": "кайт+V+ADVV_ANT(ГАч);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "орышыр", "analysis": "ор+V+RECP(Ыш)+FUT_INDF(Ыр);ор+V+RECP(Ыш)+PCP_FUT(Ыр);орыш+V+FUT_INDF(Ыр);орыш+V+PCP_FUT(Ыр);", "translations": ["битва"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "бетәр", "analysis": "бет+V+PCP_FUT(Ыр);", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;"}
-{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "ашый", "analysis": "аша+V+PRES(Й);"}
-{"prefix": " ", "surface": "алмас", "analysis": "ал+V+FUT_INDF_NEG(мАс);ал+V+PCP_FUT(мАс);"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "Аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;", "translations": ["для", "за"]}
+{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "ашый", "analysis": "аша+V+PRES(Й);", "translations": ["есть", "кушать", "через"]}
+{"prefix": " ", "surface": "алмас", "analysis": "ал+V+FUT_INDF_NEG(мАс);ал+V+PCP_FUT(мАс);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әгәр", "analysis": "әгәр+CNJ;"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "каты", "analysis": "кат+N+Sg+POSS_3(СЫ)+Nom;каты+Adj;"}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "каты", "analysis": "кат+N+Sg+POSS_3(СЫ)+Nom;каты+Adj;", "translations": ["слой", "этаж", "жёсткий", "жёстко", "крепкий", "крепко"]}
 {"prefix": " ", "surface": "дулый", "analysis": "дула+V+PRES(Й);"}
-{"prefix": " ", "surface": "башласа", "analysis": "башла+V+COND(сА);"}
+{"prefix": " ", "surface": "башласа", "analysis": "башла+V+COND(сА);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "һич", "analysis": "һич+PN;"}
-{"prefix": " ", "surface": "булмаганда", "analysis": "бул+V+NEG(мА)+PCP_PS(ГАн)+LOC(ДА);"}
+{"prefix": " ", "surface": "һич", "analysis": "һич+PN;", "translations": ["совсем"]}
+{"prefix": " ", "surface": "булмаганда", "analysis": "бул+V+NEG(мА)+PCP_PS(ГАн)+LOC(ДА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "көчләп", "analysis": "көч+N+DISTR(лАп);көчлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бардым", "analysis": "бар+V+PST_DEF(ДЫ)+1SG(м);бард+N+Sg+POSS_1SG(Ым)+Nom;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "көчләп", "analysis": "көч+N+DISTR(лАп);көчлә+V+ADVV_ACC(Ып);", "translations": ["сила"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "бардым", "analysis": "бар+V+PST_DEF(ДЫ)+1SG(м);бард+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "диярмен", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Орышса", "analysis": "ор+V+RECP(Ыш)+COND(сА);орыш+V+COND(сА);"}
+{"prefix": " ", "surface": "Орышса", "analysis": "ор+V+RECP(Ыш)+COND(сА);орыш+V+COND(сА);", "translations": ["битва"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "орышыр", "analysis": "ор+V+RECP(Ыш)+FUT_INDF(Ыр);ор+V+RECP(Ыш)+PCP_FUT(Ыр);орыш+V+FUT_INDF(Ыр);орыш+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;", "translations": ["мозг", "мой", "я"]}
+{"prefix": " ", "surface": "орышыр", "analysis": "ор+V+RECP(Ыш)+FUT_INDF(Ыр);ор+V+RECP(Ыш)+PCP_FUT(Ыр);орыш+V+FUT_INDF(Ыр);орыш+V+PCP_FUT(Ыр);", "translations": ["битва"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "орышмас", "analysis": "ор+V+RECP(Ыш)+FUT_INDF_NEG(мАс);ор+V+RECP(Ыш)+PCP_FUT(мАс);орыш+V+FUT_INDF_NEG(мАс);орыш+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "орышмас", "analysis": "ор+V+RECP(Ыш)+FUT_INDF_NEG(мАс);ор+V+RECP(Ыш)+PCP_FUT(мАс);орыш+V+FUT_INDF_NEG(мАс);орыш+V+PCP_FUT(мАс);", "translations": ["битва"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": "", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
 {"prefix": " ", "surface": "кашып", "analysis": "кашы+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм);бел+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Минем", "analysis": "мин+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "үземнең", "analysis": "үз+PN+POSS_1SG(Ым)+GEN(нЫң);"}
+{"prefix": " ", "surface": "Минем", "analysis": "мин+PN+GEN(нЫң);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "үземнең", "analysis": "үз+PN+POSS_1SG(Ым)+GEN(нЫң);", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "күрәсем", "analysis": "күр+V+OBL(ЙсЫ)+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "килә", "analysis": "кил+V+PRES(Й);"}
-{"prefix": " ", "surface": "килүен", "analysis": "кил+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;"}
-{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "нәрсәне", "analysis": "нәрсә+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "күрәсем", "analysis": "күр+V+OBL(ЙсЫ)+POSS_1SG(Ым)+Nom;", "translations": ["видеть"]}
+{"prefix": " ", "surface": "килә", "analysis": "кил+V+PRES(Й);", "translations": ["идти"]}
+{"prefix": " ", "surface": "килүен", "analysis": "кил+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["идти"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;", "translations": ["театр"]}
+{"prefix": " ", "surface": "дигән", "analysis": "ди+V+PCP_PS(ГАн);ди+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "нәрсәне", "analysis": "нәрсә+PN+ACC(нЫ);", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "җөдәтерсең", "analysis": "NR"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "әйтмәгән", "analysis": "әйт+V+NEG(мА)+PCP_PS(ГАн);әйт+V+NEG(мА)+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтмәгән", "analysis": "әйт+V+NEG(мА)+PCP_PS(ГАн);әйт+V+NEG(мА)+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Гайнулла", "analysis": "Rus"}
 {"prefix": " ", "surface": "жизнинең", "analysis": "NR"}
-{"prefix": " ", "surface": "кияве", "analysis": "кияү+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "кияве", "analysis": "кияү+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["жених", "зять"]}
 {"prefix": " ", "surface": "Гаптерәхимнәр", "analysis": "NR"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
-{"prefix": " ", "surface": "дигәннәр", "analysis": "ди+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;ди+V+PST_INDF(ГАн)+3PL(ЛАр);"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;"}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дигәннәр", "analysis": "ди+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;ди+V+PST_INDF(ГАн)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": " ", "surface": "алай", "analysis": "алай+PN;"}
-{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "булгач", "analysis": "бул+V+ADVV_ANT(ГАч);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;", "translations": ["необходимый", "нужный"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "җирмени", "analysis": "җир+N+Sg+Nom+INT_MIR(мЫни);"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "җирмени", "analysis": "җир+N+Sg+Nom+INT_MIR(мЫни);", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "баргач", "analysis": "бар+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "баргач", "analysis": "бар+V+ADVV_ANT(ГАч);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бергә-бергә", "analysis": "NR"}
-{"prefix": " ", "surface": "күңелле", "analysis": "күңел+N+ATTR_MUN(лЫ);"}
+{"prefix": " ", "surface": "күңелле", "analysis": "күңел+N+ATTR_MUN(лЫ);", "translations": ["душа"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "өстеңә", "analysis": "өс+N+Sg+POSS_2SG(Ың)+DIR(ГА);"}
-{"prefix": " ", "surface": "киен", "analysis": "ки+V+REFL(Ын)+IMP_SG();киен+V+IMP_SG();кий+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "киен", "analysis": "ки+V+REFL(Ын)+IMP_SG();киен+V+IMP_SG();кий+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["одеть", "одеваться", "одеться"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "киенеп", "analysis": "ки+V+REFL(Ын)+ADVV_ACC(Ып);киен+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыгам", "analysis": "чык+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "киенеп", "analysis": "ки+V+REFL(Ын)+ADVV_ACC(Ып);киен+V+ADVV_ACC(Ып);", "translations": ["одеть", "одеваться", "одеться"]}
+{"prefix": " ", "surface": "чыгам", "analysis": "чык+V+PRES(Й)+1SG(м);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Кызуланып", "analysis": "кызула+V+REFL(Ын)+ADVV_ACC(Ып);кызулан+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "уң", "analysis": "уң+Adj;уң+V+IMP_SG();"}
-{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();"}
-{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "уң", "analysis": "уң+Adj;уң+V+IMP_SG();", "translations": ["правый"]}
+{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "үз-үзенә", "analysis": "үз-үз+PN+POSS_3(СЫ)+DIR(ГА);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтеп", "analysis": "әйт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетерергә", "analysis": "бетер+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтеп", "analysis": "әйт+V+ADVV_ACC(Ып);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "бетерергә", "analysis": "бетер+V+INF_1(ЫргА);", "translations": ["заканчивать", "кончать", "кончить"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "өлгерә", "analysis": "өлгер+V+PRES(Й);"}
-{"prefix": " ", "surface": "алмадым", "analysis": "ал+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "өлгерә", "analysis": "өлгер+V+PRES(Й);", "translations": ["успевать", "успеть"]}
+{"prefix": " ", "surface": "алмадым", "analysis": "ал+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "киенергә", "analysis": "ки+V+REFL(Ын)+INF_1(ЫргА);киен+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "киенергә", "analysis": "ки+V+REFL(Ын)+INF_1(ЫргА);киен+V+INF_1(ЫргА);", "translations": ["одеть", "одеваться", "одеться"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Нишләргә", "analysis": "нишлә+V+INF_1(ЫргА);"}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;"}
-{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "туры", "analysis": "тур+N+Sg+POSS_3(СЫ)+Nom;туры+Adj;"}
-{"prefix": " ", "surface": "килер", "analysis": "кил+V+FUT_INDF(Ыр);кил+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;", "translations": ["же", "стрела"]}
+{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "туры", "analysis": "тур+N+Sg+POSS_3(СЫ)+Nom;туры+Adj;", "translations": ["тур", "прямо", "прямой"]}
+{"prefix": " ", "surface": "килер", "analysis": "кил+V+FUT_INDF(Ыр);кил+V+PCP_FUT(Ыр);", "translations": ["идти"]}
 {"prefix": " ", "surface": "микәнни", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;"}
-{"prefix": " ", "surface": "орышмас", "analysis": "ор+V+RECP(Ыш)+FUT_INDF_NEG(мАс);ор+V+RECP(Ыш)+PCP_FUT(мАс);орыш+V+FUT_INDF_NEG(мАс);орыш+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;", "translations": ["отец", "папа"]}
+{"prefix": " ", "surface": "орышмас", "analysis": "ор+V+RECP(Ыш)+FUT_INDF_NEG(мАс);ор+V+RECP(Ыш)+PCP_FUT(мАс);орыш+V+FUT_INDF_NEG(мАс);орыш+V+PCP_FUT(мАс);", "translations": ["битва"]}
 {"prefix": " ", "surface": "микән", "analysis": "микән+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "киткәнче", "analysis": "ки+V+CAUS(т)+ADVV_SUCC(ГАнчЫ);кит+V+ADVV_SUCC(ГАнчЫ);"}
-{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "керсә", "analysis": "кер+V+COND(сА);"}
+{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "киткәнче", "analysis": "ки+V+CAUS(т)+ADVV_SUCC(ГАнчЫ);кит+V+ADVV_SUCC(ГАнчЫ);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "керсә", "analysis": "кер+V+COND(сА);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;"}
+{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;", "translations": ["берег", "годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);"}
+{"prefix": " ", "surface": "Бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "калыр", "analysis": "кал+V+FUT_INDF(Ыр);кал+V+PCP_FUT(Ыр);", "translations": ["оставаться", "остаться"]}
+{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ);хатын+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "әтинең", "analysis": "әти+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "гадәте", "analysis": "гадәт+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "начар", "analysis": "начар+Adj;"}
+{"prefix": " ", "surface": "Хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ);хатын+N+Sg+Nom;", "translations": ["письмо", "жена", "женщина"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "әтинең", "analysis": "әти+N+Sg+GEN(нЫң);", "translations": ["отец", "папа"]}
+{"prefix": " ", "surface": "гадәте", "analysis": "гадәт+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["обычай"]}
+{"prefix": " ", "surface": "начар", "analysis": "начар+Adj;", "translations": ["плохо", "плохой"]}
 {"prefix": " ", "surface": "икәнне", "analysis": "NR"}
-{"prefix": " ", "surface": "белми", "analysis": "бел+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "белми", "analysis": "бел+V+NEG(мА)+PRES(Й);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Беркөнне", "analysis": "беркөнне+Adv;"}
 {"prefix": " ", "surface": "Гали", "analysis": "гали+Adj;"}
-{"prefix": " ", "surface": "хаҗи", "analysis": "хаҗи+N+Sg+Nom;"}
+{"prefix": " ", "surface": "хаҗи", "analysis": "хаҗи+N+Sg+Nom;", "translations": ["хаджи"]}
 {"prefix": " ", "surface": "Гаптерахманы", "analysis": "NR"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "чәйгә", "analysis": "чәй+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кергән", "analysis": "кер+V+PCP_PS(ГАн);кер+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;"}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "чәйгә", "analysis": "чәй+N+Sg+DIR(ГА);", "translations": ["чай"]}
+{"prefix": " ", "surface": "кергән", "analysis": "кер+V+PCP_PS(ГАн);кер+V+PST_INDF(ГАн);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;", "translations": ["для", "за"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "колагымны", "analysis": "колак+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "колагымны", "analysis": "колак+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["ухо"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "борып", "analysis": "бор+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "алды", "analysis": "ал+N+Sg+POSS_3(СЫ)+Nom;ал+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "борып", "analysis": "бор+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
+{"prefix": " ", "surface": "алды", "analysis": "ал+N+Sg+POSS_3(СЫ)+Nom;ал+V+PST_DEF(ДЫ);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Борып", "analysis": "бор+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "күрсәтә", "analysis": "күрсәт+V+PRES(Й);"}
+{"prefix": "", "surface": "Борып", "analysis": "бор+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
+{"prefix": " ", "surface": "күрсәтә", "analysis": "күрсәт+V+PRES(Й);", "translations": ["показать", "показывать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Күзләремнән", "analysis": "күз+N+PL(ЛАр)+POSS_1SG(Ым)+ABL(ДАн);"}
-{"prefix": " ", "surface": "утлар", "analysis": "у+V+CAUS(т)+3PL(ЛАр);ут+N+PL(ЛАр)+Nom;утла+V+FUT_INDF(Ыр);утла+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "күренде", "analysis": "күр+V+REFL(Ын)+PST_DEF(ДЫ);күрен+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "Күзләремнән", "analysis": "күз+N+PL(ЛАр)+POSS_1SG(Ым)+ABL(ДАн);", "translations": ["глаз"]}
+{"prefix": " ", "surface": "утлар", "analysis": "у+V+CAUS(т)+3PL(ЛАр);ут+N+PL(ЛАр)+Nom;утла+V+FUT_INDF(Ыр);утла+V+PCP_FUT(Ыр);", "translations": ["огонь"]}
+{"prefix": " ", "surface": "күренде", "analysis": "күр+V+REFL(Ын)+PST_DEF(ДЫ);күрен+V+PST_DEF(ДЫ);", "translations": ["видеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "йөреп", "analysis": "йөр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кешегә", "analysis": "кеше+N+Sg+DIR(ГА);", "translations": ["человек"]}
+{"prefix": " ", "surface": "сөйләп", "analysis": "сөйлә+V+ADVV_ACC(Ып);", "translations": ["говорить", "рассказывать"]}
+{"prefix": " ", "surface": "йөреп", "analysis": "йөр+V+ADVV_ACC(Ып);", "translations": ["походить", "ходить"]}
+{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "әти", "analysis": "әти+N+Sg+Nom;"}
-{"prefix": " ", "surface": "колакны", "analysis": "колак+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "борды", "analysis": "бор+V+PST_DEF(ДЫ);"}
+{"prefix": "", "surface": "әти", "analysis": "әти+N+Sg+Nom;", "translations": ["отец", "папа"]}
+{"prefix": " ", "surface": "колакны", "analysis": "колак+N+Sg+ACC(нЫ);", "translations": ["ухо"]}
+{"prefix": " ", "surface": "борды", "analysis": "бор+V+PST_DEF(ДЫ);", "translations": ["повернуть", "поворачивать"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хатынга", "analysis": "хатын+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "әйтсәң", "analysis": "әйт+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "хатынга", "analysis": "хатын+N+Sg+DIR(ГА);", "translations": ["жена", "женщина"]}
+{"prefix": " ", "surface": "әйтсәң", "analysis": "әйт+V+COND(сА)+2SG(ң);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ);хатын+N+Sg+Nom;"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ);хатын+N+Sg+Nom;", "translations": ["письмо", "жена", "женщина"]}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "һәй", "analysis": "һәй+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нәни", "analysis": "нәни+Adj;"}
+{"prefix": " ", "surface": "нәни", "analysis": "нәни+Adj;", "translations": ["маленький"]}
 {"prefix": " ", "surface": "бәби", "analysis": "бәби+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "башың", "analysis": "баш+N+Sg+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "колагыңны", "analysis": "колак+N+Sg+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "бордырып", "analysis": "бор+V+CAUS(ДЫр)+ADVV_ACC(Ып);бордыр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торасыңмы", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);тор+V+PRES(Й)+2SG(сЫң)+INT(мЫ);тора+N+Sg+2SG(сЫң)+INT(мЫ);"}
+{"prefix": " ", "surface": "Шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "башың", "analysis": "баш+N+Sg+POSS_2SG(Ың)+Nom;", "translations": ["голова"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "колагыңны", "analysis": "колак+N+Sg+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["ухо"]}
+{"prefix": " ", "surface": "бордырып", "analysis": "бор+V+CAUS(ДЫр)+ADVV_ACC(Ып);бордыр+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
+{"prefix": " ", "surface": "торасыңмы", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ);тор+V+PRES(Й)+2SG(сЫң)+INT(мЫ);тора+N+Sg+2SG(сЫң)+INT(мЫ);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "мыскыл", "analysis": "мыскыл+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итәргә", "analysis": "и+V+CAUS(т)+INF_1(ЫргА);ит+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "тотына", "analysis": "тот+V+REFL(Ын)+PRES(Й);тотын+V+PRES(Й);"}
+{"prefix": " ", "surface": "итәргә", "analysis": "и+V+CAUS(т)+INF_1(ЫргА);ит+V+INF_1(ЫргА);", "translations": ["быть", "делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "тотына", "analysis": "тот+V+REFL(Ын)+PRES(Й);тотын+V+PRES(Й);", "translations": ["держать", "схватиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Кесәсен", "analysis": "кесә+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": "", "surface": "Кесәсен", "analysis": "кесә+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["карман"]}
 {"prefix": " ", "surface": "капшап", "analysis": "капша+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
-{"prefix": " ", "surface": "баруын", "analysis": "бар+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "Барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "баруын", "analysis": "бар+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "кесәдә", "analysis": "кесә+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "барырлык", "analysis": "бар+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;бар+V+PCP_FUT(Ыр)+PSBL(лЫк);"}
-{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "кесәдә", "analysis": "кесә+N+Sg+LOC(ДА);", "translations": ["карман"]}
+{"prefix": " ", "surface": "барырлык", "analysis": "бар+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;бар+V+PCP_FUT(Ыр)+PSBL(лЫк);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;", "translations": ["деньги"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "микән", "analysis": "микән+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Портмонетын", "analysis": "NR"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "акчаларын", "analysis": "акча+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "өстәлгә", "analysis": "өстәл+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "акчаларын", "analysis": "акча+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["деньги"]}
+{"prefix": " ", "surface": "өстәлгә", "analysis": "өстәл+N+Sg+DIR(ГА);", "translations": ["стол"]}
 {"prefix": " ", "surface": "бушатып", "analysis": "буша+V+CAUS(т)+ADVV_ACC(Ып);бушат+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "саный", "analysis": "сана+V+PRES(Й);"}
+{"prefix": " ", "surface": "саный", "analysis": "сана+V+PRES(Й);", "translations": ["считать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Унбиш", "analysis": "унбиш+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "Унбиш", "analysis": "унбиш+Num;", "translations": ["пятнадцатый", "пятнадцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "унбиш", "analysis": "унбиш+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "унбиш", "analysis": "унбиш+Num;", "translations": ["пятнадцатый", "пятнадцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "утыз", "analysis": "утыз+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": "", "surface": "утыз", "analysis": "утыз+Num;", "translations": ["тридцатый", "тридцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
-{"prefix": " ", "surface": "унбиш", "analysis": "унбиш+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "унбиш", "analysis": "унбиш+Num;", "translations": ["пятнадцатый", "пятнадцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
-{"prefix": " ", "surface": "кырык", "analysis": "кырык+Num;"}
-{"prefix": " ", "surface": "биш", "analysis": "биш+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "кырык", "analysis": "кырык+Num;", "translations": ["сорок", "сороковой"]}
+{"prefix": " ", "surface": "биш", "analysis": "биш+Num;", "translations": ["пятый", "пять"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv;"}
-{"prefix": " ", "surface": "биш", "analysis": "биш+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "биш", "analysis": "биш+Num;", "translations": ["пятый", "пять"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "илле", "analysis": "ил+N+ATTR_MUN(лЫ);илле+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "илле", "analysis": "ил+N+ATTR_MUN(лЫ);илле+Num;", "translations": ["страна", "пятидесятый", "пятьдесять"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "илле", "analysis": "ил+N+ATTR_MUN(лЫ);илле+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "илле", "analysis": "ил+N+ATTR_MUN(лЫ);илле+Num;", "translations": ["страна", "пятидесятый", "пятьдесять"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;", "translations": ["двадцатый", "двадцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
-{"prefix": " ", "surface": "җитмеш", "analysis": "җитмеш+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "җитмеш", "analysis": "җитмеш+Num;", "translations": ["семидесятый", "семьдесять"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv;"}
-{"prefix": " ", "surface": "илле", "analysis": "ил+N+ATTR_MUN(лЫ);илле+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "илле", "analysis": "ил+N+ATTR_MUN(лЫ);илле+Num;", "translations": ["страна", "пятидесятый", "пятьдесять"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Бармаклары", "analysis": "бармак+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "исәпләргә", "analysis": "исәп+N+PL(ЛАр)+DIR(ГА);исәплә+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "керешеп", "analysis": "кер+V+RECP(Ыш)+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Бармаклары", "analysis": "бармак+N+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["палец"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "исәпләргә", "analysis": "исәп+N+PL(ЛАр)+DIR(ГА);исәплә+V+INF_1(ЫргА);", "translations": ["рассчёт", "считать"]}
+{"prefix": " ", "surface": "керешеп", "analysis": "кер+V+RECP(Ыш)+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Йөз", "analysis": "йөз+N+Sg+Nom;йөз+Num;йөз+V+IMP_SG();"}
+{"prefix": " ", "surface": "Йөз", "analysis": "йөз+N+Sg+Nom;йөз+Num;йөз+V+IMP_SG();", "translations": ["лицо", "плавать", "сотый", "сто"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "йөз", "analysis": "йөз+N+Sg+Nom;йөз+Num;йөз+V+IMP_SG();"}
-{"prefix": " ", "surface": "ун", "analysis": "ун+Num;"}
+{"prefix": " ", "surface": "йөз", "analysis": "йөз+N+Sg+Nom;йөз+Num;йөз+V+IMP_SG();", "translations": ["лицо", "плавать", "сотый", "сто"]}
+{"prefix": " ", "surface": "ун", "analysis": "ун+Num;", "translations": ["десятый", "десять"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "йөз", "analysis": "йөз+N+Sg+Nom;йөз+Num;йөз+V+IMP_SG();"}
-{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;"}
+{"prefix": " ", "surface": "йөз", "analysis": "йөз+N+Sg+Nom;йөз+Num;йөз+V+IMP_SG();", "translations": ["лицо", "плавать", "сотый", "сто"]}
+{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;", "translations": ["двадцатый", "двадцать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "сум", "analysis": "сум+N+Sg+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "сум", "analysis": "сум+N+Sg+Nom;", "translations": ["рубль"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;", "translations": ["двадцатый", "двадцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бусы", "analysis": "бусы+N+Sg+Nom;"}
-{"prefix": " ", "surface": "өч", "analysis": "өч+Num;"}
-{"prefix": " ", "surface": "тәңкә", "analysis": "тәңкә+N+Sg+Nom;"}
+{"prefix": " ", "surface": "өч", "analysis": "өч+Num;", "translations": ["третий", "три"]}
+{"prefix": " ", "surface": "тәңкә", "analysis": "тәңкә+N+Sg+Nom;", "translations": ["монета"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барысы", "analysis": "бары+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;"}
+{"prefix": " ", "surface": "барысы", "analysis": "бары+PN+POSS_3(СЫ)+Nom;", "translations": ["весь"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й);була+MOD;", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Янәдән", "analysis": "янәдән+Adv;"}
-{"prefix": " ", "surface": "исәпләп", "analysis": "исәп+N+DISTR(лАп);исәплә+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Янәдән", "analysis": "янәдән+Adv;", "translations": ["снова"]}
+{"prefix": " ", "surface": "исәпләп", "analysis": "исәп+N+DISTR(лАп);исәплә+V+ADVV_ACC(Ып);", "translations": ["рассчёт", "считать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Ике", "analysis": "ике+Num;"}
+{"prefix": " ", "surface": "Ике", "analysis": "ике+Num;", "translations": ["второй", "два", "оба"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "өч", "analysis": "өч+Num;"}
+{"prefix": " ", "surface": "өч", "analysis": "өч+Num;", "translations": ["третий", "три"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;"}
+{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;", "translations": ["четвёртый", "четыре"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;"}
-{"prefix": " ", "surface": "сум", "analysis": "сум+N+Sg+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "дүрт", "analysis": "дүрт+Num;", "translations": ["четвёртый", "четыре"]}
+{"prefix": " ", "surface": "сум", "analysis": "сум+N+Sg+Nom;", "translations": ["рубль"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;", "translations": ["двадцатый", "двадцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Портмонетына", "analysis": "NR"}
-{"prefix": " ", "surface": "сала", "analysis": "сал+V+PRES(Й);"}
+{"prefix": " ", "surface": "сала", "analysis": "сал+V+PRES(Й);", "translations": ["класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "өч", "analysis": "өч+Num;"}
-{"prefix": " ", "surface": "тәңкәсенә", "analysis": "тәңкә+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "билет", "analysis": "билет+N+Sg+Nom;"}
-{"prefix": " ", "surface": "алсак", "analysis": "ал+V+COND(сА)+1PL(к);"}
+{"prefix": " ", "surface": "өч", "analysis": "өч+Num;", "translations": ["третий", "три"]}
+{"prefix": " ", "surface": "тәңкәсенә", "analysis": "тәңкә+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["монета"]}
+{"prefix": " ", "surface": "билет", "analysis": "билет+N+Sg+Nom;", "translations": ["билет"]}
+{"prefix": " ", "surface": "алсак", "analysis": "ал+V+COND(сА)+1PL(к);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "каладыр", "analysis": "кал+V+PRES(Й)+PROB(ДЫр);кала+N+Sg+3SG(ДЫр);кала+N+Sg+Nom+PROB(ДЫр);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "сум", "analysis": "сум+N+Sg+Nom;"}
-{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;"}
-{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();"}
+{"prefix": " ", "surface": "каладыр", "analysis": "кал+V+PRES(Й)+PROB(ДЫр);кала+N+Sg+3SG(ДЫр);кала+N+Sg+Nom+PROB(ДЫр);", "translations": ["оставаться", "остаться", "город"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "сум", "analysis": "сум+N+Sg+Nom;", "translations": ["рубль"]}
+{"prefix": " ", "surface": "егерме", "analysis": "егерме+Num;", "translations": ["двадцатый", "двадцать"]}
+{"prefix": " ", "surface": "тиен", "analysis": "ти+V+REFL(Ын)+IMP_SG();тиен+N+Sg+Nom;тиен+V+IMP_SG();", "translations": ["копейка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Анысы", "analysis": "анысы+PN;"}
 {"prefix": " ", "surface": "барырга-кайтырга", "analysis": "NR"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәер", "analysis": "хәер+MOD;хәер+N+Sg+Nom;"}
+{"prefix": " ", "surface": "хәер", "analysis": "хәер+MOD;хәер+N+Sg+Nom;", "translations": ["благодеяние"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "җитә", "analysis": "җит+V+PRES(Й);"}
+{"prefix": " ", "surface": "җитә", "analysis": "җит+V+PRES(Й);", "translations": ["дойти", "доходить"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "җитүен", "analysis": "җит+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "җитүен", "analysis": "җит+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["дойти", "доходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "түлке", "analysis": "NR"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "барасы", "analysis": "бар+V+OBL(ЙсЫ);"}
-{"prefix": " ", "surface": "килми", "analysis": "кил+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "барасы", "analysis": "бар+V+OBL(ЙсЫ);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "килми", "analysis": "кил+V+NEG(мА)+PRES(Й);", "translations": ["идти"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ичмаса", "analysis": "ичмаса+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;"}
+{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;", "translations": ["отец", "папа"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "кайтмады", "analysis": "кайт+V+NEG(мА)+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "кайтмады", "analysis": "кайт+V+NEG(мА)+PST_DEF(ДЫ);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "бармыйм", "analysis": "бар+V+NEG(мА)+HOR_SG(Йм);бар+V+NEG(мА)+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "микән", "analysis": "микән+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "калырга", "analysis": "кал+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "бармый", "analysis": "бар+V+NEG(мА)+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "калырга", "analysis": "кал+V+INF_1(ЫргА);", "translations": ["оставаться", "остаться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
-{"prefix": " ", "surface": "качып", "analysis": "кач+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "утырам", "analysis": "утыр+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайткач", "analysis": "кайт+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "качып", "analysis": "кач+V+ADVV_ACC(Ып);", "translations": ["прятаться", "спрятаться"]}
+{"prefix": " ", "surface": "утырам", "analysis": "утыр+V+PRES(Й)+1SG(м);", "translations": ["посидеть", "садиться", "сидеть"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;", "translations": ["отец", "папа"]}
+{"prefix": " ", "surface": "кайткач", "analysis": "кайт+V+ADVV_ANT(ГАч);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": " ", "surface": "кына", "analysis": "кына+PART;"}
-{"prefix": " ", "surface": "торып", "analysis": "тор+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыгам", "analysis": "чык+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "торып", "analysis": "тор+V+ADVV_ACC(Ып);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "чыгам", "analysis": "чык+V+PRES(Й)+1SG(м);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Диван", "analysis": "диван+N+Sg+Nom;"}
-{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Диван", "analysis": "диван+N+Sg+Nom;", "translations": ["диван"]}
+{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["голова"]}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": " ", "surface": "посып", "analysis": "пос+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "утыра", "analysis": "утыр+V+PRES(Й);"}
+{"prefix": " ", "surface": "утыра", "analysis": "утыр+V+PRES(Й);", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
@@ -3842,127 +3842,127 @@
 {"prefix": "", "surface": "үз-үзенә", "analysis": "үз-үз+PN+POSS_3(СЫ)+DIR(ГА);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv;"}
-{"prefix": " ", "surface": "теге", "analysis": "теге+PN;"}
-{"prefix": " ", "surface": "уҗым", "analysis": "уҗым+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бозавы", "analysis": "бозау+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "киенеп", "analysis": "ки+V+REFL(Ын)+ADVV_ACC(Ып);киен+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
-{"prefix": " ", "surface": "алмаган", "analysis": "ал+V+NEG(мА)+PCP_PS(ГАн);ал+V+NEG(мА)+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv;", "translations": ["всегда", "всё время"]}
+{"prefix": " ", "surface": "теге", "analysis": "теге+PN;", "translations": ["там", "тот"]}
+{"prefix": " ", "surface": "уҗым", "analysis": "уҗым+N+Sg+Nom;", "translations": ["озимь"]}
+{"prefix": " ", "surface": "бозавы", "analysis": "бозау+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["телёнок"]}
+{"prefix": " ", "surface": "киенеп", "analysis": "ки+V+REFL(Ын)+ADVV_ACC(Ып);киен+V+ADVV_ACC(Ып);", "translations": ["одеть", "одеваться", "одеться"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "алмаган", "analysis": "ал+V+NEG(мА)+PCP_PS(ГАн);ал+V+NEG(мА)+PST_INDF(ГАн);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Нишләп", "analysis": "нишлә+V+ADVV_ACC(Ып);нишләп+PN;"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Сул", "analysis": "сул+Adj;"}
-{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();"}
-{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": "", "surface": "Сул", "analysis": "сул+Adj;", "translations": ["левый"]}
+{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom;як+V+IMP_SG();", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;"}
-{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
+{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;", "translations": ["немного"]}
+{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);", "translations": ["поднимать", "поднять"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;"}
-{"prefix": " ", "surface": "шатланып", "analysis": "шатлан+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv;", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "шатланып", "analysis": "шатлан+V+ADVV_ACC(Ып);", "translations": ["обрадоваться", "радоваться"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Аллага", "analysis": "алла+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "шөкер", "analysis": "шөкер+INTRJ;"}
+{"prefix": " ", "surface": "шөкер", "analysis": "шөкер+INTRJ;", "translations": ["хвала"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "котылдым", "analysis": "котыл+V+PST_DEF(ДЫ)+1SG(м);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "күрмәде", "analysis": "күр+V+NEG(мА)+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "күрмәде", "analysis": "күр+V+NEG(мА)+PST_DEF(ДЫ);", "translations": ["видеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайтыр", "analysis": "кайт+V+FUT_INDF(Ыр);кайт+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "әти", "analysis": "әти+N+Sg+Nom;", "translations": ["отец", "папа"]}
+{"prefix": " ", "surface": "кайтыр", "analysis": "кайт+V+FUT_INDF(Ыр);кайт+V+PCP_FUT(Ыр);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киткән", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн);ки+V+CAUS(т)+PST_INDF(ГАн);кит+V+PCP_PS(ГАн);кит+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киткән", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн);ки+V+CAUS(т)+PST_INDF(ГАн);кит+V+PCP_PS(ГАн);кит+V+PST_INDF(ГАн);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шундый", "analysis": "шундый+Adj;"}
-{"prefix": " ", "surface": "чакларда", "analysis": "чак+N+PL(ЛАр)+LOC(ДА);"}
+{"prefix": " ", "surface": "чакларда", "analysis": "чак+N+PL(ЛАр)+LOC(ДА);", "translations": ["время"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анасы", "analysis": "ана+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "анасы", "analysis": "ана+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["мать"]}
 {"prefix": " ", "surface": "кыйнамасын", "analysis": "кыйна+V+NEG(мА)+JUS_SG(сЫн);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "качкан", "analysis": "кач+V+PCP_PS(ГАн);кач+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "балалар", "analysis": "бала+N+PL(ЛАр)+Nom;балала+V+FUT_INDF(Ыр);балала+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "качкан", "analysis": "кач+V+PCP_PS(ГАн);кач+V+PST_INDF(ГАн);", "translations": ["прятаться", "спрятаться"]}
+{"prefix": " ", "surface": "балалар", "analysis": "бала+N+PL(ЛАр)+Nom;балала+V+FUT_INDF(Ыр);балала+V+PCP_FUT(Ыр);", "translations": ["ребёнок"]}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кача", "analysis": "кач+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "гадәте", "analysis": "гадәт+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;"}
+{"prefix": " ", "surface": "кача", "analysis": "кач+V+PRES(Й);", "translations": ["прятаться", "спрятаться"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "гадәте", "analysis": "гадәт+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["обычай"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бер-бер", "analysis": "бер-бер+Adj;"}
-{"prefix": " ", "surface": "җирдә", "analysis": "җир+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "качып", "analysis": "кач+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тормыймы", "analysis": "тор+V+NEG(мА)+PRES(Й)+INT(мЫ);"}
+{"prefix": " ", "surface": "җирдә", "analysis": "җир+N+Sg+LOC(ДА);", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "качып", "analysis": "кач+V+ADVV_ACC(Ып);", "translations": ["прятаться", "спрятаться"]}
+{"prefix": " ", "surface": "тормыймы", "analysis": "тор+V+NEG(мА)+PRES(Й)+INT(мЫ);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Эзләргә", "analysis": "эз+N+PL(ЛАр)+DIR(ГА);эзлә+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "тотына", "analysis": "тот+V+REFL(Ын)+PRES(Й);тотын+V+PRES(Й);"}
+{"prefix": "", "surface": "Эзләргә", "analysis": "эз+N+PL(ЛАр)+DIR(ГА);эзлә+V+INF_1(ЫргА);", "translations": ["след", "искать"]}
+{"prefix": " ", "surface": "тотына", "analysis": "тот+V+REFL(Ын)+PRES(Й);тотын+V+PRES(Й);", "translations": ["держать", "схватиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Почмакта", "analysis": "почмак+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "кресло", "analysis": "кресло+N+Sg+Nom;"}
-{"prefix": " ", "surface": "артларын", "analysis": "арт+Adj+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "карый", "analysis": "кара+V+PRES(Й);карый+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Почмакта", "analysis": "почмак+N+Sg+LOC(ДА);", "translations": ["угол", "уголок"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "кресло", "analysis": "кресло+N+Sg+Nom;", "translations": ["кресло"]}
+{"prefix": " ", "surface": "артларын", "analysis": "арт+Adj+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["за", "зад", "из-за", "позади", "увеличиваться", "увеличиться"]}
+{"prefix": " ", "surface": "карый", "analysis": "кара+V+PRES(Й);карый+N+Sg+Nom;", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);"}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);", "translations": ["время", "пора"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "балалар", "analysis": "бала+N+PL(ЛАр)+Nom;балала+V+FUT_INDF(Ыр);балала+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;"}
+{"prefix": " ", "surface": "балалар", "analysis": "бала+N+PL(ЛАр)+Nom;балала+V+FUT_INDF(Ыр);балала+V+PCP_FUT(Ыр);", "translations": ["ребёнок"]}
+{"prefix": " ", "surface": "шикелле", "analysis": "шикелле+POST;", "translations": ["будто"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "эчкә", "analysis": "эч+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "яшерә", "analysis": "яшер+V+PRES(Й);"}
+{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
+{"prefix": " ", "surface": "эчкә", "analysis": "эч+N+Sg+DIR(ГА);", "translations": ["в", "в течение", "внутренность", "внутри", "выпить", "из", "пить"]}
+{"prefix": " ", "surface": "яшерә", "analysis": "яшер+V+PRES(Й);", "translations": ["прятать", "спрятать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "күрә", "analysis": "күр+V+PRES(Й);күрә+POST;"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "күрә", "analysis": "күр+V+PRES(Й);күрә+POST;", "translations": ["видеть", "ввиду", "по"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "акрын", "analysis": "акр+N+Sg+POSS_3(СЫ)+ACC(нЫ);акрын+Adj;акрын+Adv;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "көлеп", "analysis": "көл+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "акрын", "analysis": "акр+N+Sg+POSS_3(СЫ)+ACC(нЫ);акрын+Adj;акрын+Adv;", "translations": ["медленно", "медленный"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "көлеп", "analysis": "көл+V+ADVV_ACC(Ып);", "translations": ["засмеяться", "смеяться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "диванның", "analysis": "диван+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "икенче", "analysis": "ике+Num+NUM_ORD(ЫнчЫ);"}
-{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "диванның", "analysis": "диван+N+Sg+GEN(нЫң);", "translations": ["диван"]}
+{"prefix": " ", "surface": "икенче", "analysis": "ике+Num+NUM_ORD(ЫнчЫ);", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["голова"]}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аягы", "analysis": "аяк+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "идәнгә", "analysis": "идән+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "тибеп", "analysis": "тип+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кычкыра", "analysis": "кычкыр+V+PRES(Й);"}
+{"prefix": " ", "surface": "аягы", "analysis": "аяк+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["нога", "ножка"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "идәнгә", "analysis": "идән+N+Sg+DIR(ГА);", "translations": ["пол"]}
+{"prefix": " ", "surface": "тибеп", "analysis": "тип+V+ADVV_ACC(Ып);", "translations": ["тип"]}
+{"prefix": " ", "surface": "кычкыра", "analysis": "кычкыр+V+PRES(Й);", "translations": ["крикнуть", "кричать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "һәй", "analysis": "һәй+INTRJ;"}
@@ -3970,7 +3970,7 @@
 {"prefix": " ", "surface": "бәдбәхет", "analysis": "бәдбәхет+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Күсе", "analysis": "күсе+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -3978,8 +3978,8 @@
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Сискәнеп", "analysis": "сискән+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "сикереп", "analysis": "сикер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "сикереп", "analysis": "сикер+V+ADVV_ACC(Ып);", "translations": ["прыгать", "прыгнуть"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
@@ -3988,7 +3988,7 @@
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "мыскыллап", "analysis": "мыскыл+N+DISTR(лАп);мыскылла+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "көлеп", "analysis": "көл+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "көлеп", "analysis": "көл+V+ADVV_ACC(Ып);", "translations": ["засмеяться", "смеяться"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "һа", "analysis": "һа+INTRJ;"}
@@ -3997,144 +3997,144 @@
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "һа", "analysis": "һа+INTRJ;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "идеңмени", "analysis": "и+V+PST_DEF(ДЫ)+2SG(ң)+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "идеңмени", "analysis": "и+V+PST_DEF(ДЫ)+2SG(ң)+INT_MIR(мЫни);", "translations": ["быть"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "белмәдем", "analysis": "бел+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "белмәдем", "analysis": "бел+V+NEG(мА)+PST_DEF(ДЫ)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
-{"prefix": " ", "surface": "куркытмаган", "analysis": "куркыт+V+NEG(мА)+PCP_PS(ГАн);куркыт+V+NEG(мА)+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
+{"prefix": " ", "surface": "куркытмаган", "analysis": "куркыт+V+NEG(мА)+PCP_PS(ГАн);куркыт+V+NEG(мА)+PST_INDF(ГАн);", "translations": ["напугать", "пугать"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшләп", "analysis": "эш+N+DISTR(лАп);эшлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "утырасың", "analysis": "утыр+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;утыр+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшләп", "analysis": "эш+N+DISTR(лАп);эшлә+V+ADVV_ACC(Ып);", "translations": ["дело", "делать", "поступать", "поступить", "работать", "сделать"]}
+{"prefix": " ", "surface": "утырасың", "analysis": "утыр+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;утыр+V+PRES(Й)+2SG(сЫң);", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);"}
+{"prefix": "", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": " ", "surface": "аптырап", "analysis": "аптыра+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торып", "analysis": "тор+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "торып", "analysis": "тор+V+ADVV_ACC(Ып);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Акчам", "analysis": "ак+Adj+EQU(чА)+POSS_1SG(Ым)+Nom;акча+N+Sg+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "төште", "analysis": "төш+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "Акчам", "analysis": "ак+Adj+EQU(чА)+POSS_1SG(Ым)+Nom;акча+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["белый", "деньги"]}
+{"prefix": " ", "surface": "төште", "analysis": "төш+V+PST_DEF(ДЫ);", "translations": ["опускаться", "опуститься", "сон"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "аладыр", "analysis": "ал+V+PRES(Й)+PROB(ДЫр);ала+Adj+3SG(ДЫр);ала+Adj+PROB(ДЫр);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "Шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "аладыр", "analysis": "ал+V+PRES(Й)+PROB(ДЫр);ала+Adj+3SG(ДЫр);ала+Adj+PROB(ДЫр);", "translations": ["алый", "брать", "браться", "взять", "мочь", "пегий"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;", "translations": ["деньги"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;"}
-{"prefix": " ", "surface": "җитә", "analysis": "җит+V+PRES(Й);"}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "барырга", "analysis": "бар+V+INF_1(ЫргА);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;", "translations": ["деньги"]}
+{"prefix": " ", "surface": "җитә", "analysis": "җит+V+PRES(Й);", "translations": ["дойти", "доходить"]}
 {"prefix": " ", "surface": "микән", "analysis": "микән+PART;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "санап", "analysis": "сана+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торадыр", "analysis": "тор+V+PRES(Й)+PROB(ДЫр);тора+N+Sg+3SG(ДЫр);тора+N+Sg+Nom+PROB(ДЫр);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "санап", "analysis": "сана+V+ADVV_ACC(Ып);", "translations": ["считать"]}
+{"prefix": " ", "surface": "торадыр", "analysis": "тор+V+PRES(Й)+PROB(ДЫр);тора+N+Sg+3SG(ДЫр);тора+N+Sg+Nom+PROB(ДЫр);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "берсе", "analysis": "бер+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "төшеп", "analysis": "төш+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "берсе", "analysis": "бер+PN+POSS_3(СЫ)+Nom;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "төшеп", "analysis": "төш+V+ADVV_ACC(Ып);", "translations": ["опускаться", "опуститься", "сон"]}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "гомердән", "analysis": "гомер+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "гомердән", "analysis": "гомер+N+Sg+ABL(ДАн);", "translations": ["жизнь"]}
+{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;", "translations": ["с"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": " ", "surface": "өстеңә", "analysis": "өс+N+Sg+POSS_2SG(Ың)+DIR(ГА);"}
-{"prefix": " ", "surface": "киенмичә", "analysis": "ки+V+REFL(Ын)+NEG(мА)+ADVV_NEG(ЙчА);киен+V+NEG(мА)+ADVV_NEG(ЙчА);"}
-{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;"}
-{"prefix": " ", "surface": "санап", "analysis": "сана+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тордыңмы", "analysis": "тор+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);"}
+{"prefix": " ", "surface": "киенмичә", "analysis": "ки+V+REFL(Ын)+NEG(мА)+ADVV_NEG(ЙчА);киен+V+NEG(мА)+ADVV_NEG(ЙчА);", "translations": ["одеть", "одеваться", "одеться"]}
+{"prefix": " ", "surface": "акча", "analysis": "акча+N+Sg+Nom;", "translations": ["деньги"]}
+{"prefix": " ", "surface": "санап", "analysis": "сана+V+ADVV_ACC(Ып);", "translations": ["считать"]}
+{"prefix": " ", "surface": "тордыңмы", "analysis": "тор+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "киенәм", "analysis": "ки+V+REFL(Ын)+PRES(Й)+1SG(м);киен+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "киенәм", "analysis": "ки+V+REFL(Ын)+PRES(Й)+1SG(м);киен+V+PRES(Й)+1SG(м);", "translations": ["одеть", "одеваться", "одеться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Башыма", "analysis": "баш+N+Sg+POSS_1SG(Ым)+DIR(ГА);"}
-{"prefix": " ", "surface": "бүрек", "analysis": "бүрек+N+Sg+Nom;"}
-{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Башыма", "analysis": "баш+N+Sg+POSS_1SG(Ым)+DIR(ГА);", "translations": ["голова"]}
+{"prefix": " ", "surface": "бүрек", "analysis": "бүрек+N+Sg+Nom;", "translations": ["шапка"]}
+{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);", "translations": ["одеть"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "тунымны", "analysis": "тун+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "тунымны", "analysis": "тун+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["шуба"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "киям", "analysis": "ки+V+PRES(Й)+1SG(м);", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "кычкырып", "analysis": "кычкыр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кала", "analysis": "кал+V+PRES(Й);кала+N+Sg+Nom;"}
+{"prefix": "", "surface": "кычкырып", "analysis": "кычкыр+V+ADVV_ACC(Ып);", "translations": ["крикнуть", "кричать"]}
+{"prefix": " ", "surface": "кала", "analysis": "кал+V+PRES(Й);кала+N+Sg+Nom;", "translations": ["оставаться", "остаться", "город"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "кәнәфи", "analysis": "кәнәфи+N+Sg+Nom;"}
-{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "акчаңны", "analysis": "ак+Adj+EQU(чА)+POSS_2SG(Ың)+ACC(нЫ);акча+N+Sg+POSS_2SG(Ың)+ACC(нЫ);"}
-{"prefix": " ", "surface": "төшермә", "analysis": "төшер+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "кәнәфи", "analysis": "кәнәфи+N+Sg+Nom;", "translations": ["кресло"]}
+{"prefix": " ", "surface": "башына", "analysis": "баш+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["голова"]}
+{"prefix": " ", "surface": "акчаңны", "analysis": "ак+Adj+EQU(чА)+POSS_2SG(Ың)+ACC(нЫ);акча+N+Sg+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["белый", "деньги"]}
+{"prefix": " ", "surface": "төшермә", "analysis": "төшер+V+NEG(мА)+IMP_SG();", "translations": ["опускать", "опустить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": " ", "surface": "күсе", "analysis": "күсе+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Көзге", "analysis": "көзге+Adj;көзге+N+Sg+Nom;"}
+{"prefix": "", "surface": "Көзге", "analysis": "көзге+Adj;көзге+N+Sg+Nom;", "translations": ["зеркало"]}
 {"prefix": " ", "surface": "каршына", "analysis": "NR"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шәлләрен", "analysis": "шәл+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "калфакларын", "analysis": "калфак+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
 {"prefix": " ", "surface": "төзәтә", "analysis": "төзә+V+CAUS(т)+PRES(Й);төзәт+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлап", "analysis": "баш+N+DISTR(лАп);башла+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "башлап", "analysis": "баш+N+DISTR(лАп);башла+V+ADVV_ACC(Ып);", "translations": ["голова", "начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Ну", "analysis": "ну+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ир", "analysis": "ир+N+Sg+Nom;"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "ир", "analysis": "ир+N+Sg+Nom;", "translations": ["мужчина"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ир", "analysis": "ир+N+Sg+Nom;"}
-{"prefix": " ", "surface": "димәсәң", "analysis": "ди+V+NEG(мА)+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "Ир", "analysis": "ир+N+Sg+Nom;", "translations": ["мужчина"]}
+{"prefix": " ", "surface": "димәсәң", "analysis": "ди+V+NEG(мА)+COND(сА)+2SG(ң);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәтере", "analysis": "хәтер+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "калырлык", "analysis": "кал+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;кал+V+PCP_FUT(Ыр)+PSBL(лЫк);"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "хәтере", "analysis": "хәтер+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["память"]}
+{"prefix": " ", "surface": "калырлык", "analysis": "кал+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;кал+V+PCP_FUT(Ыр)+PSBL(лЫк);", "translations": ["оставаться", "остаться"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
@@ -4143,116 +4143,116 @@
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "әткәй", "analysis": "әткәй+N+Sg+Nom;"}
-{"prefix": " ", "surface": "безне", "analysis": "без+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "безне", "analysis": "без+PN+ACC(нЫ);", "translations": ["мы", "наш"]}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": "", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();"}
+{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;"}
+{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;", "translations": ["зачем", "почему"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;", "translations": ["деверь"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сез", "analysis": "сез+PN;"}
+{"prefix": " ", "surface": "Сез", "analysis": "сез+PN;", "translations": ["ваш", "вы"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "барасызмыни", "analysis": "бар+V+PRES(Й)+2PL(сЫз)+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "барасызмыни", "analysis": "бар+V+PRES(Й)+2PL(сЫз)+INT_MIR(мЫни);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "Без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әмма", "analysis": "әмма+CNJ;"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
+{"prefix": " ", "surface": "әмма", "analysis": "әмма+CNJ;", "translations": ["но"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйтермен", "analysis": "әйт+V+FUT_INDF(Ыр)+1SG(мЫн);әйт+V+PCP_FUT(Ыр)+1SG(мЫн);"}
+{"prefix": " ", "surface": "әйтермен", "analysis": "әйт+V+FUT_INDF(Ыр)+1SG(мЫн);әйт+V+PCP_FUT(Ыр)+1SG(мЫн);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бая", "analysis": "бая+Adv;"}
-{"prefix": " ", "surface": "җизни", "analysis": "җизни+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Бая", "analysis": "бая+Adv;", "translations": ["недавний", "недавно"]}
+{"prefix": " ", "surface": "җизни", "analysis": "җизни+N+Sg+Nom;", "translations": ["деверь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);"}
-{"prefix": " ", "surface": "белмәссең", "analysis": "бел+V+FUT_INDF_NEG(мАс)+2SG(сЫң);бел+V+PCP_FUT(мАс)+2SG(сЫң);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "белмәссең", "analysis": "бел+V+FUT_INDF_NEG(мАс)+2SG(сЫң);бел+V+PCP_FUT(мАс)+2SG(сЫң);", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;"}
-{"prefix": " ", "surface": "әйттереп", "analysis": "әйт+V+CAUS(ДЫр)+ADVV_ACC(Ып);әйттер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "маташа", "analysis": "маташ+V+PRES(Й);"}
+{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;", "translations": ["мозг", "мой", "я"]}
+{"prefix": " ", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;", "translations": ["новый"]}
+{"prefix": " ", "surface": "әйттереп", "analysis": "әйт+V+CAUS(ДЫр)+ADVV_ACC(Ып);әйттер+V+ADVV_ACC(Ып);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "маташа", "analysis": "маташ+V+PRES(Й);", "translations": ["попытаться", "пытаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);"}
-{"prefix": " ", "surface": "белдеңме", "analysis": "бел+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "белдеңме", "analysis": "бел+V+PST_DEF(ДЫ)+2SG(ң)+INT(мЫ);", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;"}
-{"prefix": " ", "surface": "белмәскә", "analysis": "бел+V+NEG(мА)+INF_1(скА);бел+V+PCP_FUT(мАс)+DIR(ГА);"}
+{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;", "translations": ["зачем", "почему"]}
+{"prefix": " ", "surface": "белмәскә", "analysis": "бел+V+NEG(мА)+INF_1(скА);бел+V+PCP_FUT(мАс)+DIR(ГА);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "белдем", "analysis": "бел+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "белдем", "analysis": "бел+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
-{"prefix": " ", "surface": "әйтеп", "analysis": "әйт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "әйтеп", "analysis": "әйт+V+ADVV_ACC(Ып);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Безне", "analysis": "без+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "Безне", "analysis": "без+PN+ACC(нЫ);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": " ", "surface": "диярсең", "analysis": "диярсең+CNJ;"}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "белмәс", "analysis": "бел+V+FUT_INDF_NEG(мАс);бел+V+PCP_FUT(мАс);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "беләсеңме", "analysis": "бел+V+PRES(Й)+2SG(сЫң)+INT(мЫ);"}
+{"prefix": " ", "surface": "белмәс", "analysis": "бел+V+FUT_INDF_NEG(мАс);бел+V+PCP_FUT(мАс);", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "беләсеңме", "analysis": "бел+V+PRES(Й)+2SG(сЫң)+INT(мЫ);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "абыйдан", "analysis": "абый+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "күптән", "analysis": "күп+Adj+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "өйрәнеп", "analysis": "өйрән+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "куйдым", "analysis": "куй+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "абыйдан", "analysis": "абый+N+Sg+ABL(ДАн);", "translations": ["брат", "дядя"]}
+{"prefix": " ", "surface": "күптән", "analysis": "күп+Adj+Sg+ABL(ДАн);", "translations": ["много"]}
+{"prefix": " ", "surface": "өйрәнеп", "analysis": "өйрән+V+ADVV_ACC(Ып);", "translations": ["научиться", "учиться"]}
+{"prefix": " ", "surface": "куйдым", "analysis": "куй+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["баран", "класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": " ", "surface": "диярмен", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фaкиһә", "analysis": "Error"}
@@ -4262,93 +4262,93 @@
 {"prefix": " ", "surface": "аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "җебегән", "analysis": "җебе+V+PCP_PS(ГАн);җебе+V+PST_INDF(ГАн);җебегән+Adj;"}
-{"prefix": " ", "surface": "авыз", "analysis": "авыз+N+Sg+Nom;"}
+{"prefix": " ", "surface": "авыз", "analysis": "авыз+N+Sg+Nom;", "translations": ["рот"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "куштыммыни", "analysis": "куш+V+PST_DEF(ДЫ)+1SG(м)+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтергә", "analysis": "әйт+V+INF_1(ЫргА);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "куштыммыни", "analysis": "куш+V+PST_DEF(ДЫ)+1SG(м)+INT_MIR(мЫни);", "translations": ["велеть", "двойной", "складывать", "сложить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;"}
+{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;", "translations": ["зачем", "почему"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "үзең", "analysis": "үз+PN+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "әйттең", "analysis": "әйт+V+PST_DEF(ДЫ)+2SG(ң);"}
+{"prefix": " ", "surface": "үзең", "analysis": "үз+PN+POSS_2SG(Ың)+Nom;", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "әйттең", "analysis": "әйт+V+PST_DEF(ДЫ)+2SG(ң);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;"}
+{"prefix": "", "surface": "җизниләр", "analysis": "җизни+N+PL(ЛАр)+Nom;", "translations": ["деверь"]}
 {"prefix": " ", "surface": "кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сез", "analysis": "сез+PN;"}
+{"prefix": " ", "surface": "сез", "analysis": "сез+PN;", "translations": ["ваш", "вы"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "барасызмы", "analysis": "бар+V+PRES(Й)+2PL(сЫз)+INT(мЫ);"}
+{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "барасызмы", "analysis": "бар+V+PRES(Й)+2PL(сЫз)+INT(мЫ);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);"}
+{"prefix": "", "surface": "дигәч", "analysis": "ди+V+ADVV_ANT(ГАч);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Юк", "analysis": "юк+MOD;"}
+{"prefix": "", "surface": "Юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);"}
+{"prefix": " ", "surface": "без", "analysis": "без+N+Sg+Nom;без+PN;", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "барабыз", "analysis": "бар+V+PRES(Й)+1PL(бЫз);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фaкиһә", "analysis": "Error"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "телеңә", "analysis": "тел+N+Sg+POSS_2SG(Ың)+DIR(ГА);"}
-{"prefix": " ", "surface": "салынма", "analysis": "сал+V+REFL(Ын)+NEG(мА)+IMP_SG();салын+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "Күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "телеңә", "analysis": "тел+N+Sg+POSS_2SG(Ың)+DIR(ГА);", "translations": ["язык"]}
+{"prefix": " ", "surface": "салынма", "analysis": "сал+V+REFL(Ын)+NEG(мА)+IMP_SG();салын+V+NEG(мА)+IMP_SG();", "translations": ["класть", "положить", "строиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Яхшы", "analysis": "яхшы+Adj;яхшы+Adv;"}
-{"prefix": " ", "surface": "тыңла", "analysis": "тыңла+V+IMP_SG();"}
+{"prefix": " ", "surface": "Яхшы", "analysis": "яхшы+Adj;яхшы+Adv;", "translations": ["лучше", "лучший", "хороший", "хорошо"]}
+{"prefix": " ", "surface": "тыңла", "analysis": "тыңла+V+IMP_SG();", "translations": ["слушать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әгәр", "analysis": "әгәр+CNJ;"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": " ", "surface": "әткәй", "analysis": "әткәй+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);"}
+{"prefix": " ", "surface": "сораса", "analysis": "сора+V+COND(сА);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": "", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();"}
+{"prefix": " ", "surface": "диген", "analysis": "ди+V+IMP_SG();диген+V+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аңладым", "analysis": "аңла+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "аңладым", "analysis": "аңла+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["понимать", "понять"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Икесе", "analysis": "ике+Num+POSS_3(СЫ)+Nom;"}
+{"prefix": "", "surface": "Икесе", "analysis": "ике+Num+POSS_3(СЫ)+Nom;", "translations": ["второй", "два", "оба"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "диярмен", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фaкиһә", "analysis": "Error"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -4356,181 +4356,181 @@
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Факиһә", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "эшеңдә", "analysis": "эш+N+Sg+POSS_2SG(Ың)+LOC(ДА);"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "эшеңдә", "analysis": "эш+N+Sg+POSS_2SG(Ың)+LOC(ДА);", "translations": ["дело"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
-{"prefix": " ", "surface": "тунының", "analysis": "тун+N+Sg+POSS_3(СЫ)+GEN(нЫң);"}
-{"prefix": " ", "surface": "югары", "analysis": "югары+Adj;югары+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "төймәсен", "analysis": "төй+V+NEG(мА)+JUS_SG(сЫн);төймә+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "тунының", "analysis": "тун+N+Sg+POSS_3(СЫ)+GEN(нЫң);", "translations": ["шуба"]}
+{"prefix": " ", "surface": "югары", "analysis": "югары+Adj;югары+PROP+Sg+Nom;", "translations": ["высокий", "высоко"]}
+{"prefix": " ", "surface": "төймәсен", "analysis": "төй+V+NEG(мА)+JUS_SG(сЫн);төймә+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["пуговица"]}
 {"prefix": " ", "surface": "төймәли-төймәли", "analysis": "NR"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Xәбибрaхмaн", "analysis": "Error"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булдым", "analysis": "бул+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "булдым", "analysis": "бул+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фaкиһә", "analysis": "Error"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ;әйдә+V+IMP_SG();", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булсаң", "analysis": "бул+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "булсаң", "analysis": "бул+V+COND(сА)+2SG(ң);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "атла", "analysis": "атла+V+IMP_SG();"}
-{"prefix": " ", "surface": "аягыңны", "analysis": "аяк+N+Sg+POSS_2SG(Ың)+ACC(нЫ);"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "атла", "analysis": "атла+V+IMP_SG();", "translations": ["шагать", "шагнуть"]}
+{"prefix": " ", "surface": "аягыңны", "analysis": "аяк+N+Sg+POSS_2SG(Ың)+ACC(нЫ);", "translations": ["нога", "ножка"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "чыкканда", "analysis": "чык+V+PCP_PS(ГАн)+LOC(ДА);"}
+{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "чыкканда", "analysis": "чык+V+PCP_PS(ГАн)+LOC(ДА);", "translations": ["выйти", "выходить"]}
 {"prefix": " ", "surface": "Хәбибрахманның", "analysis": "NR"}
-{"prefix": " ", "surface": "аркасыннан", "analysis": "арка+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "этә", "analysis": "эт+V+PRES(Й);"}
+{"prefix": " ", "surface": "аркасыннан", "analysis": "арка+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["из-за", "спина"]}
+{"prefix": " ", "surface": "этә", "analysis": "эт+V+PRES(Й);", "translations": ["собака"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Xәбибрaхмaн", "analysis": "Error"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();"}
+{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();", "translations": ["останавливаться", "остановиться", "остановка"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Төрткәләмә", "analysis": "төр+V+CAUS(т)+RAR_1(ГАлА)+NEG(мА)+IMP_SG();төрт+V+RAR_1(ГАлА)+NEG(мА)+IMP_SG();төрткәлә+V+NEG(мА)+IMP_SG();"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
+{"prefix": " ", "surface": "Төрткәләмә", "analysis": "төр+V+CAUS(т)+RAR_1(ГАлА)+NEG(мА)+IMP_SG();төрт+V+RAR_1(ГАлА)+NEG(мА)+IMP_SG();төрткәлә+V+NEG(мА)+IMP_SG();", "translations": ["вид", "завернуть", "ткнуть"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Чыгам", "analysis": "чык+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "Чыгам", "analysis": "чык+V+PRES(Й)+1SG(м);", "translations": ["выйти", "выходить"]}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китәләр", "analysis": "ки+V+CAUS(т)+PRES(Й)+3PL(ЛАр);кит+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китәләр", "analysis": "ки+V+CAUS(т)+PRES(Й)+3PL(ЛАр);кит+V+PRES(Й)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сәхнә", "analysis": "сәхнә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "буш", "analysis": "буш+Adj;"}
-{"prefix": " ", "surface": "кала", "analysis": "кал+V+PRES(Й);кала+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Сәхнә", "analysis": "сәхнә+N+Sg+Nom;", "translations": ["сцена"]}
+{"prefix": " ", "surface": "буш", "analysis": "буш+Adj;", "translations": ["пусто", "пустой"]}
+{"prefix": " ", "surface": "кала", "analysis": "кал+V+PRES(Й);кала+N+Sg+Nom;", "translations": ["оставаться", "остаться", "город"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бераздан", "analysis": "бераздан+Adv;"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "як-ягына", "analysis": "як-ягым+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "каранып", "analysis": "кара+V+REFL(Ын)+ADVV_ACC(Ып);каран+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "каранып", "analysis": "кара+V+REFL(Ын)+ADVV_ACC(Ып);каран+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итә", "analysis": "и+V+CAUS(т)+PRES(Й);ит+V+PRES(Й);"}
+{"prefix": " ", "surface": "Кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;", "translations": ["праздник"]}
+{"prefix": " ", "surface": "итә", "analysis": "и+V+CAUS(т)+PRES(Й);ит+V+PRES(Й);", "translations": ["быть", "делать", "мясо", "сделать"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "итә", "analysis": "и+V+CAUS(т)+PRES(Й);ит+V+PRES(Й);"}
+{"prefix": " ", "surface": "итә", "analysis": "и+V+CAUS(т)+PRES(Й);ит+V+PRES(Й);", "translations": ["быть", "делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;"}
-{"prefix": " ", "surface": "бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "аласы", "analysis": "ал+V+OBL(ЙсЫ);ала+Adj+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;"}
+{"prefix": " ", "surface": "бераз", "analysis": "бераз+Adv;", "translations": ["немного"]}
+{"prefix": " ", "surface": "бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;", "translations": ["праздник"]}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "аласы", "analysis": "ал+V+OBL(ЙсЫ);ала+Adj+Sg+POSS_3(СЫ)+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь", "пегий"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ);иде+MOD;", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "һәммә", "analysis": "һәммә+PN;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);"}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);", "translations": ["походить", "ходить"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);"}
+{"prefix": " ", "surface": "йөри", "analysis": "йөр+V+PRES(Й);", "translations": ["походить", "ходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;"}
-{"prefix": " ", "surface": "ябылып", "analysis": "ябыл+V+ADVV_ACC(Ып);яп+V+PASS(Ыл)+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "ятам", "analysis": "ят+V+HOR_SG(Йм);ят+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;", "translations": ["но", "только"]}
+{"prefix": " ", "surface": "ябылып", "analysis": "ябыл+V+ADVV_ACC(Ып);яп+V+PASS(Ыл)+ADVV_ACC(Ып);", "translations": ["закрывать", "закрыть"]}
+{"prefix": " ", "surface": "ятам", "analysis": "ят+V+HOR_SG(Йм);ят+V+PRES(Й)+1SG(м);", "translations": ["лечь", "ложиться", "чужой"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;", "translations": ["праздник"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "җомга", "analysis": "җомга+N+Sg+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "җомга", "analysis": "җомга+N+Sg+Nom;", "translations": ["пятница"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;"}
+{"prefix": " ", "surface": "Бәйрәм", "analysis": "бәйрәм+N+Sg+Nom;", "translations": ["праздник"]}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;", "translations": ["быть", "дуть", "запах"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;"}
-{"prefix": " ", "surface": "төбе", "analysis": "төп+Adj+Sg+POSS_3(СЫ)+Nom;төп+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "сакла", "analysis": "сакла+V+IMP_SG();"}
+{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;", "translations": ["дверь"]}
+{"prefix": " ", "surface": "төбе", "analysis": "төп+Adj+Sg+POSS_3(СЫ)+Nom;төп+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["главный", "дно", "основной"]}
+{"prefix": " ", "surface": "сакла", "analysis": "сакла+V+IMP_SG();", "translations": ["сохранять", "хранить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Көне", "analysis": "көн+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "буе", "analysis": "буе+POST;буй+N+Sg+POSS_3(СЫ)+Nom;буй+PROP+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "байга", "analysis": "бай+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "килгән", "analysis": "кил+V+PCP_PS(ГАн);кил+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "кешене", "analysis": "кеше+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "өйгә", "analysis": "өй+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кер", "analysis": "кер+N+Sg+Nom;кер+V+IMP_SG();"}
+{"prefix": " ", "surface": "Көне", "analysis": "көн+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["день"]}
+{"prefix": " ", "surface": "буе", "analysis": "буе+POST;буй+N+Sg+POSS_3(СЫ)+Nom;буй+PROP+POSS_3(СЫ)+Nom;", "translations": ["в течение", "по", "длина", "рост"]}
+{"prefix": " ", "surface": "байга", "analysis": "бай+N+Sg+DIR(ГА);", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "килгән", "analysis": "кил+V+PCP_PS(ГАн);кил+V+PST_INDF(ГАн);", "translations": ["идти"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "кешене", "analysis": "кеше+N+Sg+ACC(нЫ);", "translations": ["человек"]}
+{"prefix": " ", "surface": "өйгә", "analysis": "өй+N+Sg+DIR(ГА);", "translations": ["дом"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кер", "analysis": "кер+N+Sg+Nom;кер+V+IMP_SG();", "translations": ["войти", "входить", "грязь"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "чәй", "analysis": "чәй+N+Sg+Nom;"}
+{"prefix": " ", "surface": "чәй", "analysis": "чәй+N+Sg+Nom;", "translations": ["чай"]}
 {"prefix": " ", "surface": "эчерт", "analysis": "эчер+V+CAUS(т)+IMP_SG();эчерт+V+IMP_SG();"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "җомга", "analysis": "җомга+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;"}
+{"prefix": " ", "surface": "җомга", "analysis": "җомга+N+Sg+Nom;", "translations": ["пятница"]}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "исә", "analysis": "и+V+COND(сА);ис+V+PRES(Й);исә+CNJ;", "translations": ["быть", "дуть", "запах"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;"}
-{"prefix": " ", "surface": "алдында", "analysis": "ал+N+Sg+POSS_3(СЫ)+LOC(ДА);алдында+POST;"}
-{"prefix": " ", "surface": "утын", "analysis": "у+V+CAUS(т)+REFL(Ын)+IMP_SG();ут+N+Sg+POSS_3(СЫ)+ACC(нЫ);утын+N+Sg+Nom;"}
-{"prefix": " ", "surface": "яр", "analysis": "яр+N+Sg+Nom;яр+PROP+Sg+Nom;яр+V+IMP_SG();"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "кар", "analysis": "кар+N+Sg+Nom;"}
+{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;", "translations": ["дверь"]}
+{"prefix": " ", "surface": "алдында", "analysis": "ал+N+Sg+POSS_3(СЫ)+LOC(ДА);алдында+POST;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "утын", "analysis": "у+V+CAUS(т)+REFL(Ын)+IMP_SG();ут+N+Sg+POSS_3(СЫ)+ACC(нЫ);утын+N+Sg+Nom;", "translations": ["огонь"]}
+{"prefix": " ", "surface": "яр", "analysis": "яр+N+Sg+Nom;яр+PROP+Sg+Nom;яр+V+IMP_SG();", "translations": ["берег"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "кар", "analysis": "кар+N+Sg+Nom;", "translations": ["снег"]}
 {"prefix": " ", "surface": "көрә", "analysis": "көрә+V+IMP_SG();"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булмас", "analysis": "бул+V+FUT_INDF_NEG(мАс);бул+V+PCP_FUT(мАс);"}
+{"prefix": " ", "surface": "булмас", "analysis": "бул+V+FUT_INDF_NEG(мАс);бул+V+PCP_FUT(мАс);", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "болай", "analysis": "болай+PN;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Эһем", "analysis": "эһем+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "эһем", "analysis": "эһем+INTRJ;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Тамак", "analysis": "тамак+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кыра", "analysis": "кыр+V+PRES(Й);"}
+{"prefix": "", "surface": "Тамак", "analysis": "тамак+N+Sg+Nom;", "translations": ["горло"]}
+{"prefix": " ", "surface": "кыра", "analysis": "кыр+V+PRES(Й);", "translations": ["поле"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;"}
-{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);"}
+{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;", "translations": ["совсем", "целиком"]}
+{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);", "translations": ["дом"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "юкмы", "analysis": "юк+MOD+INT(мЫ);"}
+{"prefix": " ", "surface": "юкмы", "analysis": "юк+MOD+INT(мЫ);", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишекләрне", "analysis": "ишек+N+PL(ЛАр)+ACC(нЫ);"}
-{"prefix": " ", "surface": "карана", "analysis": "кара+V+REFL(Ын)+PRES(Й);каран+V+PRES(Й);"}
+{"prefix": "", "surface": "Ишекләрне", "analysis": "ишек+N+PL(ЛАр)+ACC(нЫ);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "карана", "analysis": "кара+V+REFL(Ын)+PRES(Й);каран+V+PRES(Й);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
@@ -4540,100 +4540,100 @@
 {"prefix": " ", "surface": "эһем", "analysis": "эһем+INTRJ;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Нәрсәгә", "analysis": "нәрсә+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "тамак", "analysis": "тамак+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кырып", "analysis": "кыр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "йөргән", "analysis": "йөр+V+PCP_PS(ГАн);йөр+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "буласың", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бул+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Нәрсәгә", "analysis": "нәрсә+PN+DIR(ГА);", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "тамак", "analysis": "тамак+N+Sg+Nom;", "translations": ["горло"]}
+{"prefix": " ", "surface": "кырып", "analysis": "кыр+V+ADVV_ACC(Ып);", "translations": ["поле"]}
+{"prefix": " ", "surface": "йөргән", "analysis": "йөр+V+PCP_PS(ГАн);йөр+V+PST_INDF(ГАн);", "translations": ["походить", "ходить"]}
+{"prefix": " ", "surface": "буласың", "analysis": "бул+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бул+V+PRES(Й)+2SG(сЫң);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "өйдәме", "analysis": "өй+N+Sg+LOC(ДА)+INT(мЫ);"}
+{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
+{"prefix": " ", "surface": "өйдәме", "analysis": "өй+N+Sg+LOC(ДА)+INT(мЫ);", "translations": ["дом"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);"}
+{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);", "translations": ["дом"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшли", "analysis": "эшлә+V+PRES(Й);"}
+{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшли", "analysis": "эшлә+V+PRES(Й);", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тире", "analysis": "тир+N+Sg+POSS_3(СЫ)+Nom;тире+N+Sg+Nom;"}
-{"prefix": " ", "surface": "җыеп", "analysis": "җый+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "күн", "analysis": "күн+N+Sg+Nom;күн+V+IMP_SG();"}
-{"prefix": " ", "surface": "эшли", "analysis": "эшлә+V+PRES(Й);"}
+{"prefix": " ", "surface": "Тире", "analysis": "тир+N+Sg+POSS_3(СЫ)+Nom;тире+N+Sg+Nom;", "translations": ["пот", "кожа"]}
+{"prefix": " ", "surface": "җыеп", "analysis": "җый+V+ADVV_ACC(Ып);", "translations": ["собирать", "собрать"]}
+{"prefix": " ", "surface": "күн", "analysis": "күн+N+Sg+Nom;күн+V+IMP_SG();", "translations": ["кожа"]}
+{"prefix": " ", "surface": "эшли", "analysis": "эшлә+V+PRES(Й);", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шаярма", "analysis": "шаяр+V+NEG(мА)+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чынлап", "analysis": "чын+Adj+DISTR(лАп);чынла+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "чынлап", "analysis": "чын+Adj+DISTR(лАп);чынла+V+ADVV_ACC(Ып);", "translations": ["настоящий"]}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "өйдәме", "analysis": "өй+N+Sg+LOC(ДА)+INT(мЫ);"}
+{"prefix": " ", "surface": "өйдәме", "analysis": "өй+N+Sg+LOC(ДА)+INT(мЫ);", "translations": ["дом"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшкә", "analysis": "эш+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
+{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшкә", "analysis": "эш+N+Sg+DIR(ГА);", "translations": ["дело"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кирәк", "analysis": "кирәк+MOD;"}
+{"prefix": " ", "surface": "Кирәк", "analysis": "кирәк+MOD;", "translations": ["необходимый", "нужный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "әүвәле", "analysis": "әүвәле+Adj;"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "эшкә", "analysis": "эш+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "эшкә", "analysis": "эш+N+Sg+DIR(ГА);", "translations": ["дело"]}
 {"prefix": " ", "surface": "икәнен", "analysis": "икән+MOD+Sg+POSS_3(СЫ)+ACC(нЫ);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "әйтәм", "analysis": "әйт+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "әйтәм", "analysis": "әйт+V+PRES(Й)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шаярма", "analysis": "шаяр+V+NEG(мА)+IMP_SG();"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "бирәсең", "analysis": "бир+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бир+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "бирәсең", "analysis": "бир+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;бир+V+PRES(Й)+2SG(сЫң);", "translations": ["давать", "даваться", "дать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйтәм", "analysis": "әйт+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "әйтәм", "analysis": "әйт+V+PRES(Й)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "шаярып", "analysis": "шаяр+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әйтсәң", "analysis": "әйт+V+COND(сА)+2SG(ң);"}
+{"prefix": " ", "surface": "әйтсәң", "analysis": "әйт+V+COND(сА)+2SG(ң);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "үземә", "analysis": "үз+PN+POSS_1SG(Ым)+DIR(ГА);"}
-{"prefix": " ", "surface": "хатынлыкка", "analysis": "хатын+N+NMLZ(лЫк)+Sg+DIR(ГА);хатын+N+PSBL(лЫк)+DIR(ГА);"}
-{"prefix": " ", "surface": "алырмын", "analysis": "ал+V+FUT_INDF(Ыр)+1SG(мЫн);ал+V+PCP_FUT(Ыр)+1SG(мЫн);"}
+{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "үземә", "analysis": "үз+PN+POSS_1SG(Ым)+DIR(ГА);", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "хатынлыкка", "analysis": "хатын+N+NMLZ(лЫк)+Sg+DIR(ГА);хатын+N+PSBL(лЫк)+DIR(ГА);", "translations": ["жена", "женщина"]}
+{"prefix": " ", "surface": "алырмын", "analysis": "ал+V+FUT_INDF(Ыр)+1SG(мЫн);ал+V+PCP_FUT(Ыр)+1SG(мЫн);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -4645,66 +4645,66 @@
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Мәхәббәтсез", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "нишләп", "analysis": "нишлә+V+ADVV_ACC(Ып);нишләп+PN;"}
 {"prefix": " ", "surface": "мәхәббәтсез", "analysis": "NR"}
-{"prefix": " ", "surface": "булыйм", "analysis": "бул+V+HOR_SG(Йм);"}
+{"prefix": " ", "surface": "булыйм", "analysis": "бул+V+HOR_SG(Йм);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "мыекларны", "analysis": "мыек+N+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "мыекларны", "analysis": "мыек+N+PL(ЛАр)+ACC(нЫ);", "translations": ["ус"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Мыекларын", "analysis": "мыек+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "борып", "analysis": "бор+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "күрсәтә", "analysis": "күрсәт+V+PRES(Й);"}
+{"prefix": "", "surface": "Мыекларын", "analysis": "мыек+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["ус"]}
+{"prefix": " ", "surface": "борып", "analysis": "бор+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
+{"prefix": " ", "surface": "күрсәтә", "analysis": "күрсәт+V+PRES(Й);", "translations": ["показать", "показывать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Кызларның", "analysis": "кыз+N+PL(ЛАр)+GEN(нЫң);"}
+{"prefix": " ", "surface": "Кызларның", "analysis": "кыз+N+PL(ЛАр)+GEN(нЫң);", "translations": ["девушка", "дочь"]}
 {"prefix": " ", "surface": "калфак", "analysis": "калфак+N+Sg+Nom;"}
-{"prefix": " ", "surface": "чугына", "analysis": "чук+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "ярарлык", "analysis": "яр+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;яр+V+PCP_FUT(Ыр)+PSBL(лЫк);яра+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;яра+V+PCP_FUT(Ыр)+PSBL(лЫк);ярарлык+Adj;"}
+{"prefix": " ", "surface": "чугына", "analysis": "чук+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["кисть"]}
+{"prefix": " ", "surface": "ярарлык", "analysis": "яр+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;яр+V+PCP_FUT(Ыр)+PSBL(лЫк);яра+V+PCP_FUT(Ыр)+NMLZ(лЫк)+Sg+Nom;яра+V+PCP_FUT(Ыр)+PSBL(лЫк);ярарлык+Adj;", "translations": ["берег", "годиться", "рана"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;"}
-{"prefix": " ", "surface": "телеңә", "analysis": "тел+N+Sg+POSS_2SG(Ың)+DIR(ГА);"}
-{"prefix": " ", "surface": "салынып", "analysis": "сал+V+REFL(Ын)+ADVV_ACC(Ып);салын+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торма", "analysis": "тор+V+NEG(мА)+IMP_SG();торма+N+Sg+Nom;"}
-{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
+{"prefix": " ", "surface": "күп", "analysis": "күп+Adj;", "translations": ["много"]}
+{"prefix": " ", "surface": "телеңә", "analysis": "тел+N+Sg+POSS_2SG(Ың)+DIR(ГА);", "translations": ["язык"]}
+{"prefix": " ", "surface": "салынып", "analysis": "сал+V+REFL(Ын)+ADVV_ACC(Ып);салын+V+ADVV_ACC(Ып);", "translations": ["класть", "положить", "строиться"]}
+{"prefix": " ", "surface": "торма", "analysis": "тор+V+NEG(мА)+IMP_SG();торма+N+Sg+Nom;", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom;чык+V+IMP_SG();"}
+{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom;чык+V+IMP_SG();", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;"}
+{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;", "translations": ["зачем", "почему"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;"}
-{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "яратмыйсыңмыни", "analysis": "яра+V+CAUS(т)+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT_MIR(мЫни);яра+V+CAUS(т)+NEG(мА)+PRES(Й)+2SG(сЫң)+INT_MIR(мЫни);ярат+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT_MIR(мЫни);ярат+V+NEG(мА)+PRES(Й)+2SG(сЫң)+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;", "translations": ["же", "стрела"]}
+{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;", "translations": ["мозг", "мой", "я"]}
+{"prefix": " ", "surface": "яратмыйсыңмыни", "analysis": "яра+V+CAUS(т)+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT_MIR(мЫни);яра+V+CAUS(т)+NEG(мА)+PRES(Й)+2SG(сЫң)+INT_MIR(мЫни);ярат+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT_MIR(мЫни);ярат+V+NEG(мА)+PRES(Й)+2SG(сЫң)+INT_MIR(мЫни);", "translations": ["годиться", "рана", "любить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "абзыйдан", "analysis": "абзый+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "сорарга", "analysis": "сора+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "менгән", "analysis": "мен+V+PCP_PS(ГАн);мен+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сине", "analysis": "син+PN+ACC(нЫ);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "абзыйдан", "analysis": "абзый+N+Sg+ABL(ДАн);", "translations": ["дядя"]}
+{"prefix": " ", "surface": "сорарга", "analysis": "сора+V+INF_1(ЫргА);", "translations": ["спрашивать", "спросить"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "менгән", "analysis": "мен+V+PCP_PS(ГАн);мен+V+PST_INDF(ГАн);", "translations": ["подниматься", "подняться"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "ялгыз", "analysis": "ялгыз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "күңелсез", "analysis": "күңел+N+Sg+ATTR_ABES(сЫз)+Nom;"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ялгыз", "analysis": "ялгыз+N+Sg+Nom;", "translations": ["одинокий"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "күңелсез", "analysis": "күңел+N+Sg+ATTR_ABES(сЫз)+Nom;", "translations": ["душа"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "боргаланып", "analysis": "бор+V+RAR_1(ГАлА)+REFL(Ын)+ADVV_ACC(Ып);боргала+V+REFL(Ын)+ADVV_ACC(Ып);боргалан+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "боргаланып", "analysis": "бор+V+RAR_1(ГАлА)+REFL(Ын)+ADVV_ACC(Ып);боргала+V+REFL(Ын)+ADVV_ACC(Ып);боргалан+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "һай", "analysis": "һай+INTRJ;"}
@@ -4713,72 +4713,72 @@
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "ямьсез", "analysis": "ямь+N+ATTR_ABES(сЫз)+Nom;ямьсез+Adj;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "килешсез", "analysis": "кил+V+VN_2(Ыш)+2PL(сЫз);кил+V+VN_2(Ыш)+ATTR_ABES(сЫз)+Sg+Nom;килеш+N+ATTR_ABES(сЫз)+Sg+Nom;килеш+N+Sg+2PL(сЫз);"}
+{"prefix": " ", "surface": "килешсез", "analysis": "кил+V+VN_2(Ыш)+2PL(сЫз);кил+V+VN_2(Ыш)+ATTR_ABES(сЫз)+Sg+Nom;килеш+N+ATTR_ABES(сЫз)+Sg+Nom;килеш+N+Sg+2PL(сЫз);", "translations": ["идти", "согласиться", "соглашаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кызларның", "analysis": "кыз+N+PL(ЛАр)+GEN(нЫң);"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "аларның", "analysis": "алар+PN+GEN(нЫң);"}
+{"prefix": " ", "surface": "Кызларның", "analysis": "кыз+N+PL(ЛАр)+GEN(нЫң);", "translations": ["девушка", "дочь"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "аларның", "analysis": "алар+PN+GEN(нЫң);", "translations": ["они"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "алар", "analysis": "алар+PN;"}
-{"prefix": " ", "surface": "һәрвакыт", "analysis": "һәрвакыт+PN;"}
+{"prefix": " ", "surface": "алар", "analysis": "алар+PN;", "translations": ["они"]}
+{"prefix": " ", "surface": "һәрвакыт", "analysis": "һәрвакыт+PN;", "translations": ["всегда"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "һавалы", "analysis": "һава+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "булалар", "analysis": "бул+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "һавалы", "analysis": "һава+N+ATTR_MUN(лЫ);", "translations": ["воздухь¹", "воздушный", "погода"]}
+{"prefix": " ", "surface": "булалар", "analysis": "бул+V+PRES(Й)+3PL(ЛАр);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кызлар", "analysis": "кыз+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "алар", "analysis": "алар+PN;"}
+{"prefix": " ", "surface": "Кызлар", "analysis": "кыз+N+PL(ЛАр)+Nom;", "translations": ["девушка", "дочь"]}
+{"prefix": " ", "surface": "алар", "analysis": "алар+PN;", "translations": ["они"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "яшь", "analysis": "яшь+Adj;яшь+N+Sg+Nom;"}
+{"prefix": " ", "surface": "яшь", "analysis": "яшь+Adj;яшь+N+Sg+Nom;", "translations": ["возраст", "год²", "молодой", "юный"]}
 {"prefix": " ", "surface": "чагындарак", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "патшага", "analysis": "патша+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "торалар", "analysis": "тор+V+PRES(Й)+3PL(ЛАр);тора+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "патшага", "analysis": "патша+N+Sg+DIR(ГА);", "translations": ["царь"]}
+{"prefix": " ", "surface": "барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "торалар", "analysis": "тор+V+PRES(Й)+3PL(ЛАр);тора+N+PL(ЛАр)+Nom;", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);"}
+{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "ары", "analysis": "ар+N+Sg+POSS_3(СЫ)+Nom;ары+Adj;ары+V+IMP_SG();"}
+{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ары", "analysis": "ар+N+Sg+POSS_3(СЫ)+Nom;ары+Adj;ары+V+IMP_SG();", "translations": ["дальше", "после", "устать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "санаткаСанат", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "сенатор", "analysis": "сенатор+N+Sg+Nom;"}
-{"prefix": " ", "surface": "сүзеннән", "analysis": "сүз+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "үзгәртелгән", "analysis": "үзгәр+V+CAUS(т)+PASS(Ыл)+PCP_PS(ГАн);үзгәр+V+CAUS(т)+PASS(Ыл)+PST_INDF(ГАн);үзгәрт+V+PASS(Ыл)+PCP_PS(ГАн);үзгәрт+V+PASS(Ыл)+PST_INDF(ГАн);үзгәртел+V+PCP_PS(ГАн);үзгәртел+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "сүзеннән", "analysis": "сүз+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["слово"]}
+{"prefix": " ", "surface": "үзгәртелгән", "analysis": "үзгәр+V+CAUS(т)+PASS(Ыл)+PCP_PS(ГАн);үзгәр+V+CAUS(т)+PASS(Ыл)+PST_INDF(ГАн);үзгәрт+V+PASS(Ыл)+PCP_PS(ГАн);үзгәрт+V+PASS(Ыл)+PST_INDF(ГАн);үзгәртел+V+PCP_PS(ГАн);үзгәртел+V+PST_INDF(ГАн);", "translations": ["измениться", "изменяться", "изменить", "изменять"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "биредә", "analysis": "биредә+Adv;"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "түрә", "analysis": "түрә+N+Sg+Nom;"}
+{"prefix": "", "surface": "түрә", "analysis": "түрә+N+Sg+Nom;", "translations": ["начальник"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "мәгънәсендә", "analysis": "мәгънә+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
+{"prefix": " ", "surface": "мәгънәсендә", "analysis": "мәгънә+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["смысл"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтәләр", "analysis": "әйт+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтәләр", "analysis": "әйт+V+PRES(Й)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);"}
+{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": " ", "surface": "эләкмәгәч", "analysis": "эләк+V+NEG(мА)+ADVV_ANT(ГАч);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "актыгында", "analysis": "актык+Adj+Sg+POSS_3(СЫ)+LOC(ДА);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "солдат", "analysis": "солдат+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "әйтәләр", "analysis": "әйт+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "солдат", "analysis": "солдат+N+Sg+Nom;", "translations": ["солдат"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр);яра+V+FUT_INDF(Ыр);яра+V+PCP_FUT(Ыр);ярар+MOD;", "translations": ["берег", "годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әйтәләр", "analysis": "әйт+V+PRES(Й)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);"}
+{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -4786,56 +4786,56 @@
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "мыскыл", "analysis": "мыскыл+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итмә", "analysis": "и+V+CAUS(т)+NEG(мА)+IMP_SG();ит+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "итмә", "analysis": "и+V+CAUS(т)+NEG(мА)+IMP_SG();ит+V+NEG(мА)+IMP_SG();", "translations": ["быть", "делать", "мясо", "сделать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom;чык+V+IMP_SG();"}
+{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom;чык+V+IMP_SG();", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайтыр", "analysis": "кайт+V+FUT_INDF(Ыр);кайт+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
+{"prefix": " ", "surface": "кайтыр", "analysis": "кайт+V+FUT_INDF(Ыр);кайт+V+PCP_FUT(Ыр);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "абыстай", "analysis": "абыстай+N+Sg+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;"}
-{"prefix": " ", "surface": "менәр", "analysis": "мен+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv;", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "менәр", "analysis": "мен+V+PCP_FUT(Ыр);", "translations": ["подниматься", "подняться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Күптән", "analysis": "күп+Adj+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "әйтерләр", "analysis": "әйт+V+FUT_INDF(Ыр)+3PL(ЛАр);әйт+V+PCP_FUT(Ыр)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "Күптән", "analysis": "күп+Adj+Sg+ABL(ДАн);", "translations": ["много"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "әйтерләр", "analysis": "әйт+V+FUT_INDF(Ыр)+3PL(ЛАр);әйт+V+PCP_FUT(Ыр)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "синнән", "analysis": "син+PN+ABL(ДАн);"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "синнән", "analysis": "син+PN+ABL(ДАн);", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "баядан", "analysis": "NR"}
-{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;"}
+{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;", "translations": ["с"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "өйдәме", "analysis": "өй+N+Sg+LOC(ДА)+INT(мЫ);"}
+{"prefix": "", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
+{"prefix": " ", "surface": "өйдәме", "analysis": "өй+N+Sg+LOC(ДА)+INT(мЫ);", "translations": ["дом"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "сорыйм", "analysis": "сора+V+HOR_SG(Йм);сора+V+PRES(Й)+1SG(м);", "translations": ["спрашивать", "спросить"]}
 {"prefix": " ", "surface": "ич", "analysis": "ич+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "булмаса", "analysis": "бул+V+NEG(мА)+COND(сА);"}
+{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);", "translations": ["дом"]}
+{"prefix": " ", "surface": "булмаса", "analysis": "бул+V+NEG(мА)+COND(сА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хуш", "analysis": "хуш+Adj;хуш+INTRJ;"}
+{"prefix": " ", "surface": "хуш", "analysis": "хуш+Adj;хуш+INTRJ;", "translations": ["бодрый", "приятно", "приятный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сау", "analysis": "сау+Adj;сау+V+IMP_SG();"}
-{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();"}
+{"prefix": " ", "surface": "сау", "analysis": "сау+Adj;сау+V+IMP_SG();", "translations": ["здорово", "здоровый"]}
+{"prefix": " ", "surface": "бул", "analysis": "бул+V+IMP_SG();", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
@@ -4844,133 +4844,133 @@
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ялганлый", "analysis": "ялганла+V+PRES(Й);"}
-{"prefix": " ", "surface": "торгандыр", "analysis": "тор+V+PCP_PS(ГАн)+3SG(ДЫр);тор+V+PCP_PS(ГАн)+PROB(ДЫр);тор+V+PST_INDF(ГАн)+PROB(ДЫр);"}
-{"prefix": " ", "surface": "ла", "analysis": "ла+PART;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "торгандыр", "analysis": "тор+V+PCP_PS(ГАн)+3SG(ДЫр);тор+V+PCP_PS(ГАн)+PROB(ДЫр);тор+V+PST_INDF(ГАн)+PROB(ДЫр);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "ла", "analysis": "ла+PART;", "translations": ["бы", "же", "к сожалению"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "алдар", "analysis": "алда+V+FUT_INDF(Ыр);алда+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;"}
+{"prefix": " ", "surface": "мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;", "translations": ["мозг", "мой", "я"]}
+{"prefix": " ", "surface": "алдар", "analysis": "алда+V+FUT_INDF(Ыр);алда+V+PCP_FUT(Ыр);", "translations": ["впереди", "обмануть", "обманывать"]}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST;", "translations": ["для", "за"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "юри", "analysis": "юри+Adv;"}
+{"prefix": " ", "surface": "юри", "analysis": "юри+Adv;", "translations": ["нарочно"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);"}
+{"prefix": " ", "surface": "әйтә", "analysis": "әйт+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": "", "surface": "Кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бераздан", "analysis": "бераздан+Adv;"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);"}
+{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "кайтып", "analysis": "кайт+V+ADVV_ACC(Ып);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Күрмиенчә", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;"}
-{"prefix": " ", "surface": "төбенә", "analysis": "төп+Adj+Sg+POSS_3(СЫ)+DIR(ГА);төп+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "җәеп", "analysis": "җәй+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "куйган", "analysis": "куй+V+PCP_PS(ГАн);куй+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "ишек", "analysis": "ишек+N+Sg+Nom;", "translations": ["дверь"]}
+{"prefix": " ", "surface": "төбенә", "analysis": "төп+Adj+Sg+POSS_3(СЫ)+DIR(ГА);төп+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["главный", "дно", "основной"]}
+{"prefix": " ", "surface": "җәеп", "analysis": "җәй+V+ADVV_ACC(Ып);", "translations": ["лето"]}
+{"prefix": " ", "surface": "куйган", "analysis": "куй+V+PCP_PS(ГАн);куй+V+PST_INDF(ГАн);", "translations": ["баран", "класть", "положить"]}
 {"prefix": " ", "surface": "паласка", "analysis": "палас+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "сөртенә", "analysis": "сөр+V+CAUS(т)+REFL(Ын)+PRES(Й);сөрт+V+REFL(Ын)+PRES(Й);сөртен+V+PRES(Й);"}
+{"prefix": " ", "surface": "сөртенә", "analysis": "сөр+V+CAUS(т)+REFL(Ын)+PRES(Й);сөрт+V+REFL(Ын)+PRES(Й);сөртен+V+PRES(Й);", "translations": ["вытереть", "вытирать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "кычкырып", "analysis": "кычкыр+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "кычкырып", "analysis": "кычкыр+V+ADVV_ACC(Ып);", "translations": ["крикнуть", "кричать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Гөнаһ", "analysis": "гөнаһ+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Гөнаһ", "analysis": "гөнаһ+N+Sg+Nom;", "translations": ["грех"]}
 {"prefix": " ", "surface": "шомлыклары", "analysis": "шом+N+NMLZ(лЫк)+PL(ЛАр)+POSS_3(СЫ)+Nom;шом+N+PSBL(лЫк)+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аяк", "analysis": "аяк+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Аяк", "analysis": "аяк+N+Sg+Nom;", "translations": ["нога", "ножка"]}
 {"prefix": " ", "surface": "астына", "analysis": "ас+N+Sg+POSS_3(СЫ)+DIR(ГА);ас+V+CAUS(т)+REFL(Ын)+PRES(Й);астына+POST;"}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "җәеп", "analysis": "җәй+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "куйганнар", "analysis": "куй+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;куй+V+PST_INDF(ГАн)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "җәеп", "analysis": "җәй+V+ADVV_ACC(Ып);", "translations": ["лето"]}
+{"prefix": " ", "surface": "куйганнар", "analysis": "куй+V+PCP_PS(ГАн)+PL(ЛАр)+Nom;куй+V+PST_INDF(ГАн)+3PL(ЛАр);", "translations": ["баран", "класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мал", "analysis": "мал+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кадерен", "analysis": "кадер+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "белмиләр", "analysis": "бел+V+NEG(мА)+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "Мал", "analysis": "мал+N+Sg+Nom;", "translations": ["скот.sg", "товар"]}
+{"prefix": " ", "surface": "кадерен", "analysis": "кадер+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["ценность"]}
+{"prefix": " ", "surface": "белмиләр", "analysis": "бел+V+NEG(мА)+PRES(Й)+3PL(ЛАр);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тыштан", "analysis": "тыш+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "Тыштан", "analysis": "тыш+N+Sg+ABL(ДАн);", "translations": ["кроме", "наружность", "улица"]}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "күзлек", "analysis": "күз+N+NMLZ(лЫк)+Sg+Nom;күз+N+PSBL(лЫк);күзлек+N+Sg+Nom;"}
+{"prefix": " ", "surface": "күзлек", "analysis": "күз+N+NMLZ(лЫк)+Sg+Nom;күз+N+PSBL(лЫк);күзлек+N+Sg+Nom;", "translations": ["глаз", "очко"]}
 {"prefix": " ", "surface": "парлана", "analysis": "парла+V+REFL(Ын)+PRES(Й);парлан+V+PRES(Й);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "бернәрсә", "analysis": "бернәрсә+PN;", "translations": ["ничто"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "күреп", "analysis": "күр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "күреп", "analysis": "күр+V+ADVV_ACC(Ып);", "translations": ["видеть"]}
+{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Күзлеген", "analysis": "күз+N+NMLZ(лЫк)+Sg+POSS_3(СЫ)+ACC(нЫ);күз+N+PSBL(лЫк)+POSS_3(СЫ)+ACC(нЫ);күзлек+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "сөртә", "analysis": "сөр+V+CAUS(т)+PRES(Й);сөрт+V+PRES(Й);"}
+{"prefix": "", "surface": "Күзлеген", "analysis": "күз+N+NMLZ(лЫк)+Sg+POSS_3(СЫ)+ACC(нЫ);күз+N+PSBL(лЫк)+POSS_3(СЫ)+ACC(нЫ);күзлек+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["глаз", "очко"]}
+{"prefix": " ", "surface": "сөртә", "analysis": "сөр+V+CAUS(т)+PRES(Й);сөрт+V+PRES(Й);", "translations": ["вытереть", "вытирать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Беркөн", "analysis": "беркөн+Adv;"}
-{"prefix": " ", "surface": "мәдрәсәгә", "analysis": "мәдрәсә+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "мәдрәсәгә", "analysis": "мәдрәсә+N+Sg+DIR(ГА);", "translations": ["медресе"]}
+{"prefix": " ", "surface": "кергәч", "analysis": "кер+V+ADVV_ANT(ГАч);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": " ", "surface": "тә", "analysis": "тә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "әчелектәгеәчелек", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "мәдрәсәдәге", "analysis": "мәдрәсә+N+Sg+ATTR_LOC(ДАгЫ);"}
-{"prefix": " ", "surface": "чишенү", "analysis": "чиш+V+REFL(Ын)+VN_1(у/ү/в)+Nom;чишен+V+VN_1(у/ү/в)+Nom;"}
-{"prefix": " ", "surface": "бүлмәсе", "analysis": "бүлмә+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": "", "surface": "мәдрәсәдәге", "analysis": "мәдрәсә+N+Sg+ATTR_LOC(ДАгЫ);", "translations": ["медресе"]}
+{"prefix": " ", "surface": "чишенү", "analysis": "чиш+V+REFL(Ын)+VN_1(у/ү/в)+Nom;чишен+V+VN_1(у/ү/в)+Nom;", "translations": ["решать", "решить"]}
+{"prefix": " ", "surface": "бүлмәсе", "analysis": "бүлмә+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["комната"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "башмакларга", "analysis": "башмак+N+PL(ЛАр)+DIR(ГА);"}
-{"prefix": " ", "surface": "сөртенеп", "analysis": "сөр+V+CAUS(т)+REFL(Ын)+ADVV_ACC(Ып);сөрт+V+REFL(Ын)+ADVV_ACC(Ып);сөртен+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "сөртенеп", "analysis": "сөр+V+CAUS(т)+REFL(Ын)+ADVV_ACC(Ып);сөрт+V+REFL(Ын)+ADVV_ACC(Ып);сөртен+V+ADVV_ACC(Ып);", "translations": ["вытереть", "вытирать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "лаканга", "analysis": "лакан+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "егылган", "analysis": "егыл+V+PCP_PS(ГАн);егыл+V+PST_INDF(ГАн);ек+V+PASS(Ыл)+PCP_PS(ГАн);ек+V+PASS(Ыл)+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "егылган", "analysis": "егыл+V+PCP_PS(ГАн);егыл+V+PST_INDF(ГАн);ек+V+PASS(Ыл)+PCP_PS(ГАн);ек+V+PASS(Ыл)+PST_INDF(ГАн);", "translations": ["свалиться"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишек", "analysis": "ишек+N+Sg+Nom;"}
-{"prefix": " ", "surface": "янындагы", "analysis": "ян+N+Sg+POSS_3(СЫ)+ATTR_LOC(ДАгЫ);"}
-{"prefix": " ", "surface": "урындыкка", "analysis": "урындык+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "утырып", "analysis": "утыр+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Ишек", "analysis": "ишек+N+Sg+Nom;", "translations": ["дверь"]}
+{"prefix": " ", "surface": "янындагы", "analysis": "ян+N+Sg+POSS_3(СЫ)+ATTR_LOC(ДАгЫ);", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
+{"prefix": " ", "surface": "урындыкка", "analysis": "урындык+N+Sg+DIR(ГА);", "translations": ["стул"]}
+{"prefix": " ", "surface": "утырып", "analysis": "утыр+V+ADVV_ACC(Ып);", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кайсыгыз", "analysis": "кайсы+PN+POSS_2PL(ЫгЫз)+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "кайсыгыз", "analysis": "кайсы+PN+POSS_2PL(ЫгЫз)+Nom;", "translations": ["какой"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аякны", "analysis": "аяк+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "тартыгыз", "analysis": "тарт+V+IMP_PL(ЫгЫз);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Аякны", "analysis": "аяк+N+Sg+ACC(нЫ);", "translations": ["нога", "ножка"]}
+{"prefix": " ", "surface": "тартыгыз", "analysis": "тарт+V+IMP_PL(ЫгЫз);", "translations": ["тянуть"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кил", "analysis": "кил+V+IMP_SG();"}
+{"prefix": " ", "surface": "кил", "analysis": "кил+V+IMP_SG();", "translations": ["идти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": " ", "surface": "терәлеп", "analysis": "терә+V+PASS(Ыл)+ADVV_ACC(Ып);терәл+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торасың", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тор+V+PRES(Й)+2SG(сЫң);тора+N+Sg+2SG(сЫң);"}
+{"prefix": " ", "surface": "торасың", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тор+V+PRES(Й)+2SG(сЫң);тора+N+Sg+2SG(сЫң);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тарт", "analysis": "тарт+V+IMP_SG();"}
-{"prefix": " ", "surface": "аякны", "analysis": "аяк+N+Sg+ACC(нЫ);"}
+{"prefix": " ", "surface": "тарт", "analysis": "тарт+V+IMP_SG();", "translations": ["тянуть"]}
+{"prefix": " ", "surface": "аякны", "analysis": "аяк+N+Sg+ACC(нЫ);", "translations": ["нога", "ножка"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "салдыра", "analysis": "сал+V+CAUS(ДЫр)+PRES(Й);салдыр+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": " ", "surface": "салдыра", "analysis": "сал+V+CAUS(ДЫр)+PRES(Й);салдыр+V+PRES(Й);", "translations": ["класть", "положить"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Чү", "analysis": "чү+INTRJ;"}
@@ -4979,76 +4979,76 @@
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "чү", "analysis": "чү+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тарт", "analysis": "тарт+V+IMP_SG();"}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "тарт", "analysis": "тарт+V+IMP_SG();", "translations": ["тянуть"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "МәсихемнеМәсих", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "тәһарәтнең", "analysis": "тәһарәт+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "өлеше", "analysis": "өлеш+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "өлеше", "analysis": "өлеш+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["доля"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "читек", "analysis": "читек+N+Sg+Nom;"}
-{"prefix": " ", "surface": "өстеннән", "analysis": "өс+N+Sg+POSS_3(СЫ)+ABL(ДАн);өстен+Adj+Sg+ABL(ДАн);өстеннән+POST;"}
-{"prefix": " ", "surface": "су", "analysis": "су+N+Sg+Nom;"}
-{"prefix": " ", "surface": "йөгертү", "analysis": "йөгер+V+CAUS(т)+VN_1(у/ү/в)+Nom;йөгерт+V+VN_1(у/ү/в)+Nom;"}
+{"prefix": " ", "surface": "өстеннән", "analysis": "өс+N+Sg+POSS_3(СЫ)+ABL(ДАн);өстен+Adj+Sg+ABL(ДАн);өстеннән+POST;", "translations": ["господствующий", "превосходить"]}
+{"prefix": " ", "surface": "су", "analysis": "су+N+Sg+Nom;", "translations": ["вода"]}
+{"prefix": " ", "surface": "йөгертү", "analysis": "йөгер+V+CAUS(т)+VN_1(у/ү/в)+Nom;йөгерт+V+VN_1(у/ү/в)+Nom;", "translations": ["бегать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "бозма", "analysis": "боз+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "бозма", "analysis": "боз+V+NEG(мА)+IMP_SG();", "translations": ["испортить", "лед/лёд", "лёд"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Абыстаң", "analysis": "абыста+N+Sg+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;"}
-{"prefix": " ", "surface": "итекнең", "analysis": "итек+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "берсен", "analysis": "бер+PN+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "салдыра", "analysis": "сал+V+CAUS(ДЫр)+PRES(Й);салдыр+V+PRES(Й);"}
+{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;", "translations": ["войлок"]}
+{"prefix": " ", "surface": "итекнең", "analysis": "итек+N+Sg+GEN(нЫң);", "translations": ["сапог"]}
+{"prefix": " ", "surface": "берсен", "analysis": "бер+PN+POSS_3(СЫ)+ACC(нЫ);", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "салдыра", "analysis": "сал+V+CAUS(ДЫр)+PRES(Й);салдыр+V+PRES(Й);", "translations": ["класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аш", "analysis": "аш+N+Sg+Nom;"}
-{"prefix": " ", "surface": "өендә", "analysis": "өй+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
+{"prefix": " ", "surface": "Аш", "analysis": "аш+N+Sg+Nom;", "translations": ["еда", "пища"]}
+{"prefix": " ", "surface": "өендә", "analysis": "өй+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["дом"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Нишли", "analysis": "нишлә+V+PRES(Й);"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аш", "analysis": "аш+N+Sg+Nom;"}
-{"prefix": " ", "surface": "пешерә", "analysis": "пешер+V+PRES(Й);"}
+{"prefix": " ", "surface": "Аш", "analysis": "аш+N+Sg+Nom;", "translations": ["еда", "пища"]}
+{"prefix": " ", "surface": "пешерә", "analysis": "пешер+V+PRES(Й);", "translations": ["варить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;"}
+{"prefix": " ", "surface": "Ник", "analysis": "ник+PN;", "translations": ["зачем", "почему"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "килен", "analysis": "кил+V+REFL(Ын)+IMP_SG();килен+N+Sg+Nom;киль+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "килен", "analysis": "кил+V+REFL(Ын)+IMP_SG();килен+N+Sg+Nom;киль+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["идти", "невеста"]}
+{"prefix": " ", "surface": "кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алар", "analysis": "алар+PN;"}
+{"prefix": " ", "surface": "Алар", "analysis": "алар+PN;", "translations": ["они"]}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
-{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
+{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom;", "translations": ["брат", "дядя"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
-{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
+{"prefix": " ", "surface": "ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "кодаларга", "analysis": "кода+N+PL(ЛАр)+DIR(ГА);кодала+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Xәмзә", "analysis": "Error"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ныграк", "analysis": "нык+Adj+COMP(рАк)+Sg+Nom;нык+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "тарт", "analysis": "тарт+V+IMP_SG();"}
+{"prefix": " ", "surface": "Ныграк", "analysis": "нык+Adj+COMP(рАк)+Sg+Nom;нык+Adv+COMP(рАк)+Sg+Nom;", "translations": ["крепкий", "крепко"]}
+{"prefix": " ", "surface": "тарт", "analysis": "тарт+V+IMP_SG();", "translations": ["тянуть"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кулың", "analysis": "ку+N+ATTR_MUN(лЫ)+Sg+POSS_2SG(Ың)+Nom;кул+N+Sg+POSS_2SG(Ың)+Nom;"}
+{"prefix": " ", "surface": "Кулың", "analysis": "ку+N+ATTR_MUN(лЫ)+Sg+POSS_2SG(Ың)+Nom;кул+N+Sg+POSS_2SG(Ың)+Nom;", "translations": ["рука"]}
 {"prefix": " ", "surface": "чергән", "analysis": "чер+V+PCP_PS(ГАн);чер+V+PST_INDF(ГАн);"}
 {"prefix": " ", "surface": "мәллә", "analysis": "мәллә+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
@@ -5056,235 +5056,235 @@
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "кинәттән", "analysis": "кинәттән+Adv;"}
-{"prefix": " ", "surface": "тартып", "analysis": "тарт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "җибәреп", "analysis": "җибәр+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "тартып", "analysis": "тарт+V+ADVV_ACC(Ып);", "translations": ["тянуть"]}
+{"prefix": " ", "surface": "җибәреп", "analysis": "җибәр+V+ADVV_ACC(Ып);", "translations": ["пускать", "пустить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Хәмзәне", "analysis": "хәмзә+PROP+ACC(нЫ);"}
 {"prefix": " ", "surface": "егып", "analysis": "ек+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "төшерә", "analysis": "төшер+V+PRES(Й);"}
+{"prefix": " ", "surface": "төшерә", "analysis": "төшер+V+PRES(Й);", "translations": ["опускать", "опустить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "һай", "analysis": "һай+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бәдбәхет", "analysis": "бәдбәхет+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Күзең", "analysis": "күз+N+Sg+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "чыккан", "analysis": "чык+V+PCP_PS(ГАн);чык+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "Күзең", "analysis": "күз+N+Sg+POSS_2SG(Ың)+Nom;", "translations": ["глаз"]}
+{"prefix": " ", "surface": "чыккан", "analysis": "чык+V+PCP_PS(ГАн);чык+V+PST_INDF(ГАн);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кит", "analysis": "кит+V+IMP_SG();"}
+{"prefix": " ", "surface": "кит", "analysis": "кит+V+IMP_SG();", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "күземә", "analysis": "күз+N+Sg+POSS_1SG(Ым)+DIR(ГА);"}
-{"prefix": " ", "surface": "күренмә", "analysis": "күр+V+REFL(Ын)+NEG(мА)+IMP_SG();күрен+V+NEG(мА)+IMP_SG();"}
+{"prefix": " ", "surface": "күземә", "analysis": "күз+N+Sg+POSS_1SG(Ым)+DIR(ГА);", "translations": ["глаз"]}
+{"prefix": " ", "surface": "күренмә", "analysis": "күр+V+REFL(Ын)+NEG(мА)+IMP_SG();күрен+V+NEG(мА)+IMP_SG();", "translations": ["видеть"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "мәшәкатьләнеп", "analysis": "мәшәкатьлә+V+REFL(Ын)+ADVV_ACC(Ып);мәшәкатьлән+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аягын", "analysis": "аяк+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "салып", "analysis": "сал+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетерә", "analysis": "бетер+V+PRES(Й);"}
+{"prefix": " ", "surface": "аягын", "analysis": "аяк+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["нога", "ножка"]}
+{"prefix": " ", "surface": "салып", "analysis": "сал+V+ADVV_ACC(Ып);", "translations": ["класть", "положить"]}
+{"prefix": " ", "surface": "бетерә", "analysis": "бетер+V+PRES(Й);", "translations": ["заканчивать", "кончать", "кончить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);"}
+{"prefix": " ", "surface": "Башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "булса", "analysis": "бул+V+COND(сА);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "аңар", "analysis": "NR"}
-{"prefix": " ", "surface": "кирәген", "analysis": "кирәк+Adj+Sg+POSS_3(СЫ)+ACC(нЫ);кирәк+MOD+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "биргән", "analysis": "бир+V+PCP_PS(ГАн);бир+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
-{"prefix": " ", "surface": "булуын", "analysis": "бул+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "кирәген", "analysis": "кирәк+Adj+Sg+POSS_3(СЫ)+ACC(нЫ);кирәк+MOD+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["необходимый", "нужный"]}
+{"prefix": " ", "surface": "биргән", "analysis": "бир+V+PCP_PS(ГАн);бир+V+PST_INDF(ГАн);", "translations": ["давать", "даваться", "дать"]}
+{"prefix": " ", "surface": "булыр", "analysis": "бул+V+FUT_INDF(Ыр);бул+V+PCP_FUT(Ыр);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
+{"prefix": " ", "surface": "булуын", "analysis": "бул+V+VN_1(у/ү/в)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "әллә", "analysis": "әллә+CNJ;әллә+PART;"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кыз", "analysis": "кыз+N+Sg+Nom;кыз+V+IMP_SG();"}
-{"prefix": " ", "surface": "балага", "analysis": "бала+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "сугарга", "analysis": "сук+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
-{"prefix": " ", "surface": "кул", "analysis": "кул+N+Sg+Nom;"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "җитми", "analysis": "җит+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "кыз", "analysis": "кыз+N+Sg+Nom;кыз+V+IMP_SG();", "translations": ["девушка", "дочь"]}
+{"prefix": " ", "surface": "балага", "analysis": "бала+N+Sg+DIR(ГА);", "translations": ["ребёнок"]}
+{"prefix": " ", "surface": "сугарга", "analysis": "сук+V+INF_1(ЫргА);", "translations": ["бить", "побить"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
+{"prefix": " ", "surface": "кул", "analysis": "кул+N+Sg+Nom;", "translations": ["рука"]}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "җитми", "analysis": "җит+V+NEG(мА)+PRES(Й);", "translations": ["дойти", "доходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Тунын", "analysis": "тун+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "салып", "analysis": "сал+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Тунын", "analysis": "тун+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["шуба"]}
+{"prefix": " ", "surface": "салып", "analysis": "сал+V+ADVV_ACC(Ып);", "translations": ["класть", "положить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "чөйгә", "analysis": "чөй+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "элеп", "analysis": "эл+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);"}
+{"prefix": " ", "surface": "элеп", "analysis": "эл+V+ADVV_ACC(Ып);", "translations": ["повесить"]}
+{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);", "translations": ["баран", "класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Бүген", "analysis": "бүген+Adv;"}
-{"prefix": " ", "surface": "иртә", "analysis": "иртә+Adv;иртә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бүген", "analysis": "бүген+Adv;", "translations": ["сегодня", "сегодняшний"]}
+{"prefix": " ", "surface": "иртә", "analysis": "иртә+Adv;иртә+N+Sg+Nom;", "translations": ["ранний", "рано", "раньше", "утро"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();", "translations": ["волос"]}
 {"prefix": " ", "surface": "алучыга", "analysis": "NR"}
-{"prefix": " ", "surface": "кергән", "analysis": "кер+V+PCP_PS(ГАн);кер+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "кергән", "analysis": "кер+V+PCP_PS(ГАн);кер+V+PST_INDF(ГАн);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;"}
-{"prefix": " ", "surface": "ишегеннән", "analysis": "ишек+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "керер", "analysis": "кер+V+FUT_INDF(Ыр);кер+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "хәл", "analysis": "хәл+N+Sg+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;", "translations": ["совсем", "целиком"]}
+{"prefix": " ", "surface": "ишегеннән", "analysis": "ишек+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "керер", "analysis": "кер+V+FUT_INDF(Ыр);кер+V+PCP_FUT(Ыр);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "хәл", "analysis": "хәл+N+Sg+Nom;", "translations": ["состояние"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "җыен", "analysis": "җыен+N+Sg+Nom;җыен+PN;җыен+V+IMP_SG();җый+V+REFL(Ын)+IMP_SG();"}
-{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;"}
-{"prefix": " ", "surface": "авыз", "analysis": "авыз+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;"}
+{"prefix": " ", "surface": "җыен", "analysis": "җыен+N+Sg+Nom;җыен+PN;җыен+V+IMP_SG();җый+V+REFL(Ын)+IMP_SG();", "translations": ["сбор", "собираться", "собраться", "собирать", "собрать"]}
+{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;", "translations": ["красно", "красный"]}
+{"prefix": " ", "surface": "авыз", "analysis": "авыз+N+Sg+Nom;", "translations": ["рот"]}
+{"prefix": " ", "surface": "кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;", "translations": ["магазин"]}
 {"prefix": " ", "surface": "тулган", "analysis": "тул+V+PCP_PS(ГАн);тул+V+PST_INDF(ГАн);тулга+V+REFL(Ын)+IMP_SG();тулган+V+IMP_SG();"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Байларына", "analysis": "бай+N+PL(ЛАр)+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;"}
-{"prefix": " ", "surface": "әйләнеп", "analysis": "әйлән+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Байларына", "analysis": "бай+N+PL(ЛАр)+POSS_3(СЫ)+DIR(ГА);", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "бөтенләй", "analysis": "бөтенләй+Adv;", "translations": ["совсем", "целиком"]}
+{"prefix": " ", "surface": "әйләнеп", "analysis": "әйлән+V+ADVV_ACC(Ып);", "translations": ["крутиться"]}
 {"prefix": " ", "surface": "тә", "analysis": "тә+PART;"}
-{"prefix": " ", "surface": "карамыйлар", "analysis": "кара+V+NEG(мА)+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "карамыйлар", "analysis": "кара+V+NEG(мА)+PRES(Й)+3PL(ЛАр);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();"}
+{"prefix": " ", "surface": "чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();", "translations": ["волос"]}
 {"prefix": " ", "surface": "алучысы", "analysis": "NR"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "һич", "analysis": "һич+PN;"}
-{"prefix": " ", "surface": "санга", "analysis": "сан+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "санамый", "analysis": "сана+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "һич", "analysis": "һич+PN;", "translations": ["совсем"]}
+{"prefix": " ", "surface": "санга", "analysis": "сан+N+Sg+DIR(ГА);", "translations": ["количество", "цена", "число"]}
+{"prefix": " ", "surface": "санамый", "analysis": "сана+V+NEG(мА)+PRES(Й);", "translations": ["считать"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Хаҗи", "analysis": "хаҗи+N+Sg+Nom;"}
+{"prefix": "", "surface": "Хаҗи", "analysis": "хаҗи+N+Sg+Nom;", "translations": ["хаджи"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "көнне", "analysis": "көн+N+Sg+ACC(нЫ);"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "көнне", "analysis": "көн+N+Sg+ACC(нЫ);", "translations": ["день"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "керерсең", "analysis": "кер+V+FUT_INDF(Ыр)+2SG(сЫң);кер+V+PCP_FUT(Ыр)+2SG(сЫң);"}
+{"prefix": " ", "surface": "керерсең", "analysis": "кер+V+FUT_INDF(Ыр)+2SG(сЫң);кер+V+PCP_FUT(Ыр)+2SG(сЫң);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "һәрвакытта", "analysis": "һәрвакыт+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "вакытың", "analysis": "вакыт+N+Sg+POSS_2SG(Ың)+Nom;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "һәрвакытта", "analysis": "һәрвакыт+PN+LOC(ДА);", "translations": ["всегда"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "вакытың", "analysis": "вакыт+N+Sg+POSS_2SG(Ың)+Nom;", "translations": ["время", "пора"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "болар", "analysis": "бу+PN+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
-{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кешесе", "analysis": "кеше+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "болар", "analysis": "бу+PN+PL(ЛАр)+Nom;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "кешесе", "analysis": "кеше+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["человек"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "җомга", "analysis": "җомга+N+Sg+Nom;"}
-{"prefix": " ", "surface": "көннән", "analysis": "көн+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;"}
-{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "вакытлары", "analysis": "вакыт+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);"}
+{"prefix": " ", "surface": "җомга", "analysis": "җомга+N+Sg+Nom;", "translations": ["пятница"]}
+{"prefix": " ", "surface": "көннән", "analysis": "көн+N+Sg+ABL(ДАн);", "translations": ["день"]}
+{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА);башка+Adj;башка+POST;", "translations": ["голова", "другой", "кроме"]}
+{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);", "translations": ["время", "пора"]}
+{"prefix": " ", "surface": "вакытлары", "analysis": "вакыт+N+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["время", "пора"]}
+{"prefix": " ", "surface": "булмый", "analysis": "бул+V+NEG(мА)+PRES(Й);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "авызын", "analysis": "авыз+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "авызын", "analysis": "авыз+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["рот"]}
 {"prefix": " ", "surface": "җырып", "analysis": "NR"}
-{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;", "translations": ["но", "только"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чалбар", "analysis": "чалбар+N+Sg+Nom;"}
+{"prefix": "", "surface": "Чалбар", "analysis": "чалбар+N+Sg+Nom;", "translations": ["брюки"]}
 {"prefix": " ", "surface": "балагын", "analysis": "балак+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "җыеп", "analysis": "җый+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бәйләп", "analysis": "бәйлә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "куйган", "analysis": "куй+V+PCP_PS(ГАн);куй+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "җыеп", "analysis": "җый+V+ADVV_ACC(Ып);", "translations": ["собирать", "собрать"]}
+{"prefix": " ", "surface": "бәйләп", "analysis": "бәйлә+V+ADVV_ACC(Ып);", "translations": ["связать", "связывать"]}
+{"prefix": " ", "surface": "куйган", "analysis": "куй+V+PCP_PS(ГАн);куй+V+PST_INDF(ГАн);", "translations": ["баран", "класть", "положить"]}
 {"prefix": " ", "surface": "тасмаларын", "analysis": "тасма+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "чишә", "analysis": "чиш+V+PRES(Й);"}
+{"prefix": " ", "surface": "чишә", "analysis": "чиш+V+PRES(Й);", "translations": ["решать", "решить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Алары", "analysis": "алар+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
-{"prefix": " ", "surface": "кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "яклы", "analysis": "як+N+ATTR_MUN(лЫ);"}
+{"prefix": " ", "surface": "Алары", "analysis": "алар+PN+POSS_3(СЫ)+Nom;", "translations": ["они"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;", "translations": ["магазин"]}
+{"prefix": " ", "surface": "яклы", "analysis": "як+N+ATTR_MUN(лЫ);", "translations": ["сжечь", "сторона"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аларга", "analysis": "алар+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "яклы", "analysis": "як+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "булмыйча", "analysis": "бул+V+NEG(мА)+ADVV_NEG(ЙчА);"}
-{"prefix": " ", "surface": "ярыймы", "analysis": "яра+V+PRES(Й)+INT(мЫ);ярый+MOD+INT(мЫ);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "Аларга", "analysis": "алар+PN+DIR(ГА);", "translations": ["они"]}
+{"prefix": " ", "surface": "кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;", "translations": ["магазин"]}
+{"prefix": " ", "surface": "яклы", "analysis": "як+N+ATTR_MUN(лЫ);", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "булмыйча", "analysis": "бул+V+NEG(мА)+ADVV_NEG(ЙчА);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "ярыймы", "analysis": "яра+V+PRES(Й)+INT(мЫ);ярый+MOD+INT(мЫ);", "translations": ["годиться", "рана", "ладно"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;"}
-{"prefix": " ", "surface": "аларга", "analysis": "алар+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "унар", "analysis": "ун+Num+NUM_DISR(шАр);"}
+{"prefix": " ", "surface": "Кибетчеләр", "analysis": "кибет+N+PROF(чЫ)+PL(ЛАр)+Nom;", "translations": ["магазин"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom;бит+PART;", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "аларга", "analysis": "алар+PN+DIR(ГА);", "translations": ["они"]}
+{"prefix": " ", "surface": "унар", "analysis": "ун+Num+NUM_DISR(шАр);", "translations": ["десятый", "десять"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "унбишәр", "analysis": "унбиш+Num+NUM_DISR(шАр);"}
-{"prefix": " ", "surface": "тиенләп", "analysis": "тиен+N+DISTR(лАп);"}
-{"prefix": " ", "surface": "яудыралар", "analysis": "яу+V+CAUS(ДЫр)+PRES(Й)+3PL(ЛАр);яудыр+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "унбишәр", "analysis": "унбиш+Num+NUM_DISR(шАр);", "translations": ["пятнадцатый", "пятнадцать"]}
+{"prefix": " ", "surface": "тиенләп", "analysis": "тиен+N+DISTR(лАп);", "translations": ["копейка"]}
+{"prefix": " ", "surface": "яудыралар", "analysis": "яу+V+CAUS(ДЫр)+PRES(Й)+3PL(ЛАр);яудыр+V+PRES(Й)+3PL(ЛАр);", "translations": ["войско", "идти", "падать", "упасть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аларга", "analysis": "алар+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;"}
-{"prefix": " ", "surface": "акчасы", "analysis": "ак+Adj+EQU(чА)+POSS_3(СЫ)+Nom;акча+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "кызганычмыни", "analysis": "кызганыч+Adj+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "Аларга", "analysis": "алар+PN+DIR(ГА);", "translations": ["они"]}
+{"prefix": " ", "surface": "бай", "analysis": "бай+N+Sg+Nom;", "translations": ["богатый", "богач"]}
+{"prefix": " ", "surface": "акчасы", "analysis": "ак+Adj+EQU(чА)+POSS_3(СЫ)+Nom;акча+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["белый", "деньги"]}
+{"prefix": " ", "surface": "кызганычмыни", "analysis": "кызганыч+Adj+INT_MIR(мЫни);", "translations": ["жалкий", "жалко"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
+{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;"}
-{"prefix": " ", "surface": "дисез", "analysis": "ди+V+PRES(Й)+2PL(сЫз);"}
+{"prefix": " ", "surface": "Нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "дисез", "analysis": "ди+V+PRES(Й)+2PL(сЫз);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "абзый", "analysis": "абзый+N+Sg+Nom;"}
+{"prefix": " ", "surface": "абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Xәмзә", "analysis": "Error"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "берәрсенә", "analysis": "NR"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мәдрәсәдәге", "analysis": "мәдрәсә+N+Sg+ATTR_LOC(ДАгЫ);"}
+{"prefix": " ", "surface": "мәдрәсәдәге", "analysis": "мәдрәсә+N+Sg+ATTR_LOC(ДАгЫ);", "translations": ["медресе"]}
 {"prefix": " ", "surface": "Коръән", "analysis": "коръән+N+Sg+Nom;"}
-{"prefix": " ", "surface": "укый", "analysis": "укы+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "шәкертне", "analysis": "шәкерт+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "чакырып", "analysis": "чакыр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыксыннар", "analysis": "чык+V+JUS_PL(сЫннАр);"}
+{"prefix": " ", "surface": "укый", "analysis": "укы+V+PRES(Й);", "translations": ["прочитать", "учиться", "читать"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "шәкертне", "analysis": "шәкерт+N+Sg+ACC(нЫ);", "translations": ["студент"]}
+{"prefix": " ", "surface": "чакырып", "analysis": "чакыр+V+ADVV_ACC(Ып);", "translations": ["звать", "позвать", "приглашение", "призвать", "призывать"]}
+{"prefix": " ", "surface": "чыксыннар", "analysis": "чык+V+JUS_PL(сЫннАр);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();"}
-{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "чакыра", "analysis": "чакыр+V+PRES(Й);"}
+{"prefix": "", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
+{"prefix": " ", "surface": "чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();", "translations": ["волос"]}
+{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "чакыра", "analysis": "чакыр+V+PRES(Й);", "translations": ["звать", "позвать", "приглашение", "призвать", "призывать"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дисеннәр", "analysis": "ди+V+JUS_PL(сЫннАр);"}
+{"prefix": "", "surface": "дисеннәр", "analysis": "ди+V+JUS_PL(сЫннАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "мәче", "analysis": "мәче+N+Sg+Nom;"}
-{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "мәче", "analysis": "мәче+N+Sg+Nom;", "translations": ["кошка"]}
+{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -5293,528 +5293,528 @@
 {"prefix": " ", "surface": "аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "җебегән", "analysis": "җебе+V+PCP_PS(ГАн);җебе+V+PST_INDF(ГАн);җебегән+Adj;"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN;", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "мәче", "analysis": "мәче+N+Sg+Nom;"}
-{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "дидеммени", "analysis": "ди+V+PST_DEF(ДЫ)+1SG(м)+INT_MIR(мЫни);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА);", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "мәче", "analysis": "мәче+N+Sg+Nom;", "translations": ["кошка"]}
+{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "дидеммени", "analysis": "ди+V+PST_DEF(ДЫ)+1SG(м)+INT_MIR(мЫни);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();"}
-{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "Чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();", "translations": ["волос"]}
+{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();"}
+{"prefix": " ", "surface": "Чәч", "analysis": "чәч+N+Sg+Nom;чәч+V+IMP_SG();", "translations": ["волос"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "үз", "analysis": "үз+PN;"}
-{"prefix": " ", "surface": "чәчен", "analysis": "чәч+N+Sg+POSS_3(СЫ)+ACC(нЫ);чәч+V+REFL(Ын)+IMP_SG();"}
-{"prefix": " ", "surface": "тарткалап", "analysis": "тарт+V+RAR_1(ГАлА)+ADVV_ACC(Ып);тарткала+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "үз", "analysis": "үз+PN;", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "чәчен", "analysis": "чәч+N+Sg+POSS_3(СЫ)+ACC(нЫ);чәч+V+REFL(Ын)+IMP_SG();", "translations": ["волос"]}
+{"prefix": " ", "surface": "тарткалап", "analysis": "тарт+V+RAR_1(ГАлА)+ADVV_ACC(Ып);тарткала+V+ADVV_ACC(Ып);", "translations": ["тянуть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "шушыны", "analysis": "шушы+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "шушыны", "analysis": "шушы+PN+ACC(нЫ);", "translations": ["этот"]}
+{"prefix": " ", "surface": "алырга", "analysis": "ал+V+INF_1(ЫргА);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "дим", "analysis": "ди+V+PRES(Й)+1SG(м);дим+PROP+Sg+Nom;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "кадәр", "analysis": "кадәр+Adv;кадәр+POST;", "translations": ["до"]}
 {"prefix": " ", "surface": "аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
-{"prefix": " ", "surface": "булырлар", "analysis": "бул+V+FUT_INDF(Ыр)+3PL(ЛАр);бул+V+PCP_FUT(Ыр)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "булырлар", "analysis": "бул+V+FUT_INDF(Ыр)+3PL(ЛАр);бул+V+PCP_FUT(Ыр)+3PL(ЛАр);", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "җыен", "analysis": "җыен+N+Sg+Nom;җыен+PN;җыен+V+IMP_SG();җый+V+REFL(Ын)+IMP_SG();"}
+{"prefix": " ", "surface": "җыен", "analysis": "җыен+N+Sg+Nom;җыен+PN;җыен+V+IMP_SG();җый+V+REFL(Ын)+IMP_SG();", "translations": ["сбор", "собираться", "собраться", "собирать", "собрать"]}
 {"prefix": " ", "surface": "аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
-{"prefix": " ", "surface": "безгә", "analysis": "без+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "җыелган", "analysis": "җыел+V+PCP_PS(ГАн);җыел+V+PST_INDF(ГАн);җый+V+PASS(Ыл)+PCP_PS(ГАн);җый+V+PASS(Ыл)+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "безгә", "analysis": "без+PN+DIR(ГА);", "translations": ["мы", "наш"]}
+{"prefix": " ", "surface": "җыелган", "analysis": "җыел+V+PCP_PS(ГАн);җыел+V+PST_INDF(ГАн);җый+V+PASS(Ыл)+PCP_PS(ГАн);җый+V+PASS(Ыл)+PST_INDF(ГАн);", "translations": ["собираться", "собраться", "собирать", "собрать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Беркөн", "analysis": "беркөн+Adv;"}
 {"prefix": " ", "surface": "Хәбибрахманга", "analysis": "NR"}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": "", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "агач", "analysis": "агач+N+Sg+Nom;"}
-{"prefix": " ", "surface": "базарына", "analysis": "базар+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
+{"prefix": " ", "surface": "агач", "analysis": "агач+N+Sg+Nom;", "translations": ["дерево"]}
+{"prefix": " ", "surface": "базарына", "analysis": "базар+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["базар"]}
 {"prefix": " ", "surface": "Хисмәткә", "analysis": "NR"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайт", "analysis": "кайт+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кайт", "analysis": "кайт+V+IMP_SG();", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
-{"prefix": " ", "surface": "җибәргән", "analysis": "җибәр+V+PCP_PS(ГАн);җибәр+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "җибәргән", "analysis": "җибәр+V+PCP_PS(ГАн);җибәр+V+PST_INDF(ГАн);", "translations": ["пускать", "пустить"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "зур", "analysis": "зур+Adj;"}
-{"prefix": " ", "surface": "кисмәк", "analysis": "кис+V+INF_2(мАк);кисмәк+N+Sg+Nom;"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайткан", "analysis": "кайт+V+PCP_PS(ГАн);кайт+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "зур", "analysis": "зур+Adj;", "translations": ["большой"]}
+{"prefix": " ", "surface": "кисмәк", "analysis": "кис+V+INF_2(мАк);кисмәк+N+Sg+Nom;", "translations": ["резать"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кайткан", "analysis": "кайт+V+PCP_PS(ГАн);кайт+V+PST_INDF(ГАн);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "сакалымны", "analysis": "сакал+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
-{"prefix": " ", "surface": "шулар", "analysis": "шул+PN+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "сакалымны", "analysis": "сакал+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["борода"]}
+{"prefix": " ", "surface": "шулар", "analysis": "шул+PN+PL(ЛАр)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
 {"prefix": " ", "surface": "агартып", "analysis": "агар+V+CAUS(т)+ADVV_ACC(Ып);агарт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетерделәр", "analysis": "бетер+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "бетерделәр", "analysis": "бетер+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["заканчивать", "кончать", "кончить"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й);ярый+MOD;", "translations": ["годиться", "рана", "ладно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәзергә", "analysis": "хәзергә+Adv;"}
-{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "исән", "analysis": "исән+Adj;"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "хәзергә", "analysis": "хәзергә+Adv;", "translations": ["пока"]}
+{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "исән", "analysis": "исән+Adj;", "translations": ["живо", "живой"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;"}
-{"prefix": " ", "surface": "үлгәч", "analysis": "үл+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "үзем", "analysis": "үз+PN+POSS_1SG(Ым)+Nom;", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "үлгәч", "analysis": "үл+V+ADVV_ANT(ГАч);", "translations": ["умереть", "умирать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "болар", "analysis": "бу+PN+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "дөньяда", "analysis": "дөнья+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;"}
-{"prefix": " ", "surface": "күрерләр", "analysis": "күр+V+FUT_INDF(Ыр)+3PL(ЛАр);күр+V+PCP_FUT(Ыр)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "болар", "analysis": "бу+PN+PL(ЛАр)+Nom;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "дөньяда", "analysis": "дөнья+N+Sg+LOC(ДА);", "translations": ["мир¹"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN;", "translations": ["как"]}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
+{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;", "translations": ["день"]}
+{"prefix": " ", "surface": "күрерләр", "analysis": "күр+V+FUT_INDF(Ыр)+3PL(ЛАр);күр+V+PCP_FUT(Ыр)+3PL(ЛАр);", "translations": ["видеть"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "тик", "analysis": "тик+CNJ;", "translations": ["но", "только"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Нихәл", "analysis": "нихәл+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "нишләп", "analysis": "нишлә+V+ADVV_ACC(Ып);нишләп+PN;"}
 {"prefix": " ", "surface": "терәлеп", "analysis": "терә+V+PASS(Ыл)+ADVV_ACC(Ып);терәл+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "торасың", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тор+V+PRES(Й)+2SG(сЫң);тора+N+Sg+2SG(сЫң);"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "торасың", "analysis": "тор+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;тор+V+PRES(Й)+2SG(сЫң);тора+N+Sg+2SG(сЫң);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Абзый", "analysis": "абзый+N+Sg+Nom;", "translations": ["дядя"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Миннебай", "analysis": "NR"}
-{"prefix": " ", "surface": "абзыйга", "analysis": "абзый+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "әйткән", "analysis": "әйт+V+PCP_PS(ГАн);әйт+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "абзыйга", "analysis": "абзый+N+Sg+DIR(ГА);", "translations": ["дядя"]}
+{"prefix": " ", "surface": "әйткән", "analysis": "әйт+V+PCP_PS(ГАн);әйт+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["быть"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "Коръән", "analysis": "коръән+N+Sg+Nom;"}
-{"prefix": " ", "surface": "укый", "analysis": "укы+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "шәкертне", "analysis": "шәкерт+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom;чык+V+IMP_SG();"}
+{"prefix": " ", "surface": "укый", "analysis": "укы+V+PRES(Й);", "translations": ["прочитать", "учиться", "читать"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "шәкертне", "analysis": "шәкерт+N+Sg+ACC(нЫ);", "translations": ["студент"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom;чык+V+IMP_SG();", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "шәкерт", "analysis": "шәкерт+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": "", "surface": "Нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "шәкерт", "analysis": "шәкерт+N+Sg+Nom;", "translations": ["студент"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мәдрәсәдәге", "analysis": "мәдрәсә+N+Sg+ATTR_LOC(ДАгЫ);"}
-{"prefix": " ", "surface": "шәкертләр", "analysis": "шәкерт+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "алар", "analysis": "алар+PN;"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "мәдрәсәдәге", "analysis": "мәдрәсә+N+Sg+ATTR_LOC(ДАгЫ);", "translations": ["медресе"]}
+{"prefix": " ", "surface": "шәкертләр", "analysis": "шәкерт+N+PL(ЛАр)+Nom;", "translations": ["студент"]}
+{"prefix": " ", "surface": "алар", "analysis": "алар+PN;", "translations": ["они"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": " ", "surface": "Коръән", "analysis": "коръән+N+Sg+Nom;"}
-{"prefix": " ", "surface": "укыйлар", "analysis": "укы+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "укыйлар", "analysis": "укы+V+PRES(Й)+3PL(ЛАр);", "translations": ["прочитать", "учиться", "читать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "анда", "analysis": "анда+PN;ул+PN+LOC(ДА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "әфтияк", "analysis": "әфтияк+N+Sg+Nom;"}
-{"prefix": " ", "surface": "укучы", "analysis": "уку+N+PROF(чЫ)+Sg+Nom;укучы+N+Sg+Nom;укы+V+VN_1(у/ү/в)+PCP_PR(чЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "укучы", "analysis": "уку+N+PROF(чЫ)+Sg+Nom;укучы+N+Sg+Nom;укы+V+VN_1(у/ү/в)+PCP_PR(чЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+Nom;", "translations": ["ученик", "читатель", "школьник", "прочитать", "учиться", "читать"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "ди", "analysis": "ди+V+PRES(Й);"}
+{"prefix": "", "surface": "ди", "analysis": "ди+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "аяк", "analysis": "аяк+N+Sg+Nom;"}
-{"prefix": " ", "surface": "тибеп", "analysis": "тип+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "аяк", "analysis": "аяк+N+Sg+Nom;", "translations": ["нога", "ножка"]}
+{"prefix": " ", "surface": "тибеп", "analysis": "тип+V+ADVV_ACC(Ып);", "translations": ["тип"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "һай", "analysis": "һай+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ахмаклар", "analysis": "ахмак+N+PL(ЛАр)+Nom;"}
+{"prefix": " ", "surface": "ахмаклар", "analysis": "ахмак+N+PL(ЛАр)+Nom;", "translations": ["дурак"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "әрәмтамаклар", "analysis": "әрәмтамак+N+PL(ЛАр)+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();"}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "әйт", "analysis": "әйт+V+IMP_SG();", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мәчеттә", "analysis": "мәчет+N+Sg+LOC(ДА);"}
+{"prefix": " ", "surface": "мәчеттә", "analysis": "мәчет+N+Sg+LOC(ДА);", "translations": ["мечеть"]}
 {"prefix": " ", "surface": "Коръән", "analysis": "коръән+N+Sg+Nom;"}
-{"prefix": " ", "surface": "укый", "analysis": "укы+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "шәкертне", "analysis": "шәкерт+N+Sg+ACC(нЫ);"}
+{"prefix": " ", "surface": "укый", "analysis": "укы+V+PRES(Й);", "translations": ["прочитать", "учиться", "читать"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "шәкертне", "analysis": "шәкерт+N+Sg+ACC(нЫ);", "translations": ["студент"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "Гайфулланы", "analysis": "гайфулла+PROP+ACC(нЫ);"}
-{"prefix": " ", "surface": "чакырып", "analysis": "чакыр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыксын", "analysis": "чык+V+JUS_SG(сЫн);"}
+{"prefix": " ", "surface": "чакырып", "analysis": "чакыр+V+ADVV_ACC(Ып);", "translations": ["звать", "позвать", "приглашение", "призвать", "призывать"]}
+{"prefix": " ", "surface": "чыксын", "analysis": "чык+V+JUS_SG(сЫн);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Икесен", "analysis": "ике+Num+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Икесен", "analysis": "ике+Num+POSS_3(СЫ)+ACC(нЫ);", "translations": ["второй", "два", "оба"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "чакырсынмы", "analysis": "чакыр+V+JUS_SG(сЫн)+INT(мЫ);"}
+{"prefix": " ", "surface": "чакырсынмы", "analysis": "чакыр+V+JUS_SG(сЫн)+INT(мЫ);", "translations": ["звать", "позвать", "приглашение", "призвать", "призывать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;"}
-{"prefix": " ", "surface": "икесен", "analysis": "ике+Num+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Нинди", "analysis": "нинди+PN;", "translations": ["какой"]}
+{"prefix": " ", "surface": "икесен", "analysis": "ике+Num+POSS_3(СЫ)+ACC(нЫ);", "translations": ["второй", "два", "оба"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Коръән", "analysis": "коръән+N+Sg+Nom;"}
-{"prefix": " ", "surface": "укучыны", "analysis": "уку+N+PROF(чЫ)+Sg+ACC(нЫ);укучы+N+Sg+ACC(нЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "укучыны", "analysis": "уку+N+PROF(чЫ)+Sg+ACC(нЫ);укучы+N+Sg+ACC(нЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+ACC(нЫ);", "translations": ["ученик", "читатель", "школьник", "прочитать", "учиться", "читать"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Гайфулланы", "analysis": "гайфулла+PROP+ACC(нЫ);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "үләм", "analysis": "үл+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сезнең", "analysis": "сез+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "үләм", "analysis": "үл+V+PRES(Й)+1SG(м);", "translations": ["умереть", "умирать"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сезнең", "analysis": "сез+PN+GEN(нЫң);", "translations": ["ваш", "вы"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "җәфаланып", "analysis": "җәфала+V+REFL(Ын)+ADVV_ACC(Ып);җәфалан+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "үләм", "analysis": "үл+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "үләм", "analysis": "үл+V+PRES(Й)+1SG(м);", "translations": ["умереть", "умирать"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Аңгыра", "analysis": "аңгыра+Adj;аңгыра+N+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;"}
+{"prefix": " ", "surface": "Соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART;шул+PN;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": " ", "surface": "Корьән", "analysis": "NR"}
-{"prefix": " ", "surface": "укучы", "analysis": "уку+N+PROF(чЫ)+Sg+Nom;укучы+N+Sg+Nom;укы+V+VN_1(у/ү/в)+PCP_PR(чЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+Nom;"}
-{"prefix": " ", "surface": "шәкерт", "analysis": "шәкерт+N+Sg+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "укучы", "analysis": "уку+N+PROF(чЫ)+Sg+Nom;укучы+N+Sg+Nom;укы+V+VN_1(у/ү/в)+PCP_PR(чЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+Nom;", "translations": ["ученик", "читатель", "школьник", "прочитать", "учиться", "читать"]}
+{"prefix": " ", "surface": "шәкерт", "analysis": "шәкерт+N+Sg+Nom;", "translations": ["студент"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": " ", "surface": "Гайфулла", "analysis": "гайфулла+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "икесе", "analysis": "ике+Num+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "икесе", "analysis": "ике+Num+POSS_3(СЫ)+Nom;", "translations": ["второй", "два", "оба"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
 {"prefix": " ", "surface": "ләбаса", "analysis": "ләбаса+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Гөнаһ", "analysis": "гөнаһ+N+Sg+Nom;"}
+{"prefix": " ", "surface": "Гөнаһ", "analysis": "гөнаһ+N+Sg+Nom;", "translations": ["грех"]}
 {"prefix": " ", "surface": "шомлыгы", "analysis": "шом+N+NMLZ(лЫк)+Sg+POSS_3(СЫ)+Nom;шом+N+PSBL(лЫк)+POSS_3(СЫ)+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "сөйләш", "analysis": "сөйлә+V+RECP(Ыш)+IMP_SG();сөйлә+V+VN_2(Ыш)+Nom;"}
-{"prefix": " ", "surface": "алар", "analysis": "алар+PN;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "сөйләш", "analysis": "сөйлә+V+RECP(Ыш)+IMP_SG();сөйлә+V+VN_2(Ыш)+Nom;", "translations": ["говорить", "рассказывать"]}
+{"prefix": " ", "surface": "алар", "analysis": "алар+PN;", "translations": ["они"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "И", "analysis": "и+INTRJ;и+V+IMP_SG();"}
+{"prefix": " ", "surface": "И", "analysis": "и+INTRJ;и+V+IMP_SG();", "translations": ["быть"]}
 {"prefix": " ", "surface": "Алла", "analysis": "алла+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "И", "analysis": "и+INTRJ;и+V+IMP_SG();"}
+{"prefix": " ", "surface": "И", "analysis": "и+INTRJ;и+V+IMP_SG();", "translations": ["быть"]}
 {"prefix": " ", "surface": "Алла", "analysis": "алла+N+Sg+Nom;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ахры", "analysis": "ахры+PART;"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "дөньяда", "analysis": "дөнья+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "акыллы", "analysis": "акыл+N+ATTR_MUN(лЫ);акыллы+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "дөньяда", "analysis": "дөнья+N+Sg+LOC(ДА);", "translations": ["мир¹"]}
+{"prefix": " ", "surface": "акыллы", "analysis": "акыл+N+ATTR_MUN(лЫ);акыллы+N+Sg+Nom;", "translations": ["ум", "умный"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
 {"prefix": " ", "surface": "үк", "analysis": "үк+PART;"}
-{"prefix": " ", "surface": "калмагандыр", "analysis": "кал+V+NEG(мА)+PCP_PS(ГАн)+3SG(ДЫр);кал+V+NEG(мА)+PCP_PS(ГАн)+PROB(ДЫр);кал+V+NEG(мА)+PST_INDF(ГАн)+PROB(ДЫр);"}
+{"prefix": " ", "surface": "калмагандыр", "analysis": "кал+V+NEG(мА)+PCP_PS(ГАн)+3SG(ДЫр);кал+V+NEG(мА)+PCP_PS(ГАн)+PROB(ДЫр);кал+V+NEG(мА)+PST_INDF(ГАн)+PROB(ДЫр);", "translations": ["оставаться", "остаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничә", "analysis": "ничә+PN;"}
-{"prefix": " ", "surface": "елдан", "analysis": "ел+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;"}
-{"prefix": " ", "surface": "өйрәтеп", "analysis": "өйрәт+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Ничә", "analysis": "ничә+PN;", "translations": ["сколько"]}
+{"prefix": " ", "surface": "елдан", "analysis": "ел+N+Sg+ABL(ДАн);", "translations": ["год²"]}
+{"prefix": " ", "surface": "бирле", "analysis": "бирле+POST;", "translations": ["с"]}
+{"prefix": " ", "surface": "өйрәтеп", "analysis": "өйрәт+V+ADVV_ACC(Ып);", "translations": ["научить", "учить"]}
 {"prefix": " ", "surface": "тә", "analysis": "тә+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "игә-чигә", "analysis": "NR"}
-{"prefix": " ", "surface": "китерер", "analysis": "китер+V+FUT_INDF(Ыр);китер+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "хәл", "analysis": "хәл+N+Sg+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "китерер", "analysis": "китер+V+FUT_INDF(Ыр);китер+V+PCP_FUT(Ыр);", "translations": ["привести", "приводить"]}
+{"prefix": " ", "surface": "хәл", "analysis": "хәл+N+Sg+Nom;", "translations": ["состояние"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "һәр", "analysis": "һәр+PN;"}
-{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;"}
+{"prefix": " ", "surface": "һәр", "analysis": "һәр+PN;", "translations": ["каждый"]}
+{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;", "translations": ["день"]}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "башымны", "analysis": "баш+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "башымны", "analysis": "баш+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["голова"]}
 {"prefix": " ", "surface": "катырып", "analysis": "катыр+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетерәләр", "analysis": "бетер+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "бетерәләр", "analysis": "бетер+V+PRES(Й)+3PL(ЛАр);", "translations": ["заканчивать", "кончать", "кончить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Тукта", "analysis": "тук+Adj+Sg+LOC(ДА);тукта+V+IMP_SG();", "translations": ["останавливаться", "остановиться", "остановка"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әүвәл", "analysis": "әүвәл+Adv;"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
-{"prefix": " ", "surface": "чәчемне", "analysis": "чәч+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
-{"prefix": " ", "surface": "алдырыйм", "analysis": "ал+V+CAUS(ДЫр)+HOR_SG(Йм);алдыр+V+HOR_SG(Йм);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "әүвәл", "analysis": "әүвәл+Adv;", "translations": ["прежний", "раньше"]}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
+{"prefix": " ", "surface": "чәчемне", "analysis": "чәч+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["волос"]}
+{"prefix": " ", "surface": "алдырыйм", "analysis": "ал+V+CAUS(ДЫр)+HOR_SG(Йм);алдыр+V+HOR_SG(Йм);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;"}
+{"prefix": " ", "surface": "аннан", "analysis": "аннан+PN;ул+PN+ABL(ДАн);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "соң", "analysis": "соң+Adv;соң+N+Sg+Nom;соң+PART;соң+POST;", "translations": ["же", "конец", "поздний", "поздно", "после", "последний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "тәһарәт", "analysis": "тәһарәт+N+Sg+Nom;"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "вирдләремнеВирд", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дога", "analysis": "до+N+Sg+DIR(ГА);дога+N+Sg+Nom;"}
+{"prefix": "", "surface": "дога", "analysis": "до+N+Sg+DIR(ГА);дога+N+Sg+Nom;", "translations": ["молитва"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "укырмын", "analysis": "укы+V+FUT_INDF(Ыр)+1SG(мЫн);укы+V+PCP_FUT(Ыр)+1SG(мЫн);"}
+{"prefix": " ", "surface": "укырмын", "analysis": "укы+V+FUT_INDF(Ыр)+1SG(мЫн);укы+V+PCP_FUT(Ыр)+1SG(мЫн);", "translations": ["прочитать", "учиться", "читать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "Ишеккә", "analysis": "ишек+N+Sg+DIR(ГА);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "борылып", "analysis": "бор+V+PASS(Ыл)+ADVV_ACC(Ып);борыл+V+ADVV_ACC(Ып);", "translations": ["повернуть", "поворачивать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "әй", "analysis": "әй+INTRJ;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "сез", "analysis": "сез+PN;"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "сез", "analysis": "сез+PN;", "translations": ["ваш", "вы"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Башымны", "analysis": "баш+N+Sg+POSS_1SG(Ым)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Башымны", "analysis": "баш+N+Sg+POSS_1SG(Ым)+ACC(нЫ);", "translations": ["голова"]}
 {"prefix": " ", "surface": "чылатырга", "analysis": "чылат+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "сабын", "analysis": "сабын+N+Sg+Nom;сап+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "сабын", "analysis": "сабын+N+Sg+Nom;сап+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["мыло", "рукоятка"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "су", "analysis": "су+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бирегез", "analysis": "бир+V+IMP_PL(ЫгЫз);"}
+{"prefix": " ", "surface": "су", "analysis": "су+N+Sg+Nom;", "translations": ["вода"]}
+{"prefix": " ", "surface": "бирегез", "analysis": "бир+V+IMP_PL(ЫгЫз);", "translations": ["давать", "даваться", "дать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
-{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
+{"prefix": " ", "surface": "кереп", "analysis": "кер+V+ADVV_ACC(Ып);", "translations": ["войти", "входить", "грязь"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бераздан", "analysis": "бераздан+Adv;"}
-{"prefix": " ", "surface": "чынаяк", "analysis": "чынаяк+N+Sg+Nom;"}
+{"prefix": " ", "surface": "чынаяк", "analysis": "чынаяк+N+Sg+Nom;", "translations": ["чаша"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "поднослар", "analysis": "поднос+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "күтәреп", "analysis": "күтәр+V+ADVV_ACC(Ып);", "translations": ["поднимать", "поднять"]}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);"}
+{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "үзләре", "analysis": "үз+PN+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "үзләре", "analysis": "үз+PN+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["сам", "свой"]}
 {"prefix": " ", "surface": "җүнләп", "analysis": "NR"}
-{"prefix": " ", "surface": "йомыш", "analysis": "йом+V+RECP(Ыш)+IMP_SG();йом+V+VN_2(Ыш)+Nom;йомыш+N+Sg+Nom;йомыш+V+IMP_SG();"}
-{"prefix": " ", "surface": "куша", "analysis": "куш+V+PRES(Й);"}
-{"prefix": " ", "surface": "белмиләр", "analysis": "бел+V+NEG(мА)+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "йомыш", "analysis": "йом+V+RECP(Ыш)+IMP_SG();йом+V+VN_2(Ыш)+Nom;йомыш+N+Sg+Nom;йомыш+V+IMP_SG();", "translations": ["закрывать", "закрыть", "дело", "поручение"]}
+{"prefix": " ", "surface": "куша", "analysis": "куш+V+PRES(Й);", "translations": ["велеть", "двойной", "складывать", "сложить"]}
+{"prefix": " ", "surface": "белмиләр", "analysis": "бел+V+NEG(мА)+PRES(Й)+3PL(ЛАр);", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "кешене", "analysis": "кеше+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "орышалар", "analysis": "ор+V+RECP(Ыш)+PRES(Й)+3PL(ЛАр);орыш+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "кешене", "analysis": "кеше+N+Sg+ACC(нЫ);", "translations": ["человек"]}
+{"prefix": " ", "surface": "орышалар", "analysis": "ор+V+RECP(Ыш)+PRES(Й)+3PL(ЛАр);орыш+V+PRES(Й)+3PL(ЛАр);", "translations": ["битва"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чәй", "analysis": "чәй+N+Sg+Nom;"}
-{"prefix": " ", "surface": "урыны", "analysis": "урын+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": "", "surface": "Чәй", "analysis": "чәй+N+Sg+Nom;", "translations": ["чай"]}
+{"prefix": " ", "surface": "урыны", "analysis": "урын+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["место"]}
 {"prefix": " ", "surface": "хәзерли", "analysis": "хәзерлә+V+PRES(Й);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "өстәлнең", "analysis": "өстәл+N+Sg+GEN(нЫң);"}
-{"prefix": " ", "surface": "почмагына", "analysis": "почмак+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
+{"prefix": " ", "surface": "өстәлнең", "analysis": "өстәл+N+Sg+GEN(нЫң);", "translations": ["стол"]}
+{"prefix": " ", "surface": "почмагына", "analysis": "почмак+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["угол", "уголок"]}
 {"prefix": " ", "surface": "самавыр", "analysis": "самавыр+N+Sg+Nom;"}
 {"prefix": " ", "surface": "подносы", "analysis": "поднос+N+Sg+POSS_3(СЫ)+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;"}
-{"prefix": " ", "surface": "зәңгәр", "analysis": "зәңгәр+Adj;"}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
+{"prefix": " ", "surface": "зәңгәр", "analysis": "зәңгәр+Adj;", "translations": ["голубой", "синий"]}
 {"prefix": " ", "surface": "эмалированныйпласкательныйПласкатель", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "сакал-мыек", "analysis": "NR"}
-{"prefix": " ", "surface": "кырганда", "analysis": "кыр+V+PCP_PS(ГАн)+LOC(ДА);"}
+{"prefix": " ", "surface": "кырганда", "analysis": "кыр+V+PCP_PS(ГАн)+LOC(ДА);", "translations": ["поле"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сабын", "analysis": "сабын+N+Sg+Nom;сап+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "сабын", "analysis": "сабын+N+Sg+Nom;сап+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["мыло", "рукоятка"]}
 {"prefix": " ", "surface": "күбеге", "analysis": "күбек+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "ясый", "analysis": "яса+V+PRES(Й);"}
-{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "савыт", "analysis": "савыт+N+Sg+Nom;"}
+{"prefix": " ", "surface": "ясый", "analysis": "яса+V+PRES(Й);", "translations": ["делать", "сделать"]}
+{"prefix": " ", "surface": "торган", "analysis": "тор+V+PCP_PS(ГАн);тор+V+PST_INDF(ГАн);", "translations": ["вставать", "встать", "стоять"]}
+{"prefix": " ", "surface": "савыт", "analysis": "савыт+N+Sg+Nom;", "translations": ["посуда"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);"}
+{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);", "translations": ["баран", "класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Көне-төне", "analysis": "көне-төне+Adv;көне-төне+N+Sg+Nom;"}
-{"prefix": " ", "surface": "эшлисең", "analysis": "эшлә+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;эшлә+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "эшлисең", "analysis": "эшлә+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;эшлә+V+PRES(Й)+2SG(сЫң);", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "эшлисең", "analysis": "эшлә+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;эшлә+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "эшлисең", "analysis": "эшлә+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom;эшлә+V+PRES(Й)+2SG(сЫң);", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "өстенә", "analysis": "өс+N+Sg+POSS_3(СЫ)+DIR(ГА);өстенә+POST;"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
-{"prefix": " ", "surface": "һәр", "analysis": "һәр+PN;"}
-{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;"}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "һәр", "analysis": "һәр+PN;", "translations": ["каждый"]}
+{"prefix": " ", "surface": "көн", "analysis": "көн+N+Sg+Nom;", "translations": ["день"]}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "орыш", "analysis": "ор+V+RECP(Ыш)+IMP_SG();ор+V+VN_2(Ыш)+Nom;орыш+V+IMP_SG();"}
+{"prefix": "", "surface": "орыш", "analysis": "ор+V+RECP(Ыш)+IMP_SG();ор+V+VN_2(Ыш)+Nom;орыш+V+IMP_SG();", "translations": ["битва"]}
 {"prefix": " ", "surface": "та", "analysis": "та+PART;"}
-{"prefix": " ", "surface": "талаш", "analysis": "тала+V+RECP(Ыш)+IMP_SG();тала+V+VN_2(Ыш)+Nom;талаш+N+Sg+Nom;талаш+V+IMP_SG();"}
+{"prefix": " ", "surface": "талаш", "analysis": "тала+V+RECP(Ыш)+IMP_SG();тала+V+VN_2(Ыш)+Nom;талаш+N+Sg+Nom;талаш+V+IMP_SG();", "translations": ["ругаться", "ссора"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "дисәләр", "analysis": "ди+V+COND(сА)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "дисәләр", "analysis": "ди+V+COND(сА)+3PL(ЛАр);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кырык", "analysis": "кырык+Num;"}
+{"prefix": " ", "surface": "кырык", "analysis": "кырык+Num;", "translations": ["сорок", "сороковой"]}
 {"prefix": " ", "surface": "чөйләре", "analysis": "чөй+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "кырылып", "analysis": "кыр+V+PASS(Ыл)+ADVV_ACC(Ып);кырыл+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бетсен", "analysis": "бет+V+JUS_SG(сЫн);"}
-{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "кырылып", "analysis": "кыр+V+PASS(Ыл)+ADVV_ACC(Ып);кырыл+V+ADVV_ACC(Ып);", "translations": ["поле"]}
+{"prefix": " ", "surface": "бетсен", "analysis": "бет+V+JUS_SG(сЫн);", "translations": ["вошь", "кончаться", "кончиться"]}
+{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
-{"prefix": " ", "surface": "абыйларның", "analysis": "абый+N+PL(ЛАр)+GEN(нЫң);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "абыйларның", "analysis": "абый+N+PL(ЛАр)+GEN(нЫң);", "translations": ["брат", "дядя"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
-{"prefix": " ", "surface": "апаларның", "analysis": "апа+N+PL(ЛАр)+GEN(нЫң);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "киткәннәрен", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);кит+V+PCP_PS(ГАн)+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "әйтәм", "analysis": "әйт+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "апаларның", "analysis": "апа+N+PL(ЛАр)+GEN(нЫң);", "translations": ["сестра", "тетя"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "киткәннәрен", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн)+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);кит+V+PCP_PS(ГАн)+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["одеть", "уйти", "уходить"]}
+{"prefix": " ", "surface": "әйтәм", "analysis": "әйт+V+PRES(Й)+1SG(м);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "Мине", "analysis": "ми+N+Sg+ACC(нЫ);мин+PN+ACC(нЫ);мин+PN+POSS_3(СЫ)+Nom;", "translations": ["мозг", "мой", "я"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "орышмасын", "analysis": "ор+V+RECP(Ыш)+NEG(мА)+JUS_SG(сЫн);орыш+V+NEG(мА)+JUS_SG(сЫн);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "орышмасын", "analysis": "ор+V+RECP(Ыш)+NEG(мА)+JUS_SG(сЫн);орыш+V+NEG(мА)+JUS_SG(сЫн);", "translations": ["битва"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аларны", "analysis": "алар+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "орышсын", "analysis": "ор+V+RECP(Ыш)+JUS_SG(сЫн);орыш+V+JUS_SG(сЫн);"}
+{"prefix": " ", "surface": "аларны", "analysis": "алар+PN+ACC(нЫ);", "translations": ["они"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "орышсын", "analysis": "ор+V+RECP(Ыш)+JUS_SG(сЫн);орыш+V+JUS_SG(сЫн);", "translations": ["битва"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
+{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "чыга", "analysis": "чык+V+PRES(Й);", "translations": ["выйти", "выходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
 {"prefix": " ", "surface": "тәмам", "analysis": "тәмам+MOD;"}
-{"prefix": " ", "surface": "сабын", "analysis": "сабын+N+Sg+Nom;сап+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "күперткән", "analysis": "күпер+V+CAUS(т)+PCP_PS(ГАн);күпер+V+CAUS(т)+PST_INDF(ГАн);күперт+V+PCP_PS(ГАн);күперт+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "сабын", "analysis": "сабын+N+Sg+Nom;сап+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["мыло", "рукоятка"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "күперткән", "analysis": "күпер+V+CAUS(т)+PCP_PS(ГАн);күпер+V+CAUS(т)+PST_INDF(ГАн);күперт+V+PCP_PS(ГАн);күперт+V+PST_INDF(ГАн);", "translations": ["мост"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "яшел", "analysis": "яшел+Adj;яшел+PROP+Sg+Nom;"}
+{"prefix": " ", "surface": "Бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["рука"]}
+{"prefix": " ", "surface": "яшел", "analysis": "яшел+Adj;яшел+PROP+Sg+Nom;", "translations": ["зелёный"]}
 {"prefix": " ", "surface": "кәләпүшен", "analysis": "кәләпүш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "күзлеген", "analysis": "күз+N+NMLZ(лЫк)+Sg+POSS_3(СЫ)+ACC(нЫ);күз+N+PSBL(лЫк)+POSS_3(СЫ)+ACC(нЫ);күзлек+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "тоткан", "analysis": "тот+V+PCP_PS(ГАн);тот+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "кулына", "analysis": "кул+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["рука"]}
+{"prefix": " ", "surface": "күзлеген", "analysis": "күз+N+NMLZ(лЫк)+Sg+POSS_3(СЫ)+ACC(нЫ);күз+N+PSBL(лЫк)+POSS_3(СЫ)+ACC(нЫ);күзлек+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["глаз", "очко"]}
+{"prefix": " ", "surface": "тоткан", "analysis": "тот+V+PCP_PS(ГАн);тот+V+PST_INDF(ГАн);", "translations": ["держать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "муенга", "analysis": "муен+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "салырга", "analysis": "сал+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "муенга", "analysis": "муен+N+Sg+DIR(ГА);", "translations": ["шея"]}
+{"prefix": " ", "surface": "салырга", "analysis": "сал+V+INF_1(ЫргА);", "translations": ["класть", "положить"]}
 {"prefix": " ", "surface": "эскәтер", "analysis": "эскәтер+N+Sg+Nom;"}
-{"prefix": " ", "surface": "китер", "analysis": "ки+V+CAUS(т)+FUT_INDF(Ыр);ки+V+CAUS(т)+PCP_FUT(Ыр);кит+V+FUT_INDF(Ыр);кит+V+PCP_FUT(Ыр);китер+V+IMP_SG();"}
+{"prefix": " ", "surface": "китер", "analysis": "ки+V+CAUS(т)+FUT_INDF(Ыр);ки+V+CAUS(т)+PCP_FUT(Ыр);кит+V+FUT_INDF(Ыр);кит+V+PCP_FUT(Ыр);китер+V+IMP_SG();", "translations": ["одеть", "уйти", "уходить", "привести", "приводить"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "өстәл", "analysis": "өстә+V+PASS(Ыл)+IMP_SG();өстәл+N+Sg+Nom;өстәл+V+IMP_SG();"}
-{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "өстәл", "analysis": "өстә+V+PASS(Ыл)+IMP_SG();өстәл+N+Sg+Nom;өстәл+V+IMP_SG();", "translations": ["добавить", "добавлять", "стол"]}
+{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "пласкательный", "analysis": "NR"}
-{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;"}
+{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
 {"prefix": " ", "surface": "кәләпүшен", "analysis": "кәләпүш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;"}
-{"prefix": " ", "surface": "күзлеген", "analysis": "күз+N+NMLZ(лЫк)+Sg+POSS_3(СЫ)+ACC(нЫ);күз+N+PSBL(лЫк)+POSS_3(СЫ)+ACC(нЫ);күзлек+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);"}
+{"prefix": " ", "surface": "аның", "analysis": "ул+PN+GEN(нЫң);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
+{"prefix": " ", "surface": "күзлеген", "analysis": "күз+N+NMLZ(лЫк)+Sg+POSS_3(СЫ)+ACC(нЫ);күз+N+PSBL(лЫк)+POSS_3(СЫ)+ACC(нЫ);күзлек+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["глаз", "очко"]}
+{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);", "translations": ["баран", "класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;"}
-{"prefix": " ", "surface": "каралган", "analysis": "кара+V+PASS(Ыл)+PCP_PS(ГАн);кара+V+PASS(Ыл)+PST_INDF(ГАн);карал+V+PCP_PS(ГАн);карал+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;"}
+{"prefix": " ", "surface": "бер", "analysis": "бер+Num;бер+PN;", "translations": ["один", "первый"]}
+{"prefix": " ", "surface": "каралган", "analysis": "кара+V+PASS(Ыл)+PCP_PS(ГАн);кара+V+PASS(Ыл)+PST_INDF(ГАн);карал+V+PCP_PS(ГАн);карал+V+PST_INDF(ГАн);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "кызыл", "analysis": "кызыл+Adj;", "translations": ["красно", "красный"]}
 {"prefix": " ", "surface": "эскәтер", "analysis": "эскәтер+N+Sg+Nom;"}
-{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бирә", "analysis": "бир+V+PRES(Й);"}
+{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);", "translations": ["привести", "приводить"]}
+{"prefix": " ", "surface": "бирә", "analysis": "бир+V+PRES(Й);", "translations": ["давать", "даваться", "дать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бибигә", "analysis": "NR"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "урындык", "analysis": "ур+V+REFL(Ын)+PST_DEF(ДЫ)+1PL(к);урындык+N+Sg+Nom;"}
-{"prefix": " ", "surface": "бир", "analysis": "бир+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "урындык", "analysis": "ур+V+REFL(Ын)+PST_DEF(ДЫ)+1PL(к);урындык+N+Sg+Nom;", "translations": ["пожать", "стул"]}
+{"prefix": " ", "surface": "бир", "analysis": "бир+V+IMP_SG();", "translations": ["давать", "даваться", "дать"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Кызыл", "analysis": "кызыл+Adj;"}
+{"prefix": "", "surface": "Кызыл", "analysis": "кызыл+Adj;", "translations": ["красно", "красный"]}
 {"prefix": " ", "surface": "эскәтерне", "analysis": "эскәтер+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "муенына", "analysis": "муен+N+Sg+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "бәйли", "analysis": "бәйлә+V+PRES(Й);"}
+{"prefix": " ", "surface": "муенына", "analysis": "муен+N+Sg+POSS_3(СЫ)+DIR(ГА);", "translations": ["шея"]}
+{"prefix": " ", "surface": "бәйли", "analysis": "бәйлә+V+PRES(Й);", "translations": ["связать", "связывать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "урындыкны", "analysis": "урындык+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "бирә", "analysis": "бир+V+PRES(Й);"}
+{"prefix": " ", "surface": "урындыкны", "analysis": "урындык+N+Sg+ACC(нЫ);", "translations": ["стул"]}
+{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);", "translations": ["привести", "приводить"]}
+{"prefix": " ", "surface": "бирә", "analysis": "бир+V+PRES(Й);", "translations": ["давать", "даваться", "дать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Янә", "analysis": "янә+Adv;"}
+{"prefix": " ", "surface": "Янә", "analysis": "янә+Adv;", "translations": ["опять"]}
 {"prefix": " ", "surface": "Бибигә", "analysis": "NR"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "Бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "теге", "analysis": "теге+PN;"}
-{"prefix": " ", "surface": "якта", "analysis": "як+N+Sg+LOC(ДА);як+V+CAUS(т)+PRES(Й);"}
+{"prefix": " ", "surface": "теге", "analysis": "теге+PN;", "translations": ["там", "тот"]}
+{"prefix": " ", "surface": "якта", "analysis": "як+N+Sg+LOC(ДА);як+V+CAUS(т)+PRES(Й);", "translations": ["сжечь", "сторона"]}
 {"prefix": " ", "surface": "камут", "analysis": "NR"}
-{"prefix": " ", "surface": "тартмасында", "analysis": "тартма+N+Sg+POSS_3(СЫ)+LOC(ДА);"}
+{"prefix": " ", "surface": "тартмасында", "analysis": "тартма+N+Sg+POSS_3(СЫ)+LOC(ДА);", "translations": ["коробка", "ящик"]}
 {"prefix": " ", "surface": "минемплитувамПлитува", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "бритва", "analysis": "бритва+N+Sg+Nom;"}
@@ -5822,299 +5822,299 @@
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "пәке", "analysis": "пәке+N+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "бардыр", "analysis": "бар+MOD+PROB(ДЫр);бар+N+Sg+3SG(ДЫр);бар+N+Sg+Nom+PROB(ДЫр);бар+PN+PROB(ДЫр);бар+V+CAUS(ДЫр)+IMP_SG();"}
+{"prefix": " ", "surface": "бардыр", "analysis": "бар+MOD+PROB(ДЫр);бар+N+Sg+3SG(ДЫр);бар+N+Sg+Nom+PROB(ДЫр);бар+PN+PROB(ДЫр);бар+V+CAUS(ДЫр)+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
-{"prefix": " ", "surface": "китер", "analysis": "ки+V+CAUS(т)+FUT_INDF(Ыр);ки+V+CAUS(т)+PCP_FUT(Ыр);кит+V+FUT_INDF(Ыр);кит+V+PCP_FUT(Ыр);китер+V+IMP_SG();"}
+{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "китер", "analysis": "ки+V+CAUS(т)+FUT_INDF(Ыр);ки+V+CAUS(т)+PCP_FUT(Ыр);кит+V+FUT_INDF(Ыр);кит+V+PCP_FUT(Ыр);китер+V+IMP_SG();", "translations": ["одеть", "уйти", "уходить", "привести", "приводить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "урындыкка", "analysis": "урындык+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "утыра", "analysis": "утыр+V+PRES(Й);"}
+{"prefix": " ", "surface": "урындыкка", "analysis": "урындык+N+Sg+DIR(ГА);", "translations": ["стул"]}
+{"prefix": " ", "surface": "утыра", "analysis": "утыр+V+PRES(Й);", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Заманалар", "analysis": "замана+N+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "бозылды", "analysis": "боз+V+PASS(Ыл)+PST_DEF(ДЫ);бозыл+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "бозылды", "analysis": "боз+V+PASS(Ыл)+PST_DEF(ДЫ);бозыл+V+PST_DEF(ДЫ);", "translations": ["испортить", "лед/лёд", "лёд"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "бүген", "analysis": "бүген+Adv;"}
-{"prefix": " ", "surface": "теге", "analysis": "теге+PN;"}
-{"prefix": " ", "surface": "урыс", "analysis": "урыс+Adj;урыс+N+Sg+Nom;"}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "бүген", "analysis": "бүген+Adv;", "translations": ["сегодня", "сегодняшний"]}
+{"prefix": " ", "surface": "теге", "analysis": "теге+PN;", "translations": ["там", "тот"]}
+{"prefix": " ", "surface": "урыс", "analysis": "урыс+Adj;урыс+N+Sg+Nom;", "translations": ["русский"]}
 {"prefix": " ", "surface": "сымак", "analysis": "сымак+POST;"}
-{"prefix": " ", "surface": "нәрсәләр", "analysis": "нәрсә+PN+PL(ЛАр)+Nom;"}
-{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;"}
-{"prefix": " ", "surface": "уйнап", "analysis": "уйна+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "нәрсәләр", "analysis": "нәрсә+PN+PL(ЛАр)+Nom;", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "театр", "analysis": "театр+N+Sg+Nom;", "translations": ["театр"]}
+{"prefix": " ", "surface": "уйнап", "analysis": "уйна+V+ADVV_ACC(Ып);", "translations": ["игра", "играть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "динне", "analysis": "дин+N+Sg+ACC(нЫ);"}
+{"prefix": " ", "surface": "динне", "analysis": "дин+N+Sg+ACC(нЫ);", "translations": ["вера", "религия"]}
 {"prefix": " ", "surface": "мәсхәрә", "analysis": "мәсхәрә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кылмакчы", "analysis": "кыл+V+DESID(мАкчЫ);"}
-{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "йөриләр", "analysis": "йөр+V+PRES(Й)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "кылмакчы", "analysis": "кыл+V+DESID(мАкчЫ);", "translations": ["делать", "сделать"]}
+{"prefix": " ", "surface": "булып", "analysis": "бул+V+ADVV_ACC(Ып);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "йөриләр", "analysis": "йөр+V+PRES(Й)+3PL(ЛАр);", "translations": ["походить", "ходить"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "булдырмаска", "analysis": "бул+V+CAUS(ДЫр)+NEG(мА)+INF_1(скА);бул+V+CAUS(ДЫр)+PCP_FUT(мАс)+DIR(ГА);булдыр+V+NEG(мА)+INF_1(скА);булдыр+V+PCP_FUT(мАс)+DIR(ГА);"}
-{"prefix": " ", "surface": "йөреп", "analysis": "йөр+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Шуны", "analysis": "шул+PN+ACC(нЫ);шул+PN+POSS_3(СЫ)+Nom;", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "булдырмаска", "analysis": "бул+V+CAUS(ДЫр)+NEG(мА)+INF_1(скА);бул+V+CAUS(ДЫр)+PCP_FUT(мАс)+DIR(ГА);булдыр+V+NEG(мА)+INF_1(скА);булдыр+V+PCP_FUT(мАс)+DIR(ГА);", "translations": ["быть", "случиться", "создавать", "создать", "справиться"]}
+{"prefix": " ", "surface": "йөреп", "analysis": "йөр+V+ADVV_ACC(Ып);", "translations": ["походить", "ходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бүгенясигъгаЯсигъ", "analysis": "NR"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
 {"prefix": "", "surface": "ястү", "analysis": "ястү+N+Sg+Nom;"}
-{"prefix": " ", "surface": "намазы", "analysis": "намаз+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "намазы", "analysis": "намаз+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["намаз"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);"}
-{"prefix": " ", "surface": "алмый", "analysis": "ал+V+NEG(мА)+PRES(Й);"}
-{"prefix": " ", "surface": "калдым", "analysis": "кал+V+PST_DEF(ДЫ)+1SG(м);"}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "алмый", "analysis": "ал+V+NEG(мА)+PRES(Й);", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "калдым", "analysis": "кал+V+PST_DEF(ДЫ)+1SG(м);", "translations": ["оставаться", "остаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Уйнатмагыз", "analysis": "уйна+V+CAUS(т)+NEG(мА)+IMP_PL(ЫгЫз);уйнат+V+NEG(мА)+IMP_PL(ЫгЫз);"}
+{"prefix": "", "surface": "Уйнатмагыз", "analysis": "уйна+V+CAUS(т)+NEG(мА)+IMP_PL(ЫгЫз);уйнат+V+NEG(мА)+IMP_PL(ЫгЫз);", "translations": ["игра", "играть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "рөхсәт", "analysis": "рөхсәт+N+Sg+Nom;"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "рөхсәт", "analysis": "рөхсәт+N+Sg+Nom;", "translations": ["разрешение"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": "", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "җамали", "analysis": "NR"}
 {"prefix": " ", "surface": "үндергә", "analysis": "NR"}
-{"prefix": " ", "surface": "әйткән", "analysis": "әйт+V+PCP_PS(ГАн);әйт+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);"}
+{"prefix": " ", "surface": "әйткән", "analysis": "әйт+V+PCP_PS(ГАн);әйт+V+PST_INDF(ГАн);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Минем", "analysis": "мин+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "эшем", "analysis": "эш+N+Sg+POSS_1SG(Ым)+Nom;"}
+{"prefix": "", "surface": "Минем", "analysis": "мин+PN+GEN(нЫң);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "эшем", "analysis": "эш+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["дело"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "пристефкә", "analysis": "NR"}
-{"prefix": " ", "surface": "үзенә", "analysis": "үз+PN+POSS_3(СЫ)+DIR(ГА);"}
-{"prefix": " ", "surface": "әйтегез", "analysis": "әйт+V+IMP_PL(ЫгЫз);"}
+{"prefix": " ", "surface": "үзенә", "analysis": "үз+PN+POSS_3(СЫ)+DIR(ГА);", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "әйтегез", "analysis": "әйт+V+IMP_PL(ЫгЫз);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);"}
+{"prefix": "", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Пристефне", "analysis": "NR"}
-{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "туры", "analysis": "тур+N+Sg+POSS_3(СЫ)+Nom;туры+Adj;"}
-{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "булмады", "analysis": "бул+V+NEG(мА)+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);", "translations": ["дом"]}
+{"prefix": " ", "surface": "туры", "analysis": "тур+N+Sg+POSS_3(СЫ)+Nom;туры+Adj;", "translations": ["тур", "прямо", "прямой"]}
+{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);", "translations": ["привести", "приводить"]}
+{"prefix": " ", "surface": "булмады", "analysis": "бул+V+NEG(мА)+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "галавага", "analysis": "NR"}
-{"prefix": " ", "surface": "менгән", "analysis": "мен+V+PCP_PS(ГАн);мен+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);"}
+{"prefix": " ", "surface": "менгән", "analysis": "мен+V+PCP_PS(ГАн);мен+V+PST_INDF(ГАн);", "translations": ["подниматься", "подняться"]}
+{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "алар", "analysis": "алар+PN;"}
-{"prefix": " ", "surface": "яклы", "analysis": "як+N+ATTR_MUN(лЫ);"}
-{"prefix": " ", "surface": "булырга", "analysis": "бул+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "алар", "analysis": "алар+PN;", "translations": ["они"]}
+{"prefix": " ", "surface": "яклы", "analysis": "як+N+ATTR_MUN(лЫ);", "translations": ["сжечь", "сторона"]}
+{"prefix": " ", "surface": "булырга", "analysis": "бул+V+INF_1(ЫргА);", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD;", "translations": ["необходимый", "нужный"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Минем", "analysis": "мин+PN+GEN(нЫң);"}
-{"prefix": " ", "surface": "эшем", "analysis": "эш+N+Sg+POSS_1SG(Ым)+Nom;"}
+{"prefix": "", "surface": "Минем", "analysis": "мин+PN+GEN(нЫң);", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "эшем", "analysis": "эш+N+Sg+POSS_1SG(Ым)+Nom;", "translations": ["дело"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сез", "analysis": "сез+PN;"}
+{"prefix": " ", "surface": "сез", "analysis": "сез+PN;", "translations": ["ваш", "вы"]}
 {"prefix": " ", "surface": "палисәмистергә", "analysis": "NR"}
-{"prefix": " ", "surface": "барыгыз", "analysis": "бар+N+Sg+POSS_2PL(ЫгЫз)+Nom;бар+PN+POSS_2PL(ЫгЫз)+Nom;бар+V+IMP_PL(ЫгЫз);бары+PN+POSS_2PL(ЫгЫз)+Nom;барыгыз+N+Sg+Nom;"}
+{"prefix": " ", "surface": "барыгыз", "analysis": "бар+N+Sg+POSS_2PL(ЫгЫз)+Nom;бар+PN+POSS_2PL(ЫгЫз)+Nom;бар+V+IMP_PL(ЫгЫз);бары+PN+POSS_2PL(ЫгЫз)+Nom;барыгыз+N+Sg+Nom;", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);"}
+{"prefix": "", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);"}
+{"prefix": " ", "surface": "Аңа", "analysis": "ул+PN+DIR(ГА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бакзалга", "analysis": "NR"}
-{"prefix": " ", "surface": "киткән", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн);ки+V+CAUS(т)+PST_INDF(ГАн);кит+V+PCP_PS(ГАн);кит+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "киткән", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн);ки+V+CAUS(т)+PST_INDF(ГАн);кит+V+PCP_PS(ГАн);кит+V+PST_INDF(ГАн);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Губирнаторга", "analysis": "NR"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);"}
-{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "барган", "analysis": "бар+V+PCP_PS(ГАн);бар+V+PST_INDF(ГАн);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "идек", "analysis": "и+V+PST_DEF(ДЫ)+1PL(к);", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бутишник", "analysis": "NR"}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN;"}
-{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кертми", "analysis": "керт+V+NEG(мА)+PRES(Й);"}
+{"prefix": "", "surface": "Ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN;", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "вакытта", "analysis": "вакыт+N+Sg+LOC(ДА);", "translations": ["время", "пора"]}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom;", "translations": ["человек"]}
+{"prefix": " ", "surface": "кертми", "analysis": "керт+V+NEG(мА)+PRES(Й);", "translations": ["ввести", "вводить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "иртәгә", "analysis": "иртәгә+Adv;"}
-{"prefix": " ", "surface": "сәгать", "analysis": "сәгать+N+Sg+Nom;"}
-{"prefix": " ", "surface": "уникедә", "analysis": "унике+Num+LOC(ДА);"}
+{"prefix": " ", "surface": "иртәгә", "analysis": "иртәгә+Adv;", "translations": ["завтра"]}
+{"prefix": " ", "surface": "сәгать", "analysis": "сәгать+N+Sg+Nom;", "translations": ["час", "часы"]}
+{"prefix": " ", "surface": "уникедә", "analysis": "унике+Num+LOC(ДА);", "translations": ["двенадцатый", "двенадцать"]}
 {"prefix": " ", "surface": "килеңез", "analysis": "NR"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "—", "analysis": "Type2"}
-{"prefix": "", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);"}
+{"prefix": "", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Шулай", "analysis": "шулай+PN;"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып);", "translations": ["делать", "мясо", "сделать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "ахрысы", "analysis": "ахрысы+PART;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бәдбәхетләрне", "analysis": "бәдбәхет+N+PL(ЛАр)+ACC(нЫ);"}
-{"prefix": " ", "surface": "туктатып", "analysis": "тукта+V+CAUS(т)+ADVV_ACC(Ып);туктат+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "булмады", "analysis": "бул+V+NEG(мА)+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "туктатып", "analysis": "тукта+V+CAUS(т)+ADVV_ACC(Ып);туктат+V+ADVV_ACC(Ып);", "translations": ["останавливаться", "остановиться", "остановка", "останавливать", "остановить"]}
+{"prefix": " ", "surface": "булмады", "analysis": "бул+V+NEG(мА)+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Алла", "analysis": "алла+N+Sg+Nom;"}
 {"prefix": " ", "surface": "боерса", "analysis": "боер+V+COND(сА);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "икенче", "analysis": "ике+Num+NUM_ORD(ЫнчЫ);"}
-{"prefix": " ", "surface": "вакыт", "analysis": "вакыт+N+Sg+Nom;"}
-{"prefix": " ", "surface": "уйнатмабыз", "analysis": "уйна+V+CAUS(т)+FUT_INDF_NEG(мАс)+1PL(бЫз);уйнат+V+FUT_INDF_NEG(мАс)+1PL(бЫз);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
+{"prefix": " ", "surface": "икенче", "analysis": "ике+Num+NUM_ORD(ЫнчЫ);", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "вакыт", "analysis": "вакыт+N+Sg+Nom;", "translations": ["время", "пора"]}
+{"prefix": " ", "surface": "уйнатмабыз", "analysis": "уйна+V+CAUS(т)+FUT_INDF_NEG(мАс)+1PL(бЫз);уйнат+V+FUT_INDF_NEG(мАс)+1PL(бЫз);", "translations": ["игра", "играть"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "пристефне", "analysis": "NR"}
-{"prefix": " ", "surface": "алдан", "analysis": "ал+Adj+Sg+ABL(ДАн);ал+N+Sg+ABL(ДАн);ал+PN+ABL(ДАн);алда+V+REFL(Ын)+IMP_SG();алдан+Adv;алдан+PROP+Sg+Nom;алдан+V+IMP_SG();"}
-{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;"}
-{"prefix": " ", "surface": "күреп", "analysis": "күр+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "алдан", "analysis": "ал+Adj+Sg+ABL(ДАн);ал+N+Sg+ABL(ДАн);ал+PN+ABL(ДАн);алда+V+REFL(Ын)+IMP_SG();алдан+Adv;алдан+PROP+Sg+Nom;алдан+V+IMP_SG();", "translations": ["алый", "брать", "браться", "взять", "мочь", "впереди", "обмануть", "обманывать", "заранее", "прежде", "спереди"]}
+{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;", "translations": ["же", "стрела"]}
+{"prefix": " ", "surface": "күреп", "analysis": "күр+V+ADVV_ACC(Ып);", "translations": ["видеть"]}
 {"prefix": " ", "surface": "куярбыз", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);"}
+{"prefix": "", "surface": "Ишектән", "analysis": "ишек+N+Sg+ABL(ДАн);", "translations": ["дверь"]}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);"}
+{"prefix": " ", "surface": "килеп", "analysis": "кил+V+ADVV_ACC(Ып);", "translations": ["идти"]}
+{"prefix": " ", "surface": "керә", "analysis": "кер+V+PRES(Й);", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аңа", "analysis": "ул+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "аңа", "analysis": "ул+PN+DIR(ГА);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Нихәл", "analysis": "нихәл+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булдымы", "analysis": "бул+V+PST_DEF(ДЫ)+INT(мЫ);"}
+{"prefix": " ", "surface": "булдымы", "analysis": "бул+V+PST_DEF(ДЫ)+INT(мЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Бритваны", "analysis": "бритва+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "өстәлгә", "analysis": "өстәл+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);"}
+{"prefix": " ", "surface": "өстәлгә", "analysis": "өстәл+N+Sg+DIR(ГА);", "translations": ["стол"]}
+{"prefix": " ", "surface": "китереп", "analysis": "китер+V+ADVV_ACC(Ып);", "translations": ["привести", "приводить"]}
+{"prefix": " ", "surface": "куя", "analysis": "куй+V+PRES(Й);", "translations": ["баран", "класть", "положить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Коръән", "analysis": "коръән+N+Sg+Nom;"}
-{"prefix": " ", "surface": "укучы", "analysis": "уку+N+PROF(чЫ)+Sg+Nom;укучы+N+Sg+Nom;укы+V+VN_1(у/ү/в)+PCP_PR(чЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+Nom;"}
-{"prefix": " ", "surface": "шәкерт", "analysis": "шәкерт+N+Sg+Nom;"}
-{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);"}
-{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "укучы", "analysis": "уку+N+PROF(чЫ)+Sg+Nom;укучы+N+Sg+Nom;укы+V+VN_1(у/ү/в)+PCP_PR(чЫ);укы+V+VN_1(у/ү/в)+PROF(чЫ)+Sg+Nom;", "translations": ["ученик", "читатель", "школьник", "прочитать", "учиться", "читать"]}
+{"prefix": " ", "surface": "шәкерт", "analysis": "шәкерт+N+Sg+Nom;", "translations": ["студент"]}
+{"prefix": " ", "surface": "өйдә", "analysis": "өй+N+Sg+LOC(ДА);", "translations": ["дом"]}
+{"prefix": " ", "surface": "юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);"}
+{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "иптәшләре", "analysis": "иптәш+N+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "киткән", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн);ки+V+CAUS(т)+PST_INDF(ГАн);кит+V+PCP_PS(ГАн);кит+V+PST_INDF(ГАн);"}
+{"prefix": " ", "surface": "иптәшләре", "analysis": "иптәш+N+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["товарищ"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "киткән", "analysis": "ки+V+CAUS(т)+PCP_PS(ГАн);ки+V+CAUS(т)+PST_INDF(ГАн);кит+V+PCP_PS(ГАн);кит+V+PST_INDF(ГАн);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);"}
+{"prefix": " ", "surface": "ди", "analysis": "ди+V+PRES(Й);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ачуланып", "analysis": "ачулан+V+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "ачуланып", "analysis": "ачулан+V+ADVV_ACC(Ып);", "translations": ["ругать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ходай", "analysis": "ходай+N+Sg+Nom;"}
-{"prefix": " ", "surface": "орган", "analysis": "ор+V+PCP_PS(ГАн);ор+V+PST_INDF(ГАн);орган+N+Sg+Nom;"}
+{"prefix": " ", "surface": "орган", "analysis": "ор+V+PCP_PS(ГАн);ор+V+PST_INDF(ГАн);орган+N+Sg+Nom;", "translations": ["орган"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Йөзләре", "analysis": "йөз+N+PL(ЛАр)+POSS_3(СЫ)+Nom;йөз+Num+PL(ЛАр)+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "Йөзләре", "analysis": "йөз+N+PL(ЛАр)+POSS_3(СЫ)+Nom;йөз+Num+PL(ЛАр)+POSS_3(СЫ)+Nom;", "translations": ["лицо", "плавать", "сотый", "сто"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();"}
-{"prefix": " ", "surface": "булсын", "analysis": "бул+V+JUS_SG(сЫн);"}
+{"prefix": " ", "surface": "кара", "analysis": "кара+Adj;кара+MOD;кара+N+Sg+Nom;кара+V+IMP_SG();", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
+{"prefix": " ", "surface": "булсын", "analysis": "бул+V+JUS_SG(сЫн);", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();"}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD;бар+N+Sg+Nom;бар+PN;бар+V+IMP_SG();", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "чакыр", "analysis": "чакыр+V+IMP_SG();"}
-{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
+{"prefix": " ", "surface": "чакыр", "analysis": "чакыр+V+IMP_SG();", "translations": ["звать", "позвать", "приглашение", "призвать", "призывать"]}
+{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": " ", "surface": "Фатихны", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Фатих", "analysis": "фатих+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN;"}
-{"prefix": " ", "surface": "кайтканчы", "analysis": "кайт+V+ADVV_SUCC(ГАнчЫ);"}
-{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom;", "translations": ["брат", "дядя"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom;ул+PN;", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN;", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "кайтканчы", "analysis": "кайт+V+ADVV_SUCC(ГАнчЫ);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "ук", "analysis": "ук+N+Sg+Nom;ук+PART;", "translations": ["же", "стрела"]}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шунда", "analysis": "шул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "Шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "ачуы", "analysis": "ач+V+VN_1(у/ү/в)+POSS_3(СЫ)+Nom;ачу+N+Sg+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": "", "surface": "ачуы", "analysis": "ач+V+VN_1(у/ү/в)+POSS_3(СЫ)+Nom;ачу+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["открывать", "открыть", "злоба"]}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv;", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": " ", "surface": "кабарып", "analysis": "кабар+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Шунда", "analysis": "шул+PN+LOC(ДА);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "Шунда", "analysis": "шул+PN+LOC(ДА);", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "Театрга", "analysis": "театр+N+Sg+DIR(ГА);", "translations": ["театр"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кемнән", "analysis": "кем+PN+ABL(ДАн);"}
-{"prefix": " ", "surface": "сорап", "analysis": "сора+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "Кемнән", "analysis": "кем+PN+ABL(ДАн);", "translations": ["кто"]}
+{"prefix": " ", "surface": "сорап", "analysis": "сора+V+ADVV_ACC(Ып);", "translations": ["спрашивать", "спросить"]}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Берәүдән", "analysis": "бер+Num+NUM_COLL(АУ)+ABL(ДАн);"}
+{"prefix": " ", "surface": "Берәүдән", "analysis": "бер+Num+NUM_COLL(АУ)+ABL(ДАн);", "translations": ["один", "первый"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "сорамады", "analysis": "сора+V+NEG(мА)+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "сорамады", "analysis": "сора+V+NEG(мА)+PST_DEF(ДЫ);", "translations": ["спрашивать", "спросить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "кияүләр", "analysis": "кияү+N+PL(ЛАр)+Nom;кияүлә+V+FUT_INDF(Ыр);кияүлә+V+PCP_FUT(Ыр);"}
-{"prefix": " ", "surface": "белән", "analysis": "белән+POST;"}
+{"prefix": " ", "surface": "кияүләр", "analysis": "кияү+N+PL(ЛАр)+Nom;кияүлә+V+FUT_INDF(Ыр);кияүлә+V+PCP_FUT(Ыр);", "translations": ["жених", "зять"]}
+{"prefix": " ", "surface": "белән", "analysis": "белән+POST;", "translations": ["и", "на", "с"]}
 {"prefix": " ", "surface": "Хәбибрахманнар", "analysis": "NR"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч);кит+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч);кит+V+ADVV_ANT(ГАч);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN;"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
 {"prefix": " ", "surface": "нишләп", "analysis": "нишлә+V+ADVV_ACC(Ып);нишләп+PN;"}
-{"prefix": " ", "surface": "калыйм", "analysis": "кал+V+HOR_SG(Йм);"}
-{"prefix": " ", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "калыйм", "analysis": "кал+V+HOR_SG(Йм);", "translations": ["оставаться", "остаться"]}
+{"prefix": " ", "surface": "диде", "analysis": "ди+V+PST_DEF(ДЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
@@ -6122,53 +6122,53 @@
 {"prefix": " ", "surface": "алакаеп", "analysis": "NR"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;"}
-{"prefix": " ", "surface": "дисең", "analysis": "ди+V+PRES(Й)+2SG(сЫң);"}
+{"prefix": " ", "surface": "Ни", "analysis": "ни+CNJ;ни+PART;ни+PN;", "translations": ["ни", "что"]}
+{"prefix": " ", "surface": "дисең", "analysis": "ди+V+PRES(Й)+2SG(сЫң);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Вәли", "analysis": "вәли+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "кияү", "analysis": "кияү+N+Sg+Nom;"}
+{"prefix": " ", "surface": "кияү", "analysis": "кияү+N+Sg+Nom;", "translations": ["жених", "зять"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
-{"prefix": " ", "surface": "дисеңме", "analysis": "ди+V+PRES(Й)+2SG(сЫң)+INT(мЫ);"}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
+{"prefix": " ", "surface": "дисеңме", "analysis": "ди+V+PRES(Й)+2SG(сЫң)+INT(мЫ);", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "Китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "урыныннан", "analysis": "урын+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "сикереп", "analysis": "сикер+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);"}
+{"prefix": " ", "surface": "урыныннан", "analysis": "урын+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["место"]}
+{"prefix": " ", "surface": "сикереп", "analysis": "сикер+V+ADVV_ACC(Ып);", "translations": ["прыгать", "прыгнуть"]}
+{"prefix": " ", "surface": "тора", "analysis": "тор+V+PRES(Й);", "translations": ["вставать", "встать", "стоять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәбибрахман", "analysis": "NR"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "киттеме", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+INT(мЫ);кит+V+PST_DEF(ДЫ)+INT(мЫ);"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "киттеме", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+INT(мЫ);кит+V+PST_DEF(ДЫ)+INT(мЫ);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Бибинең", "analysis": "NR"}
 {"prefix": " ", "surface": "өстенэ", "analysis": "NR"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);"}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "кире", "analysis": "кире+Adj;кире+Adv;"}
-{"prefix": " ", "surface": "чигенеп", "analysis": "чиген+V+ADVV_ACC(Ып);чик+V+REFL(Ын)+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "кире", "analysis": "кире+Adj;кире+Adv;", "translations": ["обратно", "обратный", "упрямый"]}
+{"prefix": " ", "surface": "чигенеп", "analysis": "чиген+V+ADVV_ACC(Ып);чик+V+REFL(Ын)+ADVV_ACC(Ып);", "translations": ["отступать", "граница"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Китте", "analysis": "кит+V+PST_DEF(ДЫ);"}
+{"prefix": " ", "surface": "Китте", "analysis": "кит+V+PST_DEF(ДЫ);", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;"}
+{"prefix": "", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;", "translations": ["новый"]}
 {"prefix": " ", "surface": "өстенә", "analysis": "өс+N+Sg+POSS_3(СЫ)+DIR(ГА);өстенә+POST;"}
-{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "барып", "analysis": "бар+V+ADVV_ACC(Ып);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гафифә", "analysis": "NR"}
@@ -6178,101 +6178,101 @@
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;"}
-{"prefix": " ", "surface": "кире", "analysis": "кире+Adj;кире+Adv;"}
-{"prefix": " ", "surface": "чигенеп", "analysis": "чиген+V+ADVV_ACC(Ып);чик+V+REFL(Ын)+ADVV_ACC(Ып);"}
+{"prefix": "", "surface": "яңадан", "analysis": "яңа+Adj+Sg+ABL(ДАн);яңадан+Adv;", "translations": ["новый"]}
+{"prefix": " ", "surface": "кире", "analysis": "кире+Adj;кире+Adv;", "translations": ["обратно", "обратный", "упрямый"]}
+{"prefix": " ", "surface": "чигенеп", "analysis": "чиген+V+ADVV_ACC(Ып);чик+V+REFL(Ын)+ADVV_ACC(Ып);", "translations": ["отступать", "граница"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алар", "analysis": "алар+PN;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);"}
+{"prefix": " ", "surface": "Алар", "analysis": "алар+PN;", "translations": ["они"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "киттеләр", "analysis": "ки+V+CAUS(т)+PST_DEF(ДЫ)+3PL(ЛАр);кит+V+CAUS(т)+PASS(Ыл)+PCP_FUT(Ыр);кит+V+PST_DEF(ДЫ)+3PL(ЛАр);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
-{"prefix": " ", "surface": "кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["рука"]}
 {"prefix": " ", "surface": "йомарлап", "analysis": "йомарла+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "иреннәрен", "analysis": "ирен+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "тешләп", "analysis": "теш+N+DISTR(лАп);тешлә+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "иреннәрен", "analysis": "ирен+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["губа"]}
+{"prefix": " ", "surface": "тешләп", "analysis": "теш+N+DISTR(лАп);тешлә+V+ADVV_ACC(Ып);", "translations": ["зуб", "зубной"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": "", "surface": "«", "analysis": "Type4"}
 {"prefix": "", "surface": "эмммм", "analysis": "NR"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;"}
+{"prefix": " ", "surface": "дип", "analysis": "ди+V+ADVV_ACC(Ып);дип+CNJ;", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Бибинең", "analysis": "NR"}
 {"prefix": " ", "surface": "өстенә", "analysis": "өс+N+Sg+POSS_3(СЫ)+DIR(ГА);өстенә+POST;"}
-{"prefix": " ", "surface": "килә", "analysis": "кил+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": " ", "surface": "килә", "analysis": "кил+V+PRES(Й);", "translations": ["идти"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "кача", "analysis": "кач+V+PRES(Й);"}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "кача", "analysis": "кач+V+PRES(Й);", "translations": ["прятаться", "спрятаться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Хәмзә", "analysis": "хәмзә+PROP+Sg+Nom;"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Биби", "analysis": "NR"}
-{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч);кит+V+ADVV_ANT(ГАч);"}
+{"prefix": " ", "surface": "чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч);кит+V+ADVV_ANT(ГАч);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "халыкка", "analysis": "халык+N+Sg+DIR(ГА);", "translations": ["народ", "народный", "толпа"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "карап", "analysis": "кара+V+ADVV_ACC(Ып);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "сузып", "analysis": "суз+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "кулларын", "analysis": "кул+N+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ);", "translations": ["рука"]}
+{"prefix": " ", "surface": "сузып", "analysis": "суз+V+ADVV_ACC(Ып);", "translations": ["тянуть"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Йә", "analysis": "йә+CNJ;йә+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйтегез", "analysis": "әйт+V+IMP_PL(ЫгЫз);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "әйтегез", "analysis": "әйт+V+IMP_PL(ЫгЫз);", "translations": ["говорить", "сказать"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "зинһар", "analysis": "зинһар+MOD;"}
+{"prefix": " ", "surface": "зинһар", "analysis": "зинһар+MOD;", "translations": ["пожалуйста"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "нишләтим", "analysis": "нишләт+V+HOR_SG(Йм);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
-{"prefix": " ", "surface": "боларны", "analysis": "бу+PN+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
+{"prefix": " ", "surface": "боларны", "analysis": "бу+PN+PL(ЛАр)+ACC(нЫ);", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Гайрәтләнеп", "analysis": "гайрәтлән+V+ADVV_ACC(Ып);"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD;", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Боларны", "analysis": "бу+PN+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Боларны", "analysis": "бу+PN+PL(ЛАр)+ACC(нЫ);", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": " ", "surface": "болай", "analysis": "болай+PN;"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART;"}
-{"prefix": " ", "surface": "калдырырга", "analysis": "кал+V+CAUS(ДЫр)+INF_1(ЫргА);калдыр+V+INF_1(ЫргА);"}
-{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;"}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART;", "translations": ["только"]}
+{"prefix": " ", "surface": "калдырырга", "analysis": "кал+V+CAUS(ДЫр)+INF_1(ЫргА);калдыр+V+INF_1(ЫргА);", "translations": ["оставаться", "остаться", "оставить", "оставлять"]}
+{"prefix": " ", "surface": "ярамый", "analysis": "яра+V+NEG(мА)+PRES(Й);ярамый+MOD;", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "караларны", "analysis": "кара+Adj+PL(ЛАр)+ACC(нЫ);кара+N+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;", "translations": ["лицо", "плавать", "сотый", "сто"]}
+{"prefix": " ", "surface": "караларны", "analysis": "кара+Adj+PL(ЛАр)+ACC(нЫ);кара+N+PL(ЛАр)+ACC(нЫ);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "якаларыннан", "analysis": "яка+N+PL(ЛАр)+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Барам", "analysis": "бар+V+PRES(Й)+1SG(м);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "якаларыннан", "analysis": "яка+N+PL(ЛАр)+POSS_3(СЫ)+ABL(ДАн);", "translations": ["воротник"]}
+{"prefix": " ", "surface": "тотып", "analysis": "тот+V+ADVV_ACC(Ып);", "translations": ["держать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "өстерәп", "analysis": "өстерә+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кайтам", "analysis": "кайт+V+PRES(Й)+1SG(м);"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кайтам", "analysis": "кайт+V+PRES(Й)+1SG(м);", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Тиз", "analysis": "тиз+Adj;тиз+Adv;"}
+{"prefix": "", "surface": "Тиз", "analysis": "тиз+Adj;тиз+Adv;", "translations": ["быстро", "быстрый"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "өстәл", "analysis": "өстә+V+PASS(Ыл)+IMP_SG();өстәл+N+Sg+Nom;өстәл+V+IMP_SG();"}
-{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;"}
-{"prefix": " ", "surface": "килә", "analysis": "кил+V+PRES(Й);"}
+{"prefix": " ", "surface": "өстәл", "analysis": "өстә+V+PASS(Ыл)+IMP_SG();өстәл+N+Sg+Nom;өстәл+V+IMP_SG();", "translations": ["добавить", "добавлять", "стол"]}
+{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА);ян+V+REFL(Ын)+PRES(Й);янына+POST;", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
+{"prefix": " ", "surface": "килә", "analysis": "кил+V+PRES(Й);", "translations": ["идти"]}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": " ", "surface": "пласкательныйны", "analysis": "NR"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "ыргытып", "analysis": "ыргы+V+CAUS(т)+ADVV_ACC(Ып);ыргыт+V+ADVV_ACC(Ып);"}
+{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "ыргытып", "analysis": "ыргы+V+CAUS(т)+ADVV_ACC(Ып);ыргыт+V+ADVV_ACC(Ып);", "translations": ["бросать", "бросить"]}
 {"prefix": " ", "surface": "бәрә", "analysis": "бәр+V+PRES(Й);"}
 {"prefix": " ", "surface": "дә", "analysis": "дә+PART;"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
@@ -6283,96 +6283,96 @@
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Кәләпүшен", "analysis": "кәләпүш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
-{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);"}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
+{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
-{"prefix": " ", "surface": "тиз", "analysis": "тиз+Adj;тиз+Adv;"}
+{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ);", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "тиз", "analysis": "тиз+Adj;тиз+Adv;", "translations": ["быстро", "быстрый"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
-{"prefix": " ", "surface": "ала", "analysis": "ал+V+PRES(Й);ала+Adj;"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART;"}
+{"prefix": " ", "surface": "ала", "analysis": "ал+V+PRES(Й);ала+Adj;", "translations": ["алый", "брать", "браться", "взять", "мочь", "пегий"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART;", "translations": ["и", "тоже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "һай", "analysis": "һай+INTRJ;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "каралар", "analysis": "кара+Adj+PL(ЛАр)+Nom;кара+N+PL(ЛАр)+Nom;карала+V+FUT_INDF(Ыр);карала+V+PCP_FUT(Ыр);"}
+{"prefix": " ", "surface": "йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;", "translations": ["лицо", "плавать", "сотый", "сто"]}
+{"prefix": " ", "surface": "каралар", "analysis": "кара+Adj+PL(ЛАр)+Nom;кара+N+PL(ЛАр)+Nom;карала+V+FUT_INDF(Ыр);карала+V+PCP_FUT(Ыр);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Акылымнан", "analysis": "акыл+N+Sg+POSS_1SG(Ым)+ABL(ДАн);"}
+{"prefix": " ", "surface": "Акылымнан", "analysis": "акыл+N+Sg+POSS_1SG(Ым)+ABL(ДАн);", "translations": ["ум"]}
 {"prefix": " ", "surface": "шаштырасыз", "analysis": "шаш+V+CAUS(ДЫр)+PRES(Й)+2PL(сЫз);шаштыр+V+PRES(Й)+2PL(сЫз);"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD;инде+PART;", "translations": ["уже"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Тиз", "analysis": "тиз+Adj;тиз+Adv;"}
+{"prefix": "", "surface": "Тиз", "analysis": "тиз+Adj;тиз+Adv;", "translations": ["быстро", "быстрый"]}
 {"prefix": " ", "surface": "генә", "analysis": "генә+PART;"}
 {"prefix": " ", "surface": "эскәтерне", "analysis": "эскәтер+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "муеныннан", "analysis": "муен+N+Sg+POSS_3(СЫ)+ABL(ДАн);"}
-{"prefix": " ", "surface": "тартып", "analysis": "тарт+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;"}
+{"prefix": " ", "surface": "муеныннан", "analysis": "муен+N+Sg+POSS_3(СЫ)+ABL(ДАн);", "translations": ["шея"]}
+{"prefix": " ", "surface": "тартып", "analysis": "тарт+V+ADVV_ACC(Ып);", "translations": ["тянуть"]}
+{"prefix": " ", "surface": "алып", "analysis": "ал+V+ADVV_ACC(Ып);алып+N+Sg+Nom;", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);"}
+{"prefix": " ", "surface": "башын", "analysis": "баш+N+Sg+POSS_3(СЫ)+ACC(нЫ);", "translations": ["голова"]}
 {"prefix": " ", "surface": "сөртә-сөртә", "analysis": "сөртә-сөртә+Adv;"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "киемнәргә", "analysis": "кием+N+PL(ЛАр)+DIR(ГА);кий+N+Sg+POSS_1SG(Ым)+PL(ЛАр)+DIR(ГА);"}
-{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);"}
+{"prefix": " ", "surface": "киемнәргә", "analysis": "кием+N+PL(ЛАр)+DIR(ГА);кий+N+Sg+POSS_1SG(Ым)+PL(ЛАр)+DIR(ГА);", "translations": ["одежда"]}
+{"prefix": " ", "surface": "таба", "analysis": "таба+N+Sg+Nom;таба+POST;тап+V+PRES(Й);", "translations": ["к", "сковорода", "найти", "находить", "пятно"]}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й);", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;"}
-{"prefix": " ", "surface": "сезгә", "analysis": "сез+PN+DIR(ГА);"}
-{"prefix": " ", "surface": "бирим", "analysis": "бир+V+HOR_SG(Йм);"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;"}
-{"prefix": " ", "surface": "кирәгегезне", "analysis": "кирәк+Adj+Sg+POSS_2PL(ЫгЫз)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN;", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сезгә", "analysis": "сез+PN+DIR(ГА);", "translations": ["ваш", "вы"]}
+{"prefix": " ", "surface": "бирим", "analysis": "бир+V+HOR_SG(Йм);", "translations": ["давать", "даваться", "дать"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ;әле+PART;", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "кирәгегезне", "analysis": "кирәк+Adj+Sg+POSS_2PL(ЫгЫз)+ACC(нЫ);", "translations": ["необходимый", "нужный"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "өстенә", "analysis": "өс+N+Sg+POSS_3(СЫ)+DIR(ГА);өстенә+POST;"}
-{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);"}
+{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);", "translations": ["одеть"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й);", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "кычкыра", "analysis": "кычкыр+V+PRES(Й);"}
+{"prefix": " ", "surface": "кычкыра", "analysis": "кычкыр+V+PRES(Й);", "translations": ["крикнуть", "кричать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;"}
-{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;"}
-{"prefix": " ", "surface": "ката", "analysis": "кат+V+PRES(Й);ката+N+Sg+Nom;ката+POST;"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN;", "translations": ["куда"]}
+{"prefix": " ", "surface": "киез", "analysis": "киез+N+Sg+Nom;", "translations": ["войлок"]}
+{"prefix": " ", "surface": "ката", "analysis": "кат+V+PRES(Й);ката+N+Sg+Nom;ката+POST;", "translations": ["слой", "этаж"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Китерегез", "analysis": "китер+V+IMP_PL(ЫгЫз);"}
-{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;"}
+{"prefix": " ", "surface": "Китерегез", "analysis": "китер+V+IMP_PL(ЫгЫз);", "translations": ["привести", "приводить"]}
+{"prefix": " ", "surface": "тизрәк", "analysis": "тиз+Adj+COMP(рАк)+Sg+Nom;тиз+Adv+COMP(рАк)+Sg+Nom;", "translations": ["быстро", "быстрый"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;"}
-{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ;ә+PART;", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й);менә+PART;", "translations": ["подниматься", "подняться", "вот"]}
+{"prefix": " ", "surface": "монда", "analysis": "бу+PN+LOC(ДА);монда+Adv;", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": " ", "surface": "икән", "analysis": "икән+MOD;икән+PART;"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
-{"prefix": " ", "surface": "Йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;"}
-{"prefix": " ", "surface": "караларны", "analysis": "кара+Adj+PL(ЛАр)+ACC(нЫ);кара+N+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "Йөзе", "analysis": "йөз+N+Sg+POSS_3(СЫ)+Nom;йөз+Num+POSS_3(СЫ)+Nom;", "translations": ["лицо", "плавать", "сотый", "сто"]}
+{"prefix": " ", "surface": "караларны", "analysis": "кара+Adj+PL(ЛАр)+ACC(нЫ);кара+N+PL(ЛАр)+ACC(нЫ);", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "Ашыгып-ашыгып", "analysis": "NR"}
-{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);"}
+{"prefix": " ", "surface": "кия", "analysis": "ки+V+PRES(Й);", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Бәдбәхетләрне", "analysis": "бәдбәхет+N+PL(ЛАр)+ACC(нЫ);"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "муены", "analysis": "муен+N+Sg+POSS_3(СЫ)+Nom;"}
+{"prefix": " ", "surface": "муены", "analysis": "муен+N+Sg+POSS_3(СЫ)+Nom;", "translations": ["шея"]}
 {"prefix": " ", "surface": "астына", "analysis": "ас+N+Sg+POSS_3(СЫ)+DIR(ГА);ас+V+CAUS(т)+REFL(Ын)+PRES(Й);астына+POST;"}
-{"prefix": " ", "surface": "килгәннәрне", "analysis": "кил+V+PCP_PS(ГАн)+PL(ЛАр)+ACC(нЫ);"}
+{"prefix": " ", "surface": "килгәннәрне", "analysis": "кил+V+PCP_PS(ГАн)+PL(ЛАр)+ACC(нЫ);", "translations": ["идти"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);"}
+{"prefix": "", "surface": "Чыгып", "analysis": "чык+V+ADVV_ACC(Ып);", "translations": ["выйти", "выходить"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й);кит+V+PRES(Й);", "translations": ["одеть", "уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": " ", "surface": "Пәрдә", "analysis": "пәрдә+N+Sg+Nom;"}
-{"prefix": " ", "surface": "төшә", "analysis": "төш+V+PRES(Й);"}
+{"prefix": " ", "surface": "төшә", "analysis": "төш+V+PRES(Й);", "translations": ["опускаться", "опуститься", "сон"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "1908", "analysis": "Num"}
-{"prefix": " ", "surface": "ел", "analysis": "ел+N+Sg+Nom;"}
-{"prefix": " ", "surface": "Пьесаны", "analysis": "пьеса+N+Sg+ACC(нЫ);"}
-{"prefix": " ", "surface": "йөкләргә", "analysis": "йөк+N+PL(ЛАр)+DIR(ГА);йөклә+V+INF_1(ЫргА);"}
+{"prefix": " ", "surface": "ел", "analysis": "ел+N+Sg+Nom;", "translations": ["год²"]}
+{"prefix": " ", "surface": "Пьесаны", "analysis": "пьеса+N+Sg+ACC(нЫ);", "translations": ["пьеса"]}
+{"prefix": " ", "surface": "йөкләргә", "analysis": "йөк+N+PL(ЛАр)+DIR(ГА);йөклә+V+INF_1(ЫргА);", "translations": ["груз"]}
 {"prefix": "", "surface": ":", "analysis": "Type2"}
 {"prefix": " ", "surface": "TXTPDF", "analysis": "Latin"}
 {"prefix": "", "surface": "←", "analysis": "Sign"}
-{"prefix": " ", "surface": "Артка", "analysis": "арт+Adj+Sg+DIR(ГА);"}
+{"prefix": " ", "surface": "Артка", "analysis": "арт+Adj+Sg+DIR(ГА);", "translations": ["за", "зад", "из-за", "позади", "увеличиваться", "увеличиться"]}

--- a/android-app/src/main/assets/sample_book.ttmorph.jsonl
+++ b/android-app/src/main/assets/sample_book.ttmorph.jsonl
@@ -5,897 +5,897 @@
 {"prefix": " ", "surface": "КАБЫЗ", "analysis": "кабыз+V+IMP_SG()"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "Авыл", "analysis": "авыл+N+Sg+Nom"}
+{"prefix": "", "surface": "Авыл", "analysis": "авыл+N+Sg+Nom", "translations": ["деревня", "село", "сельский"]}
 {"prefix": " ", "surface": "ишегалды", "analysis": "ишегалды+N+Sg+POSS_3(СЫ)+Nom"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv", "translations": ["нынешний", "сейчас"]}
 {"prefix": " ", "surface": "андыйлар", "analysis": "андый+Adj+PL(ЛАр)+Nom"}
-{"prefix": " ", "surface": "юктыр", "analysis": "юк+MOD+PROB(ДЫр)"}
+{"prefix": " ", "surface": "юктыр", "analysis": "юк+MOD+PROB(ДЫр)", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Капкасы", "analysis": "капка+N+Sg+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD"}
+{"prefix": " ", "surface": "Капкасы", "analysis": "капка+N+Sg+POSS_3(СЫ)+Nom", "translations": ["ворота"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Агач", "analysis": "агач+N+Sg+Nom"}
-{"prefix": " ", "surface": "коймасы", "analysis": "койма+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "Агач", "analysis": "агач+N+Sg+Nom", "translations": ["дерево"]}
+{"prefix": " ", "surface": "коймасы", "analysis": "койма+N+Sg+POSS_3(СЫ)+Nom", "translations": ["забор"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "Чия", "analysis": "чия+N+Sg+Nom"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "миләшләр", "analysis": "миләш+N+PL(ЛАр)+Nom"}
-{"prefix": " ", "surface": "үсә", "analysis": "үс+V+PRES(Й)"}
+{"prefix": " ", "surface": "үсә", "analysis": "үс+V+PRES(Й)", "translations": ["вырасти", "расти"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Эскәмиядә", "analysis": "эскәмия+N+Sg+LOC(ДА)"}
-{"prefix": " ", "surface": "Бабай", "analysis": "бабай+N+Sg+Nom"}
-{"prefix": " ", "surface": "утыра", "analysis": "утыр+V+PRES(Й)"}
+{"prefix": " ", "surface": "Бабай", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
+{"prefix": " ", "surface": "утыра", "analysis": "утыр+V+PRES(Й)", "translations": ["посидеть", "садиться", "сидеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Капкага", "analysis": "капка+N+Sg+DIR(ГА)"}
+{"prefix": " ", "surface": "Капкага", "analysis": "капка+N+Sg+DIR(ГА)", "translations": ["ворота"]}
 {"prefix": " ", "surface": "шакыйлар", "analysis": "шакы+V+PRES(Й)+3PL(ЛАр)"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кем", "analysis": "кем+PN"}
+{"prefix": " ", "surface": "Кем", "analysis": "кем+PN", "translations": ["кто"]}
 {"prefix": " ", "surface": "анда", "analysis": "анда+PN"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Исәнмесез", "analysis": "исәнмесез+INTRJ"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Галимҗан", "analysis": "галимҗан+PROP+Sg+Nom"}
-{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom"}
-{"prefix": " ", "surface": "сезме", "analysis": "сез+PN+INT(мЫ)"}
+{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
+{"prefix": " ", "surface": "сезме", "analysis": "сез+PN+INT(мЫ)", "translations": ["ваш", "вы"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кем", "analysis": "кем+PN"}
+{"prefix": " ", "surface": "Кем", "analysis": "кем+PN", "translations": ["кто"]}
 {"prefix": " ", "surface": "анда", "analysis": "анда+PN"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "Әлфия", "analysis": "әлфия+PROP+Sg+Nom"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD"}
-{"prefix": " ", "surface": "кер", "analysis": "кер+N+Sg+Nom"}
+{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD", "translations": ["в таком случае", "если так", "тогда"]}
+{"prefix": " ", "surface": "кер", "analysis": "кер+N+Sg+Nom", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Әлфия", "analysis": "әлфия+PROP+Sg+Nom"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD"}
+{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD", "translations": ["да"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "исәнмесез", "analysis": "исәнмесез+INTRJ"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "Әлфия", "analysis": "әлфия+PROP+Sg+Nom"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "Казаннан", "analysis": "казан+N+Sg+ABL(ДАн)"}
-{"prefix": " ", "surface": "килдем", "analysis": "кил+V+PST_DEF(ДЫ)+1SG(м)"}
+{"prefix": " ", "surface": "Казаннан", "analysis": "казан+N+Sg+ABL(ДАн)", "translations": ["казан"]}
+{"prefix": " ", "surface": "килдем", "analysis": "кил+V+PST_DEF(ДЫ)+1SG(м)", "translations": ["идти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "җырлар", "analysis": "җыр+N+PL(ЛАр)+Nom"}
-{"prefix": " ", "surface": "яздырам", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+1SG(м)"}
+{"prefix": " ", "surface": "җырлар", "analysis": "җыр+N+PL(ЛАр)+Nom", "translations": ["песня"]}
+{"prefix": " ", "surface": "яздырам", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+1SG(м)", "translations": ["весна", "написать", "писать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "проект", "analysis": "проект+N+Sg+Nom"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST"}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST", "translations": ["для", "за"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Күршеләр", "analysis": "күрше+N+PL(ЛАр)+Nom"}
-{"prefix": " ", "surface": "әйтте", "analysis": "әйт+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "Күршеләр", "analysis": "күрше+N+PL(ЛАр)+Nom", "translations": ["сосед", "соседний"]}
+{"prefix": " ", "surface": "әйтте", "analysis": "әйт+V+PST_DEF(ДЫ)", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сез", "analysis": "сез+PN"}
+{"prefix": " ", "surface": "сез", "analysis": "сез+PN", "translations": ["ваш", "вы"]}
 {"prefix": " ", "surface": "борыңгы", "analysis": "NR"}
-{"prefix": " ", "surface": "җырларны", "analysis": "җыр+N+PL(ЛАр)+ACC(нЫ)"}
-{"prefix": " ", "surface": "беләсез", "analysis": "бел+V+PRES(Й)+2PL(сЫз)"}
+{"prefix": " ", "surface": "җырларны", "analysis": "җыр+N+PL(ЛАр)+ACC(нЫ)", "translations": ["песня"]}
+{"prefix": " ", "surface": "беләсез", "analysis": "бел+V+PRES(Й)+2PL(сЫз)", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": " ", "surface": "(", "analysis": "Type3"}
 {"prefix": "", "surface": "уфтанып", "analysis": "уфтан+V+ADVV_ACC(Ып)"}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD"}
+{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD", "translations": ["да"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "беләм", "analysis": "бел+V+PRES(Й)+1SG(м)"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
+{"prefix": " ", "surface": "беләм", "analysis": "бел+V+PRES(Й)+1SG(м)", "translations": ["знать", "узнать", "уметь"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "беләм", "analysis": "бел+V+PRES(Й)+1SG(м)"}
+{"prefix": " ", "surface": "беләм", "analysis": "бел+V+PRES(Й)+1SG(м)", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Яздырасыңмы", "analysis": "яз+V+CAUS(ДЫр)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ)"}
+{"prefix": " ", "surface": "Яздырасыңмы", "analysis": "яз+V+CAUS(ДЫр)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ)", "translations": ["весна", "написать", "писать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD"}
+{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD", "translations": ["да"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сез", "analysis": "сез+PN"}
+{"prefix": " ", "surface": "сез", "analysis": "сез+PN", "translations": ["ваш", "вы"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кайда", "analysis": "кай+PN+LOC(ДА)"}
+{"prefix": " ", "surface": "Кайда", "analysis": "кай+PN+LOC(ДА)", "translations": ["какой"]}
 {"prefix": " ", "surface": "магнитофон", "analysis": "магнитофон+N+Sg+Nom"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сезне", "analysis": "сез+PN+ACC(нЫ)"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
-{"prefix": " ", "surface": "яздырдылармы", "analysis": "яз+V+CAUS(ДЫр)+PST_DEF(ДЫ)+3PL(ЛАр)+INT(мЫ)"}
+{"prefix": " ", "surface": "Сезне", "analysis": "сез+PN+ACC(нЫ)", "translations": ["ваш", "вы"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
+{"prefix": " ", "surface": "яздырдылармы", "analysis": "яз+V+CAUS(ДЫр)+PST_DEF(ДЫ)+3PL(ЛАр)+INT(мЫ)", "translations": ["весна", "написать", "писать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Миллион", "analysis": "миллион+Num"}
-{"prefix": " ", "surface": "тапкыр", "analysis": "тапкыр+Adj"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
+{"prefix": " ", "surface": "Миллион", "analysis": "миллион+Num", "translations": ["миллион", "миллионный"]}
+{"prefix": " ", "surface": "тапкыр", "analysis": "тапкыр+Adj", "translations": ["находчивый"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бумы", "analysis": "бу+N+Sg+Nom+INT(мЫ)"}
+{"prefix": " ", "surface": "Бумы", "analysis": "бу+N+Sg+Nom+INT(мЫ)", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": " ", "surface": "магнитофоның", "analysis": "магнитофон+N+Sg+POSS_2SG(Ың)+Nom"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бикрәк", "analysis": "NR"}
-{"prefix": " ", "surface": "нечкә", "analysis": "нечкә+Adj"}
+{"prefix": " ", "surface": "нечкә", "analysis": "нечкә+Adj", "translations": ["тонкий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": " ", "surface": "ноутбук", "analysis": "Rus"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv"}
-{"prefix": " ", "surface": "барысын", "analysis": "бары+PN+POSS_3(СЫ)+ACC(нЫ)"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART"}
-{"prefix": " ", "surface": "компьютерга", "analysis": "компьютер+N+Sg+DIR(ГА)"}
-{"prefix": " ", "surface": "яздыралар", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+3PL(ЛАр)"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "барысын", "analysis": "бары+PN+POSS_3(СЫ)+ACC(нЫ)", "translations": ["весь"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "компьютерга", "analysis": "компьютер+N+Sg+DIR(ГА)", "translations": ["компьютер"]}
+{"prefix": " ", "surface": "яздыралар", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+3PL(ЛАр)", "translations": ["весна", "написать", "писать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й)"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
+{"prefix": " ", "surface": "Менә", "analysis": "мен+V+PRES(Й)", "translations": ["подниматься", "подняться"]}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": " ", "surface": "микрофон", "analysis": "микрофон+N+Sg+Nom"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "тавыш", "analysis": "тавыш+N+Sg+Nom"}
-{"prefix": " ", "surface": "картасы", "analysis": "карта+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "тавыш", "analysis": "тавыш+N+Sg+Nom", "translations": ["голос", "звук", "крик", "шум"]}
+{"prefix": " ", "surface": "картасы", "analysis": "карта+N+Sg+POSS_3(СЫ)+Nom", "translations": ["карта"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й)"}
+{"prefix": " ", "surface": "Ярый", "analysis": "яра+V+PRES(Й)", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аңлашылды", "analysis": "аңла+V+RECP(Ыш)+PASS(Ыл)+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "аңлашылды", "analysis": "аңла+V+RECP(Ыш)+PASS(Ыл)+PST_DEF(ДЫ)", "translations": ["понимать", "понять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кинога", "analysis": "кино+N+Sg+DIR(ГА)"}
-{"prefix": " ", "surface": "төшермисеңме", "analysis": "төшер+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ)"}
+{"prefix": " ", "surface": "Кинога", "analysis": "кино+N+Sg+DIR(ГА)", "translations": ["кино"]}
+{"prefix": " ", "surface": "төшермисеңме", "analysis": "төшер+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom+INT(мЫ)", "translations": ["опускать", "опустить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Элек", "analysis": "элек+Adv"}
-{"prefix": " ", "surface": "төшерәләр", "analysis": "төшер+V+PRES(Й)+3PL(ЛАр)"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "Элек", "analysis": "элек+Adv", "translations": ["бывший", "раньше"]}
+{"prefix": " ", "surface": "төшерәләр", "analysis": "төшер+V+PRES(Й)+3PL(ЛАр)", "translations": ["опускать", "опустить"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN"}
-{"prefix": " ", "surface": "басыйм", "analysis": "бас+V+HOR_SG(Йм)"}
-{"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
-{"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кая", "analysis": "кая+PN"}
-{"prefix": " ", "surface": "телисез", "analysis": "телә+V+PRES(Й)+2PL(сЫз)"}
-{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА)"}
-{"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Авыл", "analysis": "авыл+N+Sg+Nom"}
-{"prefix": " ", "surface": "тавышлары", "analysis": "тавыш+N+PL(ЛАр)+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART"}
-{"prefix": " ", "surface": "керсең", "analysis": "кер+N+Sg+2SG(сЫң)"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN", "translations": ["куда"]}
+{"prefix": " ", "surface": "басыйм", "analysis": "бас+V+HOR_SG(Йм)", "translations": ["вставать", "встать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Төшермисең", "analysis": "төшер+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom"}
+{"prefix": " ", "surface": "Кая", "analysis": "кая+PN", "translations": ["куда"]}
+{"prefix": " ", "surface": "телисез", "analysis": "телә+V+PRES(Й)+2PL(сЫз)", "translations": ["желать", "пожелать"]}
+{"prefix": " ", "surface": "шунда", "analysis": "шул+PN+LOC(ДА)", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": "", "surface": ".", "analysis": "Type1"}
+{"prefix": " ", "surface": "Авыл", "analysis": "авыл+N+Sg+Nom", "translations": ["деревня", "село", "сельский"]}
+{"prefix": " ", "surface": "тавышлары", "analysis": "тавыш+N+PL(ЛАр)+POSS_3(СЫ)+Nom", "translations": ["голос", "звук", "крик", "шум"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "керсең", "analysis": "кер+N+Sg+2SG(сЫң)", "translations": ["войти", "входить", "грязь"]}
+{"prefix": "", "surface": "?", "analysis": "Type1"}
+{"prefix": "", "surface": "\n", "analysis": "NL"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
+{"prefix": "", "surface": ".", "analysis": "Type1"}
+{"prefix": " ", "surface": "Төшермисең", "analysis": "төшер+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom", "translations": ["опускать", "опустить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "димәк", "analysis": "ди+V+INF_2(мАк)"}
+{"prefix": " ", "surface": "димәк", "analysis": "ди+V+INF_2(мАк)", "translations": ["говорить", "сказать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "БААЙ", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ну", "analysis": "ну+INTRJ"}
-{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й)"}
+{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й)", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Авыл", "analysis": "авыл+N+Sg+Nom"}
-{"prefix": " ", "surface": "тавышлары", "analysis": "тавыш+N+PL(ЛАр)+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА)"}
-{"prefix": " ", "surface": "нигә", "analysis": "ни+PN+DIR(ГА)"}
+{"prefix": " ", "surface": "Авыл", "analysis": "авыл+N+Sg+Nom", "translations": ["деревня", "село", "сельский"]}
+{"prefix": " ", "surface": "тавышлары", "analysis": "тавыш+N+PL(ЛАр)+POSS_3(СЫ)+Nom", "translations": ["голос", "звук", "крик", "шум"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА)", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "нигә", "analysis": "ни+PN+DIR(ГА)", "translations": ["ни", "что"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Алай", "analysis": "алай+PN"}
 {"prefix": " ", "surface": "аутентичныйрак", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм)"}
+{"prefix": " ", "surface": "Белмим", "analysis": "бел+V+NEG(мА)+HOR_SG(Йм)", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN"}
-{"prefix": " ", "surface": "сөйлисең", "analysis": "сөйлә+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom"}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "сөйлисең", "analysis": "сөйлә+V+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom", "translations": ["говорить", "рассказывать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Әйдә", "analysis": "әйдә+INTRJ"}
+{"prefix": " ", "surface": "Әйдә", "analysis": "әйдә+INTRJ", "translations": ["давай"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD"}
-{"prefix": " ", "surface": "сыер", "analysis": "сыер+N+Sg+Nom"}
+{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD", "translations": ["в таком случае", "если так", "тогда"]}
+{"prefix": " ", "surface": "сыер", "analysis": "сыер+N+Sg+Nom", "translations": ["корова"]}
 {"prefix": " ", "surface": "абзары", "analysis": "абзар+N+Sg+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА)"}
+{"prefix": " ", "surface": "янына", "analysis": "ян+N+Sg+POSS_3(СЫ)+DIR(ГА)", "translations": ["бок", "гореть", "к", "мимо", "сгореть", "у", "угрожать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "анда", "analysis": "анда+PN"}
-{"prefix": " ", "surface": "авыл", "analysis": "авыл+N+Sg+Nom"}
-{"prefix": " ", "surface": "тавышлары", "analysis": "тавыш+N+PL(ЛАр)+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "авыл", "analysis": "авыл+N+Sg+Nom", "translations": ["деревня", "село", "сельский"]}
+{"prefix": " ", "surface": "тавышлары", "analysis": "тавыш+N+PL(ЛАр)+POSS_3(СЫ)+Nom", "translations": ["голос", "звук", "крик", "шум"]}
 {"prefix": " ", "surface": "байтак", "analysis": "байтак+Adj"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Синең", "analysis": "син+PN+GEN(нЫң)"}
+{"prefix": " ", "surface": "Синең", "analysis": "син+PN+GEN(нЫң)", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "магнитофоның", "analysis": "магнитофон+N+Sg+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "исләр", "analysis": "ис+N+PL(ЛАр)+Nom"}
-{"prefix": " ", "surface": "яздырмыймы", "analysis": "яз+V+CAUS(ДЫр)+NEG(мА)+PRES(Й)+INT(мЫ)"}
+{"prefix": " ", "surface": "исләр", "analysis": "ис+N+PL(ЛАр)+Nom", "translations": ["дуть", "запах"]}
+{"prefix": " ", "surface": "яздырмыймы", "analysis": "яз+V+CAUS(ДЫр)+NEG(мА)+PRES(Й)+INT(мЫ)", "translations": ["весна", "написать", "писать"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD"}
+{"prefix": " ", "surface": "Юк", "analysis": "юк+MOD", "translations": ["быть", "нет", "отсутствующий"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Анысы", "analysis": "анысы+PN"}
-{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj"}
+{"prefix": " ", "surface": "яхшы", "analysis": "яхшы+Adj", "translations": ["лучше", "лучший", "хороший", "хорошо"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)", "translations": ["берег"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "нәрсәне", "analysis": "нәрсә+PN+ACC(нЫ)"}
-{"prefix": " ", "surface": "җырлыйм", "analysis": "җырла+V+HOR_SG(Йм)"}
+{"prefix": " ", "surface": "нәрсәне", "analysis": "нәрсә+PN+ACC(нЫ)", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "җырлыйм", "analysis": "җырла+V+HOR_SG(Йм)", "translations": ["петь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Күпме", "analysis": "күп+Adj+INT(мЫ)"}
-{"prefix": " ", "surface": "минут", "analysis": "минут+N+Sg+Nom"}
+{"prefix": " ", "surface": "Күпме", "analysis": "күп+Adj+INT(мЫ)", "translations": ["много"]}
+{"prefix": " ", "surface": "минут", "analysis": "минут+N+Sg+Nom", "translations": ["минута"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Бер-ике", "analysis": "бер-ике+Num"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Галимҗан", "analysis": "галимҗан+PROP+Sg+Nom"}
-{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й)"}
-{"prefix": " ", "surface": "күпме", "analysis": "күп+Adj+INT(мЫ)"}
-{"prefix": " ", "surface": "җыр", "analysis": "җыр+N+Sg+Nom"}
-{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й)"}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й)", "translations": ["подниматься", "подняться"]}
+{"prefix": " ", "surface": "күпме", "analysis": "күп+Adj+INT(мЫ)", "translations": ["много"]}
+{"prefix": " ", "surface": "җыр", "analysis": "җыр+N+Sg+Nom", "translations": ["песня"]}
+{"prefix": " ", "surface": "бара", "analysis": "бар+V+PRES(Й)", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шулкадәр", "analysis": "шулкадәр+Adv"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сәер", "analysis": "сәер+Adj"}
+{"prefix": " ", "surface": "Сәер", "analysis": "сәер+Adj", "translations": ["странно", "странный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "элек", "analysis": "элек+Adv"}
-{"prefix": " ", "surface": "ике", "analysis": "ике+Num"}
-{"prefix": " ", "surface": "минут", "analysis": "минут+N+Sg+Nom"}
-{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)"}
-{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м)"}
+{"prefix": " ", "surface": "элек", "analysis": "элек+Adv", "translations": ["бывший", "раньше"]}
+{"prefix": " ", "surface": "ике", "analysis": "ике+Num", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "минут", "analysis": "минут+N+Sg+Nom", "translations": ["минута"]}
+{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)", "translations": ["петь"]}
+{"prefix": " ", "surface": "идем", "analysis": "и+V+PST_DEF(ДЫ)+1SG(м)", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аннары", "analysis": "аннары+PN"}
-{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ)"}
-{"prefix": " ", "surface": "телевизорда", "analysis": "телевизор+N+Sg+LOC(ДА)"}
-{"prefix": " ", "surface": "күрсәткәннәр", "analysis": "күрсәт+V+PCP_PS(ГАн)+PL(ЛАр)+Nom"}
+{"prefix": " ", "surface": "аннары", "analysis": "аннары+PN", "translations": ["далее", "затем", "потом"]}
+{"prefix": " ", "surface": "шуны", "analysis": "шул+PN+ACC(нЫ)", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "телевизорда", "analysis": "телевизор+N+Sg+LOC(ДА)", "translations": ["телевизор"]}
+{"prefix": " ", "surface": "күрсәткәннәр", "analysis": "күрсәт+V+PCP_PS(ГАн)+PL(ЛАр)+Nom", "translations": ["показать", "показывать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ну", "analysis": "ну+INTRJ"}
-{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й)"}
+{"prefix": " ", "surface": "ярый", "analysis": "яра+V+PRES(Й)", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ", "translations": ["давай"]}
 {"prefix": "", "surface": "", "analysis": "Error"}
-{"prefix": " - ", "surface": "әзермен", "analysis": "әзер+Adj+1SG(мЫн)"}
+{"prefix": " - ", "surface": "әзермен", "analysis": "әзер+Adj+1SG(мЫн)", "translations": ["готовый"]}
 {"prefix": " ", "surface": "анда", "analysis": "анда+PN"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "", "analysis": "Error"}
-{"prefix": " - ", "surface": "сузыйм", "analysis": "суз+V+HOR_SG(Йм)"}
-{"prefix": " ", "surface": "берне", "analysis": "бер+Num+ACC(нЫ)"}
+{"prefix": " - ", "surface": "сузыйм", "analysis": "суз+V+HOR_SG(Йм)", "translations": ["тянуть"]}
+{"prefix": " ", "surface": "берне", "analysis": "бер+Num+ACC(нЫ)", "translations": ["один", "первый"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Фамилиягез", "analysis": "фамилия+N+Sg+POSS_2PL(ЫгЫз)+Nom"}
-{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN"}
+{"prefix": " ", "surface": "Фамилиягез", "analysis": "фамилия+N+Sg+POSS_2PL(ЫгЫз)+Nom", "translations": ["фамилия"]}
+{"prefix": " ", "surface": "ничек", "analysis": "ничек+PN", "translations": ["как"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN", "translations": ["вещь", "что"]}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST", "translations": ["для", "за"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тарих", "analysis": "тарих+N+Sg+Nom"}
-{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST"}
+{"prefix": " ", "surface": "Тарих", "analysis": "тарих+N+Sg+Nom", "translations": ["история"]}
+{"prefix": " ", "surface": "өчен", "analysis": "өчен+POST", "translations": ["для", "за"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD"}
+{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD", "translations": ["в таком случае", "если так", "тогда"]}
 {"prefix": " ", "surface": "Галимҗанов", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бабаем", "analysis": "бабай+N+Sg+POSS_1SG(Ым)+Nom"}
-{"prefix": " ", "surface": "хөрмәтенә", "analysis": "хөрмәт+N+Sg+POSS_3(СЫ)+DIR(ГА)"}
+{"prefix": " ", "surface": "Бабаем", "analysis": "бабай+N+Sg+POSS_1SG(Ым)+Nom", "translations": ["дед"]}
+{"prefix": " ", "surface": "хөрмәтенә", "analysis": "хөрмәт+N+Sg+POSS_3(СЫ)+DIR(ГА)", "translations": ["уважение"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Окей", "analysis": "Rus"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Галимҗан", "analysis": "галимҗан+PROP+Sg+Nom"}
 {"prefix": " ", "surface": "Галимҗанов", "analysis": "NR"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "Котлы", "analysis": "кот+N+ATTR_MUN(лЫ)"}
+{"prefix": " ", "surface": "Котлы", "analysis": "кот+N+ATTR_MUN(лЫ)", "translations": ["душа", "красота"]}
 {"prefix": " ", "surface": "Бүкәш", "analysis": "NR"}
-{"prefix": " ", "surface": "авылы", "analysis": "авыл+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "авылы", "analysis": "авыл+N+Sg+POSS_3(СЫ)+Nom", "translations": ["деревня", "село", "сельский"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "26", "analysis": "Num"}
-{"prefix": " ", "surface": "апрель", "analysis": "апрель+N+Sg+Nom"}
+{"prefix": " ", "surface": "апрель", "analysis": "апрель+N+Sg+Nom", "translations": ["апрель"]}
 {"prefix": " ", "surface": "2020", "analysis": "Num"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярыймы", "analysis": "яра+V+PRES(Й)+INT(мЫ)"}
+{"prefix": " ", "surface": "Ярыймы", "analysis": "яра+V+PRES(Й)+INT(мЫ)", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Җырлый", "analysis": "җырла+V+PRES(Й)"}
-{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й)"}
+{"prefix": "", "surface": "Җырлый", "analysis": "җырла+V+PRES(Й)", "translations": ["петь"]}
+{"prefix": " ", "surface": "башлый", "analysis": "башла+V+PRES(Й)", "translations": ["начать", "начаться", "начинать", "начинаться"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Каз", "analysis": "каз+N+Sg+Nom"}
-{"prefix": " ", "surface": "канаты", "analysis": "канат+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "Каз", "analysis": "каз+N+Sg+Nom", "translations": ["гусь"]}
+{"prefix": " ", "surface": "канаты", "analysis": "канат+N+Sg+POSS_3(СЫ)+Nom", "translations": ["крыло"]}
 {"prefix": " ", "surface": "кат-кат", "analysis": "кат-кат+Adv"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)"}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "Ир", "analysis": "ир+N+Sg+Nom"}
-{"prefix": " ", "surface": "канаты", "analysis": "канат+N+Sg+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "ат", "analysis": "ат+N+Sg+Nom"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)"}
+{"prefix": " ", "surface": "Ир", "analysis": "ир+N+Sg+Nom", "translations": ["мужчина"]}
+{"prefix": " ", "surface": "канаты", "analysis": "канат+N+Sg+POSS_3(СЫ)+Nom", "translations": ["крыло"]}
+{"prefix": " ", "surface": "ат", "analysis": "ат+N+Sg+Nom", "translations": ["лошадь", "стрелять"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ";", "analysis": "Type2"}
-{"prefix": " ", "surface": "Чит", "analysis": "чит+Adj"}
-{"prefix": " ", "surface": "җирләрдә", "analysis": "җир+N+PL(ЛАр)+LOC(ДА)"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv"}
-{"prefix": " ", "surface": "күп", "analysis": "күп+Adj"}
-{"prefix": " ", "surface": "йөрсәң", "analysis": "йөр+V+COND(сА)+2SG(ң)"}
+{"prefix": " ", "surface": "Чит", "analysis": "чит+Adj", "translations": ["чужой"]}
+{"prefix": " ", "surface": "җирләрдә", "analysis": "җир+N+PL(ЛАр)+LOC(ДА)", "translations": ["земля", "земной"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv", "translations": ["замок", "очень"]}
+{"prefix": " ", "surface": "күп", "analysis": "күп+Adj", "translations": ["много"]}
+{"prefix": " ", "surface": "йөрсәң", "analysis": "йөр+V+COND(сА)+2SG(ң)", "translations": ["походить", "ходить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "Сөйгән", "analysis": "сөй+V+PCP_PS(ГАн)"}
-{"prefix": " ", "surface": "ярың", "analysis": "яр+N+Sg+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "ят", "analysis": "ят+Adj"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)"}
+{"prefix": " ", "surface": "Сөйгән", "analysis": "сөй+V+PCP_PS(ГАн)", "translations": ["любить"]}
+{"prefix": " ", "surface": "ярың", "analysis": "яр+N+Sg+POSS_2SG(Ың)+Nom", "translations": ["берег"]}
+{"prefix": " ", "surface": "ят", "analysis": "ят+Adj", "translations": ["лечь", "ложиться", "чужой"]}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Галимҗан", "analysis": "галимҗан+PROP+Sg+Nom"}
-{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom"}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "борыңгы", "analysis": "NR"}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
+{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN", "translations": ["как"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
 {"prefix": " ", "surface": "борыңгы", "analysis": "NR"}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ)"}
-{"prefix": " ", "surface": "хәтта", "analysis": "хәтта+CNJ"}
+{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ)", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "хәтта", "analysis": "хәтта+CNJ", "translations": ["даже"]}
 {"prefix": " ", "surface": "Первый", "analysis": "Rus"}
-{"prefix": " ", "surface": "каналда", "analysis": "канал+N+Sg+LOC(ДА)"}
-{"prefix": " ", "surface": "күрсәтәләр", "analysis": "күрсәт+V+PRES(Й)+3PL(ЛАр)"}
+{"prefix": " ", "surface": "каналда", "analysis": "канал+N+Sg+LOC(ДА)", "translations": ["канал"]}
+{"prefix": " ", "surface": "күрсәтәләр", "analysis": "күрсәт+V+PRES(Й)+3PL(ЛАр)", "translations": ["показать", "показывать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)", "translations": ["берег"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "матур", "analysis": "матур+Adj"}
-{"prefix": " ", "surface": "җыр", "analysis": "җыр+N+Sg+Nom"}
-{"prefix": " ", "surface": "булсын", "analysis": "бул+V+JUS_SG(сЫн)"}
+{"prefix": " ", "surface": "матур", "analysis": "матур+Adj", "translations": ["красиво", "красивый"]}
+{"prefix": " ", "surface": "җыр", "analysis": "җыр+N+Sg+Nom", "translations": ["песня"]}
+{"prefix": " ", "surface": "булсын", "analysis": "бул+V+JUS_SG(сЫн)", "translations": ["быть", "случиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv"}
-{"prefix": " ", "surface": "ниндиләрен", "analysis": "нинди+PN+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ)"}
-{"prefix": " ", "surface": "беләсез", "analysis": "бел+V+PRES(Й)+2PL(сЫз)"}
+{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "ниндиләрен", "analysis": "нинди+PN+PL(ЛАр)+POSS_3(СЫ)+ACC(нЫ)", "translations": ["какой"]}
+{"prefix": " ", "surface": "беләсез", "analysis": "бел+V+PRES(Й)+2PL(сЫз)", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Пленкаң", "analysis": "пленка+N+Sg+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "җитәрме", "analysis": "җит+V+PCP_FUT(Ыр)+INT(мЫ)"}
+{"prefix": " ", "surface": "җитәрме", "analysis": "җит+V+PCP_FUT(Ыр)+INT(мЫ)", "translations": ["дойти", "доходить"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Җитәрлек", "analysis": "җит+V+PCP_FUT(Ыр)+PSBL(лЫк)"}
+{"prefix": " ", "surface": "Җитәрлек", "analysis": "җит+V+PCP_FUT(Ыр)+PSBL(лЫк)", "translations": ["дойти", "доходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD"}
-{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й)"}
+{"prefix": " ", "surface": "Алайса", "analysis": "алайса+MOD", "translations": ["в таком случае", "если так", "тогда"]}
+{"prefix": " ", "surface": "менә", "analysis": "мен+V+PRES(Й)", "translations": ["подниматься", "подняться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)"}
-{"prefix": " ", "surface": "яратканым", "analysis": "яра+V+CAUS(т)+PCP_PS(ГАн)+POSS_1SG(Ым)+Nom"}
+{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "яратканым", "analysis": "яра+V+CAUS(т)+PCP_PS(ГАн)+POSS_1SG(Ым)+Nom", "translations": ["годиться", "рана"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сугыш", "analysis": "сугыш+N+Sg+Nom"}
-{"prefix": " ", "surface": "турында", "analysis": "тур+N+Sg+POSS_3(СЫ)+LOC(ДА)"}
+{"prefix": " ", "surface": "Сугыш", "analysis": "сугыш+N+Sg+Nom", "translations": ["биться", "бой¹", "война", "драться"]}
+{"prefix": " ", "surface": "турында", "analysis": "тур+N+Sg+POSS_3(СЫ)+LOC(ДА)", "translations": ["тур"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гакыйль", "analysis": "NR"}
-{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн)"}
-{"prefix": " ", "surface": "татарларны", "analysis": "татар+N+PL(ЛАр)+ACC(нЫ)"}
-{"prefix": " ", "surface": "ник", "analysis": "ник+PN"}
-{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
+{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн)", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "татарларны", "analysis": "татар+N+PL(ЛАр)+ACC(нЫ)", "translations": ["татарин", "татарский"]}
+{"prefix": " ", "surface": "ник", "analysis": "ник+PN", "translations": ["зачем", "почему"]}
+{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom", "translations": ["будить"]}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Гакыйль", "analysis": "NR"}
-{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн)"}
-{"prefix": " ", "surface": "татарларны", "analysis": "татар+N+PL(ЛАр)+ACC(нЫ)"}
-{"prefix": " ", "surface": "ник", "analysis": "ник+PN"}
-{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
+{"prefix": " ", "surface": "булган", "analysis": "бул+V+PCP_PS(ГАн)", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "татарларны", "analysis": "татар+N+PL(ЛАр)+ACC(нЫ)", "translations": ["татарин", "татарский"]}
+{"prefix": " ", "surface": "ник", "analysis": "ник+PN", "translations": ["зачем", "почему"]}
+{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom", "translations": ["будить"]}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ах", "analysis": "ах+INTRJ"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
-{"prefix": " ", "surface": "ник", "analysis": "ник+PN"}
-{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv"}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
+{"prefix": " ", "surface": "ник", "analysis": "ник+PN", "translations": ["зачем", "почему"]}
+{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom", "translations": ["будить"]}
+{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv", "translations": ["всегда", "всё время"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ах", "analysis": "ах+INTRJ"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN"}
+{"prefix": " ", "surface": "син", "analysis": "син+PN", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom"}
-{"prefix": " ", "surface": "ник", "analysis": "ник+PN"}
-{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv"}
+{"prefix": " ", "surface": "заман", "analysis": "заман+N+Sg+Nom", "translations": ["время", "эпоха"]}
+{"prefix": " ", "surface": "ник", "analysis": "ник+PN", "translations": ["зачем", "почему"]}
+{"prefix": " ", "surface": "уятмыйсың", "analysis": "уят+V+NEG(мА)+OBL(ЙсЫ)+POSS_2SG(Ың)+Nom", "translations": ["будить"]}
+{"prefix": " ", "surface": "һаман", "analysis": "һаман+Adv", "translations": ["всегда", "всё время"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Галимҗан", "analysis": "галимҗан+PROP+Sg+Nom"}
-{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": " ", "surface": "бабай", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "җырны", "analysis": "җыр+N+Sg+ACC(нЫ)"}
-{"prefix": " ", "surface": "беләм", "analysis": "бел+V+PRES(Й)+1SG(м)"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "җырны", "analysis": "җыр+N+Sg+ACC(нЫ)", "translations": ["песня"]}
+{"prefix": " ", "surface": "беләм", "analysis": "бел+V+PRES(Й)+1SG(м)", "translations": ["знать", "узнать", "уметь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom"}
+{"prefix": " ", "surface": "Ул", "analysis": "ул+N+Sg+Nom", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әлбәттә", "analysis": "әлбәттә+MOD"}
+{"prefix": " ", "surface": "әлбәттә", "analysis": "әлбәттә+MOD", "translations": ["конечно", "непременно"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "иске", "analysis": "иске+Adj"}
+{"prefix": " ", "surface": "иске", "analysis": "иске+Adj", "translations": ["старый"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әмма", "analysis": "әмма+CNJ"}
-{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ)"}
+{"prefix": " ", "surface": "әмма", "analysis": "әмма+CNJ", "translations": ["но"]}
+{"prefix": " ", "surface": "аны", "analysis": "ул+PN+ACC(нЫ)", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "Айдар", "analysis": "айдар+PROP+Sg+Nom"}
 {"prefix": " ", "surface": "Фәйзрахманов", "analysis": "NR"}
-{"prefix": " ", "surface": "ансамбле", "analysis": "ансамбль+N+Sg+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART"}
-{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom"}
+{"prefix": " ", "surface": "ансамбле", "analysis": "ансамбль+N+Sg+POSS_3(СЫ)+Nom", "translations": ["ансамбль"]}
+{"prefix": " ", "surface": "да", "analysis": "да+PART", "translations": ["и", "тоже"]}
+{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)", "translations": ["петь"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ә", "analysis": "ә+INTRJ"}
-{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN"}
+{"prefix": " ", "surface": "Ә", "analysis": "ә+INTRJ", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "нәрсә", "analysis": "нәрсә+PN", "translations": ["вещь", "что"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "синең", "analysis": "син+PN+GEN(нЫң)"}
+{"prefix": " ", "surface": "синең", "analysis": "син+PN+GEN(нЫң)", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "Айдарың", "analysis": "айдар+PROP+POSS_2SG(Ың)+Nom"}
-{"prefix": " ", "surface": "җырлагач", "analysis": "җырла+V+ADVV_ANT(ГАч)"}
+{"prefix": " ", "surface": "җырлагач", "analysis": "җырла+V+ADVV_ANT(ГАч)", "translations": ["петь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom"}
-{"prefix": " ", "surface": "халык", "analysis": "халык+N+Sg+Nom"}
-{"prefix": " ", "surface": "җыры", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "халык", "analysis": "халык+N+Sg+Nom", "translations": ["народ", "народный", "толпа"]}
+{"prefix": " ", "surface": "җыры", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom", "translations": ["песня"]}
 {"prefix": " ", "surface": "түгелмени", "analysis": "түгел+PART+INT_MIR(мЫни)"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv", "translations": ["нынешний", "сейчас"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)", "translations": ["берег"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр)", "translations": ["берег"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА)"}
-{"prefix": " ", "surface": "ошый", "analysis": "оша+V+PRES(Й)"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА)", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "ошый", "analysis": "оша+V+PRES(Й)", "translations": ["нравиться", "понравиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj"}
+{"prefix": " ", "surface": "Кара", "analysis": "кара+Adj", "translations": ["посмотреть", "смотреть", "чернила", "чёрный"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "җырыңны", "analysis": "җыр+N+Sg+POSS_2SG(Ың)+ACC(нЫ)"}
-{"prefix": " ", "surface": "хәтта", "analysis": "хәтта+CNJ"}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "җырыңны", "analysis": "җыр+N+Sg+POSS_2SG(Ың)+ACC(нЫ)", "translations": ["песня"]}
+{"prefix": " ", "surface": "хәтта", "analysis": "хәтта+CNJ", "translations": ["даже"]}
 {"prefix": " ", "surface": "яңартырга", "analysis": "яңар+V+CAUS(т)+INF_1(ЫргА)"}
-{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)"}
+{"prefix": " ", "surface": "була", "analysis": "бул+V+PRES(Й)", "translations": ["быть", "случиться"]}
 {"prefix": " ", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Җырны", "analysis": "җыр+N+Sg+ACC(нЫ)"}
+{"prefix": "", "surface": "Җырны", "analysis": "җыр+N+Sg+ACC(нЫ)", "translations": ["песня"]}
 {"prefix": " ", "surface": "сэмплларга", "analysis": "NR"}
 {"prefix": " ", "surface": "тураклый", "analysis": "туракла+V+PRES(Й)"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom"}
-{"prefix": " ", "surface": "сала", "analysis": "сал+V+PRES(Й)"}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "сала", "analysis": "сал+V+PRES(Й)", "translations": ["класть", "положить"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "тыңлыйлар", "analysis": "тыңла+V+PRES(Й)+3PL(ЛАр)"}
+{"prefix": " ", "surface": "тыңлыйлар", "analysis": "тыңла+V+PRES(Й)+3PL(ЛАр)", "translations": ["слушать"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN"}
-{"prefix": " ", "surface": "сезгә", "analysis": "сез+PN+DIR(ГА)"}
+{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN", "translations": ["как"]}
+{"prefix": " ", "surface": "сезгә", "analysis": "сез+PN+DIR(ГА)", "translations": ["ваш", "вы"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": " ", "surface": "Өр-яңа", "analysis": "өр-яңа+Adj"}
-{"prefix": " ", "surface": "җыр", "analysis": "җыр+N+Sg+Nom"}
-{"prefix": " ", "surface": "кебек", "analysis": "кебек+POST"}
+{"prefix": " ", "surface": "җыр", "analysis": "җыр+N+Sg+Nom", "translations": ["песня"]}
+{"prefix": " ", "surface": "кебек", "analysis": "кебек+POST", "translations": ["как"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)"}
-{"prefix": " ", "surface": "җырым", "analysis": "җыр+N+Sg+POSS_1SG(Ым)+Nom"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "җырым", "analysis": "җыр+N+Sg+POSS_1SG(Ым)+Nom", "translations": ["песня"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Теге", "analysis": "теге+PN"}
+{"prefix": " ", "surface": "Теге", "analysis": "теге+PN", "translations": ["там", "тот"]}
 {"prefix": " ", "surface": "Айдарның", "analysis": "айдар+PROP+GEN(нЫң)"}
-{"prefix": " ", "surface": "да", "analysis": "да+PART"}
+{"prefix": " ", "surface": "да", "analysis": "да+PART", "translations": ["и", "тоже"]}
 {"prefix": " ", "surface": "түгел", "analysis": "түгел+PART"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
 {"prefix": " ", "surface": "синеке", "analysis": "си+N+Sg+ATTR_GEN(нЫкЫ)"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Син", "analysis": "син+PN"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom"}
-{"prefix": " ", "surface": "эшләдең", "analysis": "эшлә+V+PST_DEF(ДЫ)+2SG(ң)"}
+{"prefix": " ", "surface": "Син", "analysis": "син+PN", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom", "translations": ["ведь", "лицо", "страница"]}
+{"prefix": " ", "surface": "эшләдең", "analysis": "эшлә+V+PST_DEF(ДЫ)+2SG(ң)", "translations": ["делать", "поступать", "поступить", "работать", "сделать"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА)"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv"}
+{"prefix": " ", "surface": "Миңа", "analysis": "мин+PN+DIR(ГА)", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv", "translations": ["замок", "очень"]}
 {"prefix": " ", "surface": "үк", "analysis": "үк+PART"}
-{"prefix": " ", "surface": "ошамый", "analysis": "оша+V+NEG(мА)+PRES(Й)"}
+{"prefix": " ", "surface": "ошамый", "analysis": "оша+V+NEG(мА)+PRES(Й)", "translations": ["нравиться", "понравиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "ләкин", "analysis": "ләкин+CNJ"}
-{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)"}
-{"prefix": " ", "surface": "үз", "analysis": "үз+PN"}
-{"prefix": " ", "surface": "көйләрем", "analysis": "көй+N+PL(ЛАр)+POSS_1SG(Ым)+Nom"}
-{"prefix": " ", "surface": "бар", "analysis": "бар+MOD"}
+{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "үз", "analysis": "үз+PN", "translations": ["сам", "свой"]}
+{"prefix": " ", "surface": "көйләрем", "analysis": "көй+N+PL(ЛАр)+POSS_1SG(Ым)+Nom", "translations": ["лад", "мелодия"]}
+{"prefix": " ", "surface": "бар", "analysis": "бар+MOD", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "", "analysis": "Error"}
 {"prefix": " - ", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Каз", "analysis": "каз+N+Sg+Nom"}
-{"prefix": " ", "surface": "канаты", "analysis": "канат+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": "", "surface": "Каз", "analysis": "каз+N+Sg+Nom", "translations": ["гусь"]}
+{"prefix": " ", "surface": "канаты", "analysis": "канат+N+Sg+POSS_3(СЫ)+Nom", "translations": ["крыло"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "һәм", "analysis": "һәм+CNJ"}
-{"prefix": "  ", "surface": "сугыш", "analysis": "сугыш+N+Sg+Nom"}
-{"prefix": " ", "surface": "турында", "analysis": "тур+N+Sg+POSS_3(СЫ)+LOC(ДА)"}
+{"prefix": " ", "surface": "һәм", "analysis": "һәм+CNJ", "translations": ["и"]}
+{"prefix": "  ", "surface": "сугыш", "analysis": "сугыш+N+Sg+Nom", "translations": ["биться", "бой¹", "война", "драться"]}
+{"prefix": " ", "surface": "турында", "analysis": "тур+N+Sg+POSS_3(СЫ)+LOC(ДА)", "translations": ["тур"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv"}
+{"prefix": " ", "surface": "Тагын", "analysis": "тагын+Adv", "translations": ["ещё", "опять", "снова"]}
 {"prefix": " ", "surface": "үх", "analysis": "NR"}
-{"prefix": " ", "surface": "җырларыгыз", "analysis": "җыр+N+PL(ЛАр)+POSS_2PL(ЫгЫз)+Nom"}
-{"prefix": " ", "surface": "бармы", "analysis": "бар+MOD+INT(мЫ)"}
+{"prefix": " ", "surface": "җырларыгыз", "analysis": "җыр+N+PL(ЛАр)+POSS_2PL(ЫгЫз)+Nom", "translations": ["песня"]}
+{"prefix": " ", "surface": "бармы", "analysis": "бар+MOD+INT(мЫ)", "translations": ["бар", "быть", "весь", "идти", "пойти"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Туган", "analysis": "ту+V+PCP_PS(ГАн)"}
-{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom"}
+{"prefix": "", "surface": "Туган", "analysis": "ту+V+PCP_PS(ГАн)", "translations": ["родиться", "рождаться"]}
+{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom", "translations": ["сжечь", "сторона"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": " ", "surface": "ны", "analysis": "NR"}
-{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)"}
-{"prefix": " ", "surface": "алам", "analysis": "ал+V+PRES(Й)+1SG(м)"}
+{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)", "translations": ["петь"]}
+{"prefix": " ", "surface": "алам", "analysis": "ал+V+PRES(Й)+1SG(м)", "translations": ["алый", "брать", "браться", "взять", "мочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "попса", "analysis": "Rus"}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Явыз", "analysis": "явыз+Adj"}
-{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN"}
+{"prefix": " ", "surface": "кеше", "analysis": "кеше+N+Sg+Nom", "translations": ["человек"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN", "translations": ["твой", "ты"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сиңа", "analysis": "син+PN+DIR(ГА)"}
-{"prefix": " ", "surface": "җырлыйлар", "analysis": "җырла+V+PRES(Й)+3PL(ЛАр)"}
+{"prefix": " ", "surface": "Сиңа", "analysis": "син+PN+DIR(ГА)", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "җырлыйлар", "analysis": "җырла+V+PRES(Й)+3PL(ЛАр)", "translations": ["петь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN"}
+{"prefix": " ", "surface": "ә", "analysis": "ә+INTRJ", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "мыскыллыйсын", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)"}
-{"prefix": " ", "surface": "җырлар", "analysis": "җыр+N+PL(ЛАр)+Nom"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "минем", "analysis": "мин+PN+GEN(нЫң)", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "җырлар", "analysis": "җыр+N+PL(ЛАр)+Nom", "translations": ["песня"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Каз", "analysis": "каз+N+Sg+Nom"}
+{"prefix": "", "surface": "Каз", "analysis": "каз+N+Sg+Nom", "translations": ["гусь"]}
 {"prefix": " ", "surface": "канатын", "analysis": "кана+V+CAUS(т)+REFL(Ын)+IMP_SG()"}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
-{"prefix": " ", "surface": "икенче", "analysis": "ике+Num+NUM_ORD(ЫнчЫ)"}
-{"prefix": " ", "surface": "хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ)"}
-{"prefix": " ", "surface": "ярата", "analysis": "яра+V+CAUS(т)+PRES(Й)"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "икенче", "analysis": "ике+Num+NUM_ORD(ЫнчЫ)", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "хатын", "analysis": "хат+N+Sg+POSS_3(СЫ)+ACC(нЫ)", "translations": ["письмо"]}
+{"prefix": " ", "surface": "ярата", "analysis": "яра+V+CAUS(т)+PRES(Й)", "translations": ["годиться", "рана"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "яшь", "analysis": "яшь+Adj"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom"}
+{"prefix": " ", "surface": "яшь", "analysis": "яшь+Adj", "translations": ["возраст", "год²", "молодой", "юный"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)", "translations": ["быть"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "яшьли", "analysis": "яшьли+Adv"}
-{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "китте", "analysis": "кит+V+PST_DEF(ДЫ)", "translations": ["уйти", "уходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Сугыш", "analysis": "сугыш+N+Sg+Nom"}
-{"prefix": " ", "surface": "турында", "analysis": "тур+N+Sg+POSS_3(СЫ)+LOC(ДА)"}
-{"prefix": " ", "surface": "көйне", "analysis": "көй+N+Sg+ACC(нЫ)"}
-{"prefix": " ", "surface": "телевизордан", "analysis": "телевизор+N+Sg+ABL(ДАн)"}
-{"prefix": " ", "surface": "күрдем", "analysis": "күр+V+PST_DEF(ДЫ)+1SG(м)"}
+{"prefix": " ", "surface": "Сугыш", "analysis": "сугыш+N+Sg+Nom", "translations": ["биться", "бой¹", "война", "драться"]}
+{"prefix": " ", "surface": "турында", "analysis": "тур+N+Sg+POSS_3(СЫ)+LOC(ДА)", "translations": ["тур"]}
+{"prefix": " ", "surface": "көйне", "analysis": "көй+N+Sg+ACC(нЫ)", "translations": ["лад", "мелодия"]}
+{"prefix": " ", "surface": "телевизордан", "analysis": "телевизор+N+Sg+ABL(ДАн)", "translations": ["телевизор"]}
+{"prefix": " ", "surface": "күрдем", "analysis": "күр+V+PST_DEF(ДЫ)+1SG(м)", "translations": ["видеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "бердәнбер", "analysis": "бердәнбер+N+Sg+Nom"}
+{"prefix": " ", "surface": "бердәнбер", "analysis": "бердәнбер+N+Sg+Nom", "translations": ["единственный"]}
 {"prefix": " ", "surface": "дустым", "analysis": "дуст+N+Sg+POSS_1SG(Ым)+Nom"}
-{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ)"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART"}
-{"prefix": " ", "surface": "телевизор", "analysis": "телевизор+N+Sg+Nom"}
+{"prefix": " ", "surface": "булды", "analysis": "бул+V+PST_DEF(ДЫ)", "translations": ["быть", "случиться"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
+{"prefix": " ", "surface": "телевизор", "analysis": "телевизор+N+Sg+Nom", "translations": ["телевизор"]}
 {"prefix": "", "surface": "!", "analysis": "Type1"}
 {"prefix": " ", "surface": "«", "analysis": "Type4"}
-{"prefix": "", "surface": "Туган", "analysis": "ту+V+PCP_PS(ГАн)"}
-{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom"}
+{"prefix": "", "surface": "Туган", "analysis": "ту+V+PCP_PS(ГАн)", "translations": ["родиться", "рождаться"]}
+{"prefix": " ", "surface": "як", "analysis": "як+N+Sg+Nom", "translations": ["сжечь", "сторона"]}
 {"prefix": "", "surface": "»", "analysis": "Type4"}
 {"prefix": " ", "surface": "ны", "analysis": "NR"}
-{"prefix": " ", "surface": "оныгым", "analysis": "онык+N+Sg+POSS_1SG(Ым)+Nom"}
-{"prefix": " ", "surface": "тыңлата", "analysis": "тыңла+V+CAUS(т)+PRES(Й)"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "оныгым", "analysis": "онык+N+Sg+POSS_1SG(Ым)+Nom", "translations": ["внук"]}
+{"prefix": " ", "surface": "тыңлата", "analysis": "тыңла+V+CAUS(т)+PRES(Й)", "translations": ["слушать"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)", "translations": ["быть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "авылга", "analysis": "авыл+N+Sg+DIR(ГА)"}
-{"prefix": " ", "surface": "кайтканда", "analysis": "кайт+V+PCP_PS(ГАн)+LOC(ДА)"}
+{"prefix": " ", "surface": "авылга", "analysis": "авыл+N+Sg+DIR(ГА)", "translations": ["деревня", "село", "сельский"]}
+{"prefix": " ", "surface": "кайтканда", "analysis": "кайт+V+PCP_PS(ГАн)+LOC(ДА)", "translations": ["возвратиться", "возвращаться", "возвращение"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv"}
-{"prefix": " ", "surface": "кайтмый", "analysis": "кайт+V+NEG(мА)+PRES(Й)"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
+{"prefix": " ", "surface": "хәзер", "analysis": "хәзер+Adv", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "кайтмый", "analysis": "кайт+V+NEG(мА)+PRES(Й)", "translations": ["возвратиться", "возвращаться", "возвращение"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ошамаса", "analysis": "оша+V+NEG(мА)+COND(сА)"}
+{"prefix": " ", "surface": "Ошамаса", "analysis": "оша+V+NEG(мА)+COND(сА)", "translations": ["нравиться", "понравиться"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "әнә", "analysis": "әнә+PN"}
-{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom"}
+{"prefix": " ", "surface": "чык", "analysis": "чык+N+Sg+Nom", "translations": ["выйти", "выходить"]}
 {"prefix": " ", "surface": "та", "analysis": "та+PART"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА)"}
-{"prefix": " ", "surface": "кешеләрне", "analysis": "кеше+N+PL(ЛАр)+ACC(нЫ)"}
+{"prefix": " ", "surface": "башка", "analysis": "баш+N+Sg+DIR(ГА)", "translations": ["голова"]}
+{"prefix": " ", "surface": "кешеләрне", "analysis": "кеше+N+PL(ЛАр)+ACC(нЫ)", "translations": ["человек"]}
 {"prefix": " ", "surface": "аптырат", "analysis": "аптыра+V+CAUS(т)+IMP_SG()"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)", "translations": ["берег"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "ярар", "analysis": "яр+V+PCP_FUT(Ыр)", "translations": ["берег"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "Галимҗан", "analysis": "галимҗан+PROP+Sg+Nom"}
-{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom"}
+{"prefix": " ", "surface": "абый", "analysis": "абый+N+Sg+Nom", "translations": ["брат", "дядя"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Җитәр", "analysis": "җит+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "Җитәр", "analysis": "җит+V+PCP_FUT(Ыр)", "translations": ["дойти", "доходить"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN"}
-{"prefix": " ", "surface": "аңлыйм", "analysis": "аңла+V+HOR_SG(Йм)"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "аңлыйм", "analysis": "аңла+V+HOR_SG(Йм)", "translations": ["понимать", "понять"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Ләкин", "analysis": "ләкин+CNJ"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "сәхнә", "analysis": "сәхнә+N+Sg+Nom"}
-{"prefix": " ", "surface": "җырлары", "analysis": "җыр+N+PL(ЛАр)+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom"}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "сәхнә", "analysis": "сәхнә+N+Sg+Nom", "translations": ["сцена"]}
+{"prefix": " ", "surface": "җырлары", "analysis": "җыр+N+PL(ЛАр)+POSS_3(СЫ)+Nom", "translations": ["песня"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ә", "analysis": "ә+INTRJ"}
-{"prefix": " ", "surface": "бу", "analysis": "бу+PN"}
-{"prefix": "  ", "surface": "нәрсә", "analysis": "нәрсә+PN"}
+{"prefix": " ", "surface": "Ә", "analysis": "ә+INTRJ", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": "  ", "surface": "нәрсә", "analysis": "нәрсә+PN", "translations": ["вещь", "что"]}
 {"prefix": " ", "surface": "–", "analysis": "Type2"}
-{"prefix": " ", "surface": "сәхнә", "analysis": "сәхнә+N+Sg+Nom"}
+{"prefix": " ", "surface": "сәхнә", "analysis": "сәхнә+N+Sg+Nom", "translations": ["сцена"]}
 {"prefix": " ", "surface": "мени", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
-{"prefix": " ", "surface": "Яхшы", "analysis": "яхшы+Adj"}
+{"prefix": " ", "surface": "Яхшы", "analysis": "яхшы+Adj", "translations": ["лучше", "лучший", "хороший", "хорошо"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN"}
-{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА)"}
-{"prefix": " ", "surface": "бик", "analysis": "бик+Adv"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "сиңа", "analysis": "син+PN+DIR(ГА)", "translations": ["твой", "ты"]}
+{"prefix": " ", "surface": "бик", "analysis": "бик+Adv", "translations": ["замок", "очень"]}
 {"prefix": " ", "surface": "борыңгы", "analysis": "NR"}
-{"prefix": " ", "surface": "җырны", "analysis": "җыр+N+Sg+ACC(нЫ)"}
-{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)"}
-{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD"}
+{"prefix": " ", "surface": "җырны", "analysis": "җыр+N+Sg+ACC(нЫ)", "translations": ["песня"]}
+{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)", "translations": ["петь"]}
+{"prefix": " ", "surface": "алайса", "analysis": "алайса+MOD", "translations": ["в таком случае", "если так", "тогда"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Әни", "analysis": "әни+N+Sg+Nom"}
-{"prefix": " ", "surface": "җырлады", "analysis": "җырла+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "Әни", "analysis": "әни+N+Sg+Nom", "translations": ["мама"]}
+{"prefix": " ", "surface": "җырлады", "analysis": "җырла+V+PST_DEF(ДЫ)", "translations": ["петь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "аңа", "analysis": "ул+PN+DIR(ГА)"}
-{"prefix": " ", "surface": "әнисе", "analysis": "әни+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "аңа", "analysis": "ул+PN+DIR(ГА)", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "әнисе", "analysis": "әни+N+Sg+POSS_3(СЫ)+Nom", "translations": ["мама"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "шулай", "analysis": "шулай+PN"}
-{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып)"}
+{"prefix": " ", "surface": "итеп", "analysis": "ит+V+ADVV_ACC(Ып)", "translations": ["делать", "мясо", "сделать"]}
 {"prefix": "", "surface": "…", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN"}
-{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom"}
+{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN", "translations": ["как"]}
+{"prefix": " ", "surface": "әле", "analysis": "әле+CNJ", "translations": ["ещё", "настоящий", "пожалуйста", "пока", "сегодняшний"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD"}
+{"prefix": " ", "surface": "Әйе", "analysis": "әйе+MOD", "translations": ["да"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "бишек", "analysis": "бишек+N+Sg+Nom"}
-{"prefix": " ", "surface": "җыры", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "җыры", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom", "translations": ["песня"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "БИШЕК", "analysis": "бишек+N+Sg+Nom"}
-{"prefix": " ", "surface": "ҖЫРЫ", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "ҖЫРЫ", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom", "translations": ["песня"]}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "Туктый", "analysis": "тукта+V+PRES(Й)"}
+{"prefix": "", "surface": "Туктый", "analysis": "тукта+V+PRES(Й)", "translations": ["останавливаться", "остановиться", "остановка"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бетте", "analysis": "бет+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "Бетте", "analysis": "бет+V+PST_DEF(ДЫ)", "translations": ["вошь", "кончаться", "кончиться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Кебек", "analysis": "кебек+POST"}
+{"prefix": " ", "surface": "Кебек", "analysis": "кебек+POST", "translations": ["как"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
-{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom"}
+{"prefix": " ", "surface": "Ничек", "analysis": "ничек+PN", "translations": ["как"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
+{"prefix": " ", "surface": "ул", "analysis": "ул+N+Sg+Nom", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
 {"prefix": " ", "surface": "–", "analysis": "Type2"}
-{"prefix": " ", "surface": "кебек", "analysis": "кебек+POST"}
+{"prefix": " ", "surface": "кебек", "analysis": "кебек+POST", "translations": ["как"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Бу", "analysis": "бу+PN"}
-{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom"}
+{"prefix": " ", "surface": "Бу", "analysis": "бу+PN", "translations": ["душить", "здесь", "это", "этот"]}
+{"prefix": " ", "surface": "бит", "analysis": "бит+N+Sg+Nom", "translations": ["ведь", "лицо", "страница"]}
 {"prefix": " ", "surface": "бишек", "analysis": "бишек+N+Sg+Nom"}
-{"prefix": " ", "surface": "җыры", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom"}
+{"prefix": " ", "surface": "җыры", "analysis": "җыр+N+Sg+POSS_3(СЫ)+Nom", "translations": ["песня"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ)"}
-{"prefix": " ", "surface": "бала", "analysis": "бала+N+Sg+Nom"}
-{"prefix": " ", "surface": "йокыга", "analysis": "йокы+N+Sg+DIR(ГА)"}
-{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч)"}
+{"prefix": " ", "surface": "Аны", "analysis": "ул+PN+ACC(нЫ)", "translations": ["его", "их", "он", "она", "они", "оно", "сын", "этот"]}
+{"prefix": " ", "surface": "бала", "analysis": "бала+N+Sg+Nom", "translations": ["ребёнок"]}
+{"prefix": " ", "surface": "йокыга", "analysis": "йокы+N+Sg+DIR(ГА)", "translations": ["сон"]}
+{"prefix": " ", "surface": "киткәч", "analysis": "ки+V+CAUS(т)+ADVV_ANT(ГАч)", "translations": ["одеть"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
 {"prefix": " ", "surface": "тәмамлилар", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Йокламаса", "analysis": "йокла+V+NEG(мА)+COND(сА)"}
+{"prefix": " ", "surface": "Йокламаса", "analysis": "йокла+V+NEG(мА)+COND(сА)", "translations": ["спать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "төне", "analysis": "төн+N+Sg+POSS_3(СЫ)+Nom"}
-{"prefix": " ", "surface": "буе", "analysis": "буе+POST"}
+{"prefix": " ", "surface": "төне", "analysis": "төн+N+Sg+POSS_3(СЫ)+Nom", "translations": ["ночь"]}
+{"prefix": " ", "surface": "буе", "analysis": "буе+POST", "translations": ["в течение", "по"]}
 {"prefix": " ", "surface": "җырлыйсын", "analysis": "NR"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ә", "analysis": "ә+INTRJ"}
-{"prefix": " ", "surface": "син", "analysis": "син+PN"}
+{"prefix": " ", "surface": "Ә", "analysis": "ә+INTRJ", "translations": ["а", "однако"]}
+{"prefix": " ", "surface": "син", "analysis": "син+PN", "translations": ["твой", "ты"]}
 {"prefix": " ", "surface": "йокламыйсын", "analysis": "NR"}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)"}
+{"prefix": " ", "surface": "Ярар", "analysis": "яр+V+PCP_FUT(Ыр)", "translations": ["берег"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ"}
-{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv"}
-{"prefix": " ", "surface": "җырла", "analysis": "җырла+V+IMP_SG()"}
+{"prefix": " ", "surface": "әйдә", "analysis": "әйдә+INTRJ", "translations": ["давай"]}
+{"prefix": " ", "surface": "тагын", "analysis": "тагын+Adv", "translations": ["ещё", "опять", "снова"]}
+{"prefix": " ", "surface": "җырла", "analysis": "җырла+V+IMP_SG()", "translations": ["петь"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "мин", "analysis": "мин+PN"}
-{"prefix": " ", "surface": "тырышырмын", "analysis": "тырыш+V+FUT_INDF(Ыр)+1SG(мЫн)"}
+{"prefix": " ", "surface": "мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
+{"prefix": " ", "surface": "тырышырмын", "analysis": "тырыш+V+FUT_INDF(Ыр)+1SG(мЫн)", "translations": ["постараться", "пытаться", "стараться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom"}
-{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)"}
+{"prefix": "", "surface": "БАБАЙ", "analysis": "бабай+N+Sg+Nom", "translations": ["дед"]}
+{"prefix": " ", "surface": "җырлый", "analysis": "җырла+V+PRES(Й)", "translations": ["петь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
-{"prefix": " ", "surface": "йокыга", "analysis": "йокы+N+Sg+DIR(ГА)"}
-{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й)"}
+{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
+{"prefix": " ", "surface": "йокыга", "analysis": "йокы+N+Sg+DIR(ГА)", "translations": ["сон"]}
+{"prefix": " ", "surface": "китә", "analysis": "ки+V+CAUS(т)+PRES(Й)", "translations": ["одеть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Капкага", "analysis": "капка+N+Sg+DIR(ГА)"}
+{"prefix": " ", "surface": "Капкага", "analysis": "капка+N+Sg+DIR(ГА)", "translations": ["ворота"]}
 {"prefix": " ", "surface": "шакудан", "analysis": "шакы+V+VN_1(у/ү/в)+ABL(ДАн)"}
-{"prefix": " ", "surface": "уяна", "analysis": "уян+V+PRES(Й)"}
+{"prefix": " ", "surface": "уяна", "analysis": "уян+V+PRES(Й)", "translations": ["проснуться"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": " ", "surface": "–", "analysis": "Type2"}
-{"prefix": " ", "surface": "карт", "analysis": "карт+Adj"}
+{"prefix": " ", "surface": "карт", "analysis": "карт+Adj", "translations": ["старик", "старый"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "ИКЕНЧЕ", "analysis": "ике+Num+NUM_ORD(ЫнчЫ)"}
-{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "ИКЕНЧЕ", "analysis": "ике+Num+NUM_ORD(ЫнчЫ)", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": " ", "surface": "(", "analysis": "Type3"}
-{"prefix": "", "surface": "керә", "analysis": "кер+V+PRES(Й)"}
+{"prefix": "", "surface": "керә", "analysis": "кер+V+PRES(Й)", "translations": ["войти", "входить", "грязь"]}
 {"prefix": "", "surface": ")", "analysis": "Type3"}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "Исәнмесез", "analysis": "исәнмесез+INTRJ"}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА)"}
+{"prefix": " ", "surface": "миңа", "analysis": "мин+PN+DIR(ГА)", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "Галимҗан", "analysis": "галимҗан+PROP+Sg+Nom"}
-{"prefix": " ", "surface": "карт", "analysis": "карт+Adj"}
-{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD"}
-{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)"}
+{"prefix": " ", "surface": "карт", "analysis": "карт+Adj", "translations": ["старик", "старый"]}
+{"prefix": " ", "surface": "кирәк", "analysis": "кирәк+MOD", "translations": ["необходимый", "нужный"]}
+{"prefix": " ", "surface": "иде", "analysis": "и+V+PST_DEF(ДЫ)", "translations": ["быть"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "Әлфия", "analysis": "әлфия+PROP+Sg+Nom"}
-{"prefix": " ", "surface": "карчык", "analysis": "карчык+N+Sg+Nom"}
-{"prefix": " ", "surface": "шул", "analysis": "шул+PART"}
+{"prefix": " ", "surface": "карчык", "analysis": "карчык+N+Sg+Nom", "translations": ["старуха"]}
+{"prefix": " ", "surface": "шул", "analysis": "шул+PART", "translations": ["ведь", "оттуда", "потом", "так", "тот", "это"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "ИКЕНЧЕ", "analysis": "ике+Num+NUM_ORD(ЫнчЫ)"}
-{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "ИКЕНЧЕ", "analysis": "ике+Num+NUM_ORD(ЫнчЫ)", "translations": ["второй", "два", "оба"]}
+{"prefix": " ", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Мин", "analysis": "мин+PN"}
+{"prefix": " ", "surface": "Мин", "analysis": "мин+PN", "translations": ["мой", "я"]}
 {"prefix": " ", "surface": "борыңгы", "analysis": "NR"}
-{"prefix": " ", "surface": "җырлар", "analysis": "җыр+N+PL(ЛАр)+Nom"}
-{"prefix": " ", "surface": "яздырам", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+1SG(м)"}
+{"prefix": " ", "surface": "җырлар", "analysis": "җыр+N+PL(ЛАр)+Nom", "translations": ["песня"]}
+{"prefix": " ", "surface": "яздырам", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+1SG(м)", "translations": ["весна", "написать", "писать"]}
 {"prefix": "", "surface": ",", "analysis": "Type2"}
-{"prefix": " ", "surface": "сез", "analysis": "сез+PN"}
+{"prefix": " ", "surface": "сез", "analysis": "сез+PN", "translations": ["ваш", "вы"]}
 {"prefix": " ", "surface": "андыйларны", "analysis": "андый+Adj+PL(ЛАр)+ACC(нЫ)"}
-{"prefix": " ", "surface": "җырлыйсызмы", "analysis": "җырла+V+PRES(Й)+2PL(сЫз)+INT(мЫ)"}
+{"prefix": " ", "surface": "җырлыйсызмы", "analysis": "җырла+V+PRES(Й)+2PL(сЫз)+INT(мЫ)", "translations": ["петь"]}
 {"prefix": "", "surface": "?", "analysis": "Type1"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}
-{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom"}
+{"prefix": "", "surface": "КЫЗ", "analysis": "кыз+N+Sg+Nom", "translations": ["девушка", "дочь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Җырламыйм", "analysis": "җырла+V+NEG(мА)+HOR_SG(Йм)"}
+{"prefix": " ", "surface": "Җырламыйм", "analysis": "җырла+V+NEG(мА)+HOR_SG(Йм)", "translations": ["петь"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv"}
-{"prefix": " ", "surface": "җырламыйлар", "analysis": "җырла+V+NEG(мА)+PRES(Й)+3PL(ЛАр)"}
-{"prefix": " ", "surface": "инде", "analysis": "инде+MOD"}
+{"prefix": " ", "surface": "Хәзер", "analysis": "хәзер+Adv", "translations": ["нынешний", "сейчас"]}
+{"prefix": " ", "surface": "җырламыйлар", "analysis": "җырла+V+NEG(мА)+PRES(Й)+3PL(ЛАр)", "translations": ["петь"]}
+{"prefix": " ", "surface": "инде", "analysis": "инде+MOD", "translations": ["уже"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
-{"prefix": " ", "surface": "Яздыралар", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+3PL(ЛАр)"}
-{"prefix": " ", "surface": "гына", "analysis": "гына+PART"}
+{"prefix": " ", "surface": "Яздыралар", "analysis": "яз+V+CAUS(ДЫр)+PRES(Й)+3PL(ЛАр)", "translations": ["весна", "написать", "писать"]}
+{"prefix": " ", "surface": "гына", "analysis": "гына+PART", "translations": ["только"]}
 {"prefix": "", "surface": ".", "analysis": "Type1"}
 {"prefix": " ", "surface": "\"", "analysis": "Type4"}
 {"prefix": "", "surface": "\n", "analysis": "NL"}

--- a/web-app/src/main/java/com/example/uqureader/webapp/Main.java
+++ b/web-app/src/main/java/com/example/uqureader/webapp/Main.java
@@ -1,5 +1,6 @@
 package com.example.uqureader.webapp;
 
+import com.example.uqureader.webapp.assets.JsonlTranslationAugmenter;
 import com.example.uqureader.webapp.dictionary.TatRusDictionaryImporter;
 import com.sun.net.httpserver.HttpServer;
 
@@ -26,6 +27,23 @@ public final class Main {
             TatRusDictionaryImporter importer = new TatRusDictionaryImporter();
             int count = importer.importLatest(database);
             System.out.printf("Imported %d dictionary entries into %s%n", count, database.toAbsolutePath());
+            return;
+        }
+
+        if (args.length > 0 && "--augment-assets".equals(args[0])) {
+            Path assetsDirectory = args.length > 1
+                    ? Paths.get(args[1])
+                    : Paths.get("android-app", "src", "main", "assets");
+            Path dictionaryPath = args.length > 2
+                    ? Paths.get(args[2])
+                    : Paths.get("data", "tat_rus_dictionary.db");
+            JsonlTranslationAugmenter augmenter = new JsonlTranslationAugmenter();
+            JsonlTranslationAugmenter.Report report = augmenter.augment(assetsDirectory, dictionaryPath);
+            System.out.printf("Augmented %d files (%d tokens processed, %d with translations, %d translations recorded)%n",
+                    report.getFilesProcessed(),
+                    report.getTokensProcessed(),
+                    report.getTokensWithTranslations(),
+                    report.getTranslationsWritten());
             return;
         }
 

--- a/web-app/src/main/java/com/example/uqureader/webapp/assets/JsonlTranslationAugmenter.java
+++ b/web-app/src/main/java/com/example/uqureader/webapp/assets/JsonlTranslationAugmenter.java
@@ -1,0 +1,324 @@
+package com.example.uqureader.webapp.assets;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Populates JSONL morphology files with Russian translations resolved from the tat-rus dictionary.
+ */
+public final class JsonlTranslationAugmenter {
+
+    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+    /**
+     * Result of an augmentation run.
+     */
+    public static final class Report {
+        private final int filesProcessed;
+        private final int tokensProcessed;
+        private final int tokensWithTranslations;
+        private final int translationsWritten;
+
+        Report(int filesProcessed, int tokensProcessed, int tokensWithTranslations, int translationsWritten) {
+            this.filesProcessed = filesProcessed;
+            this.tokensProcessed = tokensProcessed;
+            this.tokensWithTranslations = tokensWithTranslations;
+            this.translationsWritten = translationsWritten;
+        }
+
+        public int getFilesProcessed() {
+            return filesProcessed;
+        }
+
+        public int getTokensProcessed() {
+            return tokensProcessed;
+        }
+
+        public int getTokensWithTranslations() {
+            return tokensWithTranslations;
+        }
+
+        public int getTranslationsWritten() {
+            return translationsWritten;
+        }
+    }
+
+    /**
+     * Updates every <code>*.jsonl</code> file in the provided directory by appending a {@code translations}
+     * property that contains candidate Russian lemmas for the token.
+     *
+     * @param assetsDirectory directory with JSONL files
+     * @param dictionaryFile  SQLite dictionary file produced by {@link
+     *                        com.example.uqureader.webapp.dictionary.TatRusDictionaryImporter}
+     * @return statistics about the augmentation
+     * @throws IOException  when files cannot be read or written
+     * @throws SQLException when the dictionary cannot be queried
+     */
+    public Report augment(Path assetsDirectory, Path dictionaryFile) throws IOException, SQLException {
+        Objects.requireNonNull(assetsDirectory, "assetsDirectory");
+        Objects.requireNonNull(dictionaryFile, "dictionaryFile");
+
+        if (!Files.isDirectory(assetsDirectory)) {
+            throw new IOException("Assets directory not found: " + assetsDirectory.toAbsolutePath());
+        }
+        if (!Files.exists(dictionaryFile)) {
+            throw new IOException("Dictionary file not found: " + dictionaryFile.toAbsolutePath());
+        }
+
+        int filesProcessed = 0;
+        int tokensProcessed = 0;
+        int tokensWithTranslations = 0;
+        int translationsWritten = 0;
+
+        Map<String, List<String>> cache = new HashMap<>();
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + dictionaryFile.toAbsolutePath());
+             PreparedStatement lookup = connection.prepareStatement(
+                     "SELECT DISTINCT rus_lemma FROM tat_rus_dictionary "
+                             + "WHERE tat_lemma = ? COLLATE NOCASE ORDER BY rus_lemma COLLATE NOCASE")) {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(assetsDirectory, "*.jsonl")) {
+                for (Path file : stream) {
+                    FileReport report = augmentFile(file, lookup, cache);
+                    if (report.tokensProcessed > 0) {
+                        filesProcessed++;
+                        tokensProcessed += report.tokensProcessed;
+                        tokensWithTranslations += report.tokensWithTranslations;
+                        translationsWritten += report.translationsWritten;
+                    }
+                }
+            }
+        }
+
+        return new Report(filesProcessed, tokensProcessed, tokensWithTranslations, translationsWritten);
+    }
+
+    private FileReport augmentFile(Path file,
+                                   PreparedStatement lookup,
+                                   Map<String, List<String>> cache) throws IOException, SQLException {
+        List<String> output = new ArrayList<>();
+        boolean modified = false;
+        int tokensProcessed = 0;
+        int tokensWithTranslations = 0;
+        int translationsWritten = 0;
+
+        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty()) {
+                    output.add(line);
+                    continue;
+                }
+                JsonObject object = GSON.fromJson(line, JsonObject.class);
+                tokensProcessed++;
+                List<String> translations = resolveTranslations(object, lookup, cache);
+                if (translations.isEmpty()) {
+                    if (object.has("translations")) {
+                        object.remove("translations");
+                    }
+                } else {
+                    JsonArray existingArray = object.has("translations") && object.get("translations").isJsonArray()
+                            ? object.getAsJsonArray("translations")
+                            : null;
+                    if (!matches(existingArray, translations)) {
+                        JsonArray array = new JsonArray();
+                        for (String translation : translations) {
+                            array.add(translation);
+                        }
+                        object.remove("translations");
+                        object.add("translations", array);
+                    }
+                    tokensWithTranslations++;
+                    translationsWritten += translations.size();
+                }
+                String serialised = toJsonLine(object);
+                if (!serialised.equals(line)) {
+                    modified = true;
+                }
+                output.add(serialised);
+            }
+        }
+
+        if (modified) {
+            try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+                for (int i = 0; i < output.size(); i++) {
+                    if (i > 0) {
+                        writer.newLine();
+                    }
+                    writer.write(output.get(i));
+                }
+            }
+        }
+
+        return new FileReport(tokensProcessed, tokensWithTranslations, translationsWritten);
+    }
+
+    private List<String> resolveTranslations(JsonObject object,
+                                             PreparedStatement lookup,
+                                             Map<String, List<String>> cache) throws SQLException {
+        if (object == null || !object.has("analysis")) {
+            return Collections.emptyList();
+        }
+        JsonElement element = object.get("analysis");
+        if (!element.isJsonPrimitive()) {
+            return Collections.emptyList();
+        }
+        String analysis = element.getAsString();
+        if (analysis == null || analysis.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Set<String> translations = new LinkedHashSet<>();
+        for (String lemma : extractCandidateLemmas(analysis)) {
+            List<String> values = lookupTranslations(lemma, lookup, cache);
+            for (String value : values) {
+                if (value != null && !value.isBlank()) {
+                    translations.add(value);
+                }
+            }
+        }
+        return new ArrayList<>(translations);
+    }
+
+    private List<String> extractCandidateLemmas(String analysis) {
+        if (analysis == null || analysis.isBlank()) {
+            return Collections.emptyList();
+        }
+        String[] parts = analysis.split(";");
+        Set<String> lemmas = new LinkedHashSet<>();
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int plus = trimmed.indexOf('+');
+            if (plus <= 0) {
+                continue;
+            }
+            String lemma = trimmed.substring(0, plus).trim();
+            if (lemma.isEmpty()) {
+                continue;
+            }
+            String normalised = Normalizer.normalize(lemma, Normalizer.Form.NFC)
+                    .toLowerCase(Locale.ROOT);
+            lemmas.add(normalised);
+        }
+        return new ArrayList<>(lemmas);
+    }
+
+    private List<String> lookupTranslations(String lemma,
+                                             PreparedStatement lookup,
+                                             Map<String, List<String>> cache) throws SQLException {
+        if (lemma == null || lemma.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> cached = cache.get(lemma);
+        if (cached != null) {
+            return cached;
+        }
+        List<String> results = new ArrayList<>();
+        lookup.setString(1, lemma);
+        try (ResultSet rs = lookup.executeQuery()) {
+            while (rs.next()) {
+                String value = rs.getString(1);
+                if (value != null) {
+                    results.add(value);
+                }
+            }
+        }
+        List<String> unmodifiable = Collections.unmodifiableList(results);
+        cache.put(lemma, unmodifiable);
+        return unmodifiable;
+    }
+
+    private boolean matches(JsonArray existing, List<String> translations) {
+        if (existing == null) {
+            return false;
+        }
+        if (existing.size() != translations.size()) {
+            return false;
+        }
+        for (int i = 0; i < translations.size(); i++) {
+            JsonElement element = existing.get(i);
+            if (!element.isJsonPrimitive()) {
+                return false;
+            }
+            String value = element.getAsString();
+            if (!Objects.equals(value, translations.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String toJsonLine(JsonObject object) {
+        StringBuilder builder = new StringBuilder();
+        builder.append('{');
+        boolean first = true;
+        for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+            if (!first) {
+                builder.append(", ");
+            }
+            first = false;
+            builder.append(GSON.toJson(entry.getKey()));
+            builder.append(": ");
+            JsonElement value = entry.getValue();
+            if (value.isJsonArray() && "translations".equals(entry.getKey())) {
+                builder.append(formatArray(value.getAsJsonArray()));
+            } else {
+                builder.append(GSON.toJson(value));
+            }
+        }
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private String formatArray(JsonArray array) {
+        StringBuilder builder = new StringBuilder();
+        builder.append('[');
+        for (int i = 0; i < array.size(); i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            builder.append(GSON.toJson(array.get(i)));
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    private static final class FileReport {
+        final int tokensProcessed;
+        final int tokensWithTranslations;
+        final int translationsWritten;
+
+        FileReport(int tokensProcessed, int tokensWithTranslations, int translationsWritten) {
+            this.tokensProcessed = tokensProcessed;
+            this.tokensWithTranslations = tokensWithTranslations;
+            this.translationsWritten = translationsWritten;
+        }
+    }
+}

--- a/web-app/src/test/java/com/example/uqureader/webapp/assets/JsonlTranslationAugmenterTest.java
+++ b/web-app/src/test/java/com/example/uqureader/webapp/assets/JsonlTranslationAugmenterTest.java
@@ -1,0 +1,69 @@
+package com.example.uqureader.webapp.assets;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonlTranslationAugmenterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void augmentAddsTranslationsAndIsIdempotent() throws Exception {
+        Path assets = Files.createDirectory(tempDir.resolve("assets"));
+        Path dictionary = tempDir.resolve("tat_rus_dictionary.db");
+        createDictionary(dictionary);
+
+        Path jsonl = assets.resolve("sample.jsonl");
+        Files.writeString(jsonl,
+                "{\"prefix\": \"\", \"surface\": \"сүз\", \"analysis\": \"сүз+N+Sg+Nom;\"}\n"
+                        + "{\"prefix\": \"\", \"surface\": \"бар\", \"analysis\": \"бар+N+Sg+Nom;бар+PN;\"}\n"
+                        + "{\"prefix\": \"\", \"surface\": \"Рус\", \"analysis\": \"Rus\"}\n",
+                StandardCharsets.UTF_8);
+
+        JsonlTranslationAugmenter augmenter = new JsonlTranslationAugmenter();
+        JsonlTranslationAugmenter.Report report = augmenter.augment(assets, dictionary);
+
+        String content = Files.readString(jsonl, StandardCharsets.UTF_8);
+        String[] lines = content.split("\\R");
+        assertTrue(lines[0].contains("\"translations\": [\"слово\"]"));
+        assertTrue(lines[1].contains("\"translations\": [\"есть\", \"каждый\"]")
+                || lines[1].contains("\"translations\": [\"каждый\", \"есть\"]"));
+        assertTrue(!lines[2].contains("\"translations\""));
+
+        assertEquals(1, report.getFilesProcessed());
+        assertEquals(3, report.getTokensProcessed());
+        assertEquals(2, report.getTokensWithTranslations());
+        assertEquals(3, report.getTranslationsWritten());
+
+        String before = content;
+        JsonlTranslationAugmenter.Report second = augmenter.augment(assets, dictionary);
+        String after = Files.readString(jsonl, StandardCharsets.UTF_8);
+        assertEquals(before, after);
+        assertEquals(1, second.getFilesProcessed());
+        assertEquals(3, second.getTokensProcessed());
+        assertEquals(2, second.getTokensWithTranslations());
+        assertEquals(3, second.getTranslationsWritten());
+    }
+
+    private void createDictionary(Path dbPath) throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + dbPath.toAbsolutePath());
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE tat_rus_dictionary (tat_lemma TEXT, rus_lemma TEXT)");
+            statement.executeUpdate("INSERT INTO tat_rus_dictionary (tat_lemma, rus_lemma) VALUES\n"
+                    + "('сүз', 'слово'),\n"
+                    + "('бар', 'есть'),\n"
+                    + "('бар', 'каждый')");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a JsonlTranslationAugmenter utility that reads the tat-rus dictionary and enriches JSONL tokens with translation arrays
- expose a new `--augment-assets` command in the web-app entry point and cover the augmenter with unit tests
- run the augmenter to populate the Android JSONL assets with Russian translations for matching lemmas

## Testing
- ./mvnw -pl web-app test

------
https://chatgpt.com/codex/tasks/task_e_68cfb04a9d90832a8e27d921c41a8747