### PR TITLE
Show lemma translations in stats view

### DIFF
--- a/android-app/src/main/res/layout/item_stats_entry.xml
+++ b/android-app/src/main/res/layout/item_stats_entry.xml
@@ -13,6 +13,13 @@
         android:textSize="16sp"/>
 
     <TextView
+        android:id="@+id/statsTranslation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="2dp"
+        android:textAppearance="?android:attr/textAppearanceSmall"/>
+
+    <TextView
         android:id="@+id/statsExposure"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android-app/src/main/res/values/strings.xml
+++ b/android-app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="feature_codes_format">морфологический набор: %1$s</string>
     <string name="features_title">Суффиксы и окончания</string>
     <string name="translation_format">→ %1$s</string>
+    <string name="stats_translation_label">Перевод: %1$s</string>
     <string name="feature_chip_format">%1$s · %2$s</string>
     <string name="feature_no_form">—</string>
     <string name="feature_dialog_tt">Татарское название: %1$s</string>


### PR DESCRIPTION
## Summary
- load the bilingual dictionary in stats mode and fetch Russian equivalents for each lemma
- surface those translations in the lemma statistics list with a compact label

## Testing
- `./mvnw -pl android-app -am test` *(fails: missing Android SDK platform files in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb65e76a8832a80a9f07b8d31915a