### PR TITLE
Handle lemma detail cancellation from media controls

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -347,6 +347,13 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         super.onDestroy();
     }
 
+    @Override public void onBackPressed() {
+        if (cancelDetailSpeech()) {
+            return;
+        }
+        super.onBackPressed();
+    }
+
     @Override public void onTokenLongPress(TokenSpan span, List<String> ruLemmas) {
         boolean resumeAfter = isSpeaking || shouldContinueSpeech;
         speakTokenDetails(span, ruLemmas, resumeAfter);
@@ -375,18 +382,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         awaitingResumeAfterDetail = !resumeAfter;
         detailAutoResume = resumeAfter;
         stopDetailPlayback();
-        if (pendingDetailRequest != null) {
-            Iterator<Map.Entry<String, SpeechRequest>> iterator = pendingRequests.entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<String, SpeechRequest> entry = iterator.next();
-                if (entry.getValue() == pendingDetailRequest) {
-                    iterator.remove();
-                    break;
-                }
-            }
-            pendingDetailRequest.deleteFile();
-            pendingDetailRequest = null;
-        }
+        cancelPendingDetailRequest();
         try {
             File file = File.createTempFile("detail_" + Math.max(0, span.getStartIndex()) + "_", ".wav", getCacheDir());
             String utteranceId = "detail_" + (utteranceSequence++);
@@ -406,6 +402,29 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         } catch (IOException e) {
             Log.e(TAG, "Failed to synthesize detail audio", e);
             awaitingResumeAfterDetail = !resumeAfter;
+        }
+    }
+
+    private void cancelPendingDetailRequest() {
+        if (pendingDetailRequest == null) {
+            return;
+        }
+        removePendingRequest(pendingDetailRequest);
+        pendingDetailRequest.deleteFile();
+        pendingDetailRequest = null;
+    }
+
+    private void removePendingRequest(SpeechRequest target) {
+        if (target == null) {
+            return;
+        }
+        Iterator<Map.Entry<String, SpeechRequest>> iterator = pendingRequests.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, SpeechRequest> entry = iterator.next();
+            if (entry.getValue() == target) {
+                iterator.remove();
+                break;
+            }
         }
     }
 
@@ -826,7 +845,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
             textToSpeech.stop();
         }
         stopDetailPlayback();
-        pendingDetailRequest = null;
+        cancelPendingDetailRequest();
         activeDetailRequest = null;
         detailAutoResume = false;
         releaseSentencePlayer();
@@ -1259,6 +1278,13 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     }
 
     private void performMediaButtonAction() {
+        if (cancelDetailSpeech()) {
+            return;
+        }
+        if (awaitingResumeAfterDetail) {
+            resumeSentenceAfterDetail();
+            return;
+        }
         if (isSpeaking) {
             pauseSpeechFromHeadset();
         } else {
@@ -1267,7 +1293,11 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     }
 
     private void handleMediaSkip(boolean forward) {
-        if (detailPlaybackActive() || pendingDetailRequest != null || awaitingResumeAfterDetail) {
+        boolean detailActive = detailPlaybackActive()
+                || activeDetailRequest != null
+                || pendingDetailRequest != null
+                || awaitingResumeAfterDetail;
+        if (detailActive && !isSpeaking) {
             handleDetailSkip(forward);
             return;
         }
@@ -1633,6 +1663,22 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         }
     }
 
+    private boolean cancelDetailSpeech() {
+        boolean hasDetail = detailPlaybackActive()
+                || activeDetailRequest != null
+                || pendingDetailRequest != null;
+        if (!hasDetail) {
+            return false;
+        }
+        stopDetailPlayback();
+        cancelPendingDetailRequest();
+        detailAutoResume = false;
+        awaitingResumeAfterDetail = true;
+        updatePlaybackState(PlaybackState.STATE_PAUSED);
+        updateSpeechButtons();
+        return true;
+    }
+
     private boolean detailPlaybackActive() {
         if (detailPlayer == null) return false;
         try {
@@ -1779,8 +1825,10 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
             return false;
         }
         int keyCode = event.getKeyCode();
-        if (detailPlaybackActive() || pendingDetailRequest != null) {
-            if (isSkipForwardKey(keyCode)) {
+        if (detailPlaybackActive() || activeDetailRequest != null || pendingDetailRequest != null) {
+            if (isPlayPauseKey(keyCode) || keyCode == KeyEvent.KEYCODE_BACK) {
+                cancelDetailSpeech();
+            } else if (isSkipForwardKey(keyCode)) {
                 handleDetailSkip(true);
             } else if (isSkipBackwardKey(keyCode)) {
                 handleDetailSkip(false);


### PR DESCRIPTION
## Summary
- stop lemma detail playback immediately when back or play/pause controls are pressed and await resume
- centralize cancellation of pending lemma detail synthesis requests and reuse it across callers
- prevent media skip buttons from triggering lemma detail playback while sentences are being read

## Testing
- ./mvnw -pl android-app test *(fails: missing Android SDK android-28 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68d0218827b0832aacfb1f4f82509b5e