### PR TITLE
Fix TTS detail speech to include token translations

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -356,7 +356,14 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private void speakTokenDetails(TokenSpan span, List<String> translations, boolean resumeAfter) {
         if (!ttsReady || textToSpeech == null || talgatVoice == null) return;
         if (span == null || span.token == null) return;
-        List<String> safeTranslations = DetailSpeechFormatter.sanitizeTranslations(translations);
+        List<String> combinedTranslations = new ArrayList<>();
+        if (translations != null) {
+            combinedTranslations.addAll(translations);
+        }
+        if (span.token != null && span.token.translations != null) {
+            combinedTranslations.addAll(span.token.translations);
+        }
+        List<String> safeTranslations = DetailSpeechFormatter.sanitizeTranslations(combinedTranslations);
         String detailText = DetailSpeechFormatter.buildDetailSpeech(span, safeTranslations, true);
         if (TextUtils.isEmpty(detailText)) {
             return;

--- a/android-app/src/main/java/com/example/ttreader/reader/TtsReaderController.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/TtsReaderController.java
@@ -186,7 +186,14 @@ public class TtsReaderController {
 
     public void speakTokenDetails(TokenSpan span, List<String> translations, boolean resumeAfter) {
         if (!initialized || span == null || span.token == null) return;
-        List<String> safeTranslations = DetailSpeechFormatter.sanitizeTranslations(translations);
+        List<String> combinedTranslations = new ArrayList<>();
+        if (translations != null) {
+            combinedTranslations.addAll(translations);
+        }
+        if (span.token != null && span.token.translations != null) {
+            combinedTranslations.addAll(span.token.translations);
+        }
+        List<String> safeTranslations = DetailSpeechFormatter.sanitizeTranslations(combinedTranslations);
         resumeAfterDetails = resumeAfter && mode == Mode.READING;
         mode = Mode.DETAIL;
         updatePlaybackState();


### PR DESCRIPTION
## Summary
- merge dictionary results with token-provided translations before building detail speech text
- apply the same combination when speaking token details via the reader controller so speech reflects available translations

## Testing
- ./mvnw -pl android-app test *(fails: missing /usr/lib/android-sdk/platforms/android-28/android.jar in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfea3b7024832a82691b65b978a4a0