### PR TITLE
Add async DB writes and bluetooth pause stats

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/data/DbHelper.java
+++ b/android-app/src/main/java/com/example/ttreader/data/DbHelper.java
@@ -18,7 +18,7 @@ import java.io.OutputStream;
 
 public class DbHelper extends SQLiteOpenHelper {
     public static final String APP_DB_NAME = "appdata.db";
-    private static final int APP_DB_VERSION = 3;
+    private static final int APP_DB_VERSION = 4;
 
     private static final String TAG = "DbHelper";
     private static final String PREFS_NAME = "com.example.ttreader.DB_PREFS";
@@ -43,6 +43,7 @@ public class DbHelper extends SQLiteOpenHelper {
                 ")");
         db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS memory_idx ON memory(lemma, IFNULL(feature_key,'~'))");
         createUsageTables(db);
+        createDeviceStatsTables(db);
     }
 
     @Override public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
@@ -53,6 +54,9 @@ public class DbHelper extends SQLiteOpenHelper {
             db.execSQL("DROP TABLE IF EXISTS usage_stats");
             db.execSQL("DROP TABLE IF EXISTS usage_event_log");
             createUsageTables(db);
+        }
+        if (oldVersion < 4) {
+            createDeviceStatsTables(db);
         }
     }
 
@@ -194,6 +198,36 @@ public class DbHelper extends SQLiteOpenHelper {
                 ")");
         db.execSQL("CREATE INDEX IF NOT EXISTS usage_event_lookup_idx ON usage_event_log(\n" +
                 " language_pair, work_id, lemma, pos, event_type, timestamp_ms\n" +
+                ")");
+    }
+
+    private void createDeviceStatsTables(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS device_pause_events(\n" +
+                " id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
+                " descriptor TEXT NOT NULL,\n" +
+                " display_name TEXT,\n" +
+                " vendor_id INTEGER,\n" +
+                " product_id INTEGER,\n" +
+                " source_flags INTEGER,\n" +
+                " pause_offset_ms INTEGER NOT NULL,\n" +
+                " target_offset_ms INTEGER NOT NULL,\n" +
+                " delta_ms INTEGER NOT NULL,\n" +
+                " char_delta INTEGER NOT NULL,\n" +
+                " language_pair TEXT,\n" +
+                " work_id TEXT,\n" +
+                " recorded_at_ms INTEGER NOT NULL\n" +
+                ")");
+        db.execSQL("CREATE INDEX IF NOT EXISTS device_pause_events_descriptor_idx\n" +
+                " ON device_pause_events(descriptor, recorded_at_ms)");
+        db.execSQL("CREATE TABLE IF NOT EXISTS device_reaction_stats(\n" +
+                " descriptor TEXT PRIMARY KEY,\n" +
+                " display_name TEXT,\n" +
+                " vendor_id INTEGER,\n" +
+                " product_id INTEGER,\n" +
+                " source_flags INTEGER,\n" +
+                " sample_count INTEGER NOT NULL DEFAULT 0,\n" +
+                " avg_reaction_delay_ms REAL NOT NULL DEFAULT 0,\n" +
+                " last_seen_ms INTEGER NOT NULL DEFAULT 0\n" +
                 ")");
     }
 

--- a/android-app/src/main/java/com/example/ttreader/data/DbWriteQueue.java
+++ b/android-app/src/main/java/com/example/ttreader/data/DbWriteQueue.java
@@ -1,0 +1,88 @@
+package com.example.ttreader.data;
+
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+import android.util.Log;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serializes database write operations on a background thread and batches them to avoid UI stalls.
+ */
+public final class DbWriteQueue {
+    private static final String TAG = "DbWriteQueue";
+    private static final int MAX_BATCH_SIZE = 32;
+    private static final long BATCH_DELAY_MS = 24L;
+
+    private static final DbWriteQueue INSTANCE = new DbWriteQueue();
+
+    private final HandlerThread workerThread;
+    private final Handler workerHandler;
+    private final ArrayDeque<Runnable> pending = new ArrayDeque<>();
+    private final Object lock = new Object();
+    private boolean drainScheduled = false;
+
+    private final Runnable drainRunnable = new Runnable() {
+        @Override
+        public void run() {
+            List<Runnable> batch = new ArrayList<>(MAX_BATCH_SIZE);
+            while (true) {
+                boolean scheduleMore;
+                batch.clear();
+                synchronized (lock) {
+                    while (!pending.isEmpty() && batch.size() < MAX_BATCH_SIZE) {
+                        batch.add(pending.removeFirst());
+                    }
+                    scheduleMore = !pending.isEmpty();
+                    if (scheduleMore) {
+                        workerHandler.postDelayed(this, BATCH_DELAY_MS);
+                    } else {
+                        drainScheduled = false;
+                    }
+                }
+                if (batch.isEmpty()) {
+                    break;
+                }
+                for (Runnable task : batch) {
+                    try {
+                        task.run();
+                    } catch (Exception e) {
+                        Log.e(TAG, "DB write task failed", e);
+                    }
+                }
+                if (!scheduleMore) {
+                    break;
+                }
+                // When more work remains we break here; the re-post above will pick it up shortly.
+                break;
+            }
+        }
+    };
+
+    private DbWriteQueue() {
+        workerThread = new HandlerThread("DbWriteQueue");
+        workerThread.start();
+        Looper looper = workerThread.getLooper();
+        workerHandler = new Handler(looper);
+    }
+
+    public static DbWriteQueue getInstance() {
+        return INSTANCE;
+    }
+
+    public void enqueue(Runnable task) {
+        if (task == null) {
+            return;
+        }
+        synchronized (lock) {
+            pending.addLast(task);
+            if (!drainScheduled) {
+                drainScheduled = true;
+                workerHandler.post(drainRunnable);
+            }
+        }
+    }
+}

--- a/android-app/src/main/java/com/example/ttreader/data/DeviceIdentity.java
+++ b/android-app/src/main/java/com/example/ttreader/data/DeviceIdentity.java
@@ -1,0 +1,107 @@
+package com.example.ttreader.data;
+
+import android.os.Build;
+import android.text.TextUtils;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+
+/**
+ * Extracts a stable identity for input devices that trigger media events.
+ */
+public final class DeviceIdentity {
+    private static final DeviceIdentity UNKNOWN = new DeviceIdentity(-1, "", "", 0, 0, 0, false, false);
+
+    public final int deviceId;
+    public final String descriptor;
+    public final String displayName;
+    public final int vendorId;
+    public final int productId;
+    public final int sourceFlags;
+    public final boolean external;
+    public final boolean bluetoothLikely;
+
+    private DeviceIdentity(int deviceId, String descriptor, String displayName,
+                           int vendorId, int productId, int sourceFlags,
+                           boolean external, boolean bluetoothLikely) {
+        this.deviceId = deviceId;
+        this.descriptor = descriptor == null ? "" : descriptor;
+        this.displayName = displayName == null ? "" : displayName;
+        this.vendorId = vendorId;
+        this.productId = productId;
+        this.sourceFlags = sourceFlags;
+        this.external = external;
+        this.bluetoothLikely = bluetoothLikely;
+    }
+
+    public static DeviceIdentity from(KeyEvent event) {
+        if (event == null) {
+            return UNKNOWN;
+        }
+        int deviceId = event.getDeviceId();
+        InputDevice device = event.getDevice();
+        if (device == null && deviceId != InputDevice.SOURCE_ANY) {
+            device = InputDevice.getDevice(deviceId);
+        }
+        if (device == null) {
+            return new DeviceIdentity(deviceId, "", "", 0, 0, 0, false, false);
+        }
+        int sources = device.getSources();
+        boolean external = isExternal(device);
+        boolean bluetooth = (sources & InputDevice.SOURCE_BLUETOOTH_STYLUS) != 0
+                || (sources & InputDevice.SOURCE_CLASS_JOYSTICK) != 0
+                || (sources & InputDevice.SOURCE_CLASS_BUTTON) != 0;
+        String descriptor = device.getDescriptor();
+        String name = device.getName();
+        if (!bluetooth) {
+            bluetooth = (!TextUtils.isEmpty(descriptor) && descriptor.toLowerCase().contains("bluetooth"))
+                    || (!TextUtils.isEmpty(name) && name.toLowerCase().contains("bluetooth"));
+        }
+        return new DeviceIdentity(deviceId,
+                descriptor,
+                name,
+                device.getVendorId(),
+                device.getProductId(),
+                sources,
+                external,
+                bluetooth);
+    }
+
+    public boolean isValid() {
+        return deviceId != -1 || !TextUtils.isEmpty(descriptor) || !TextUtils.isEmpty(displayName);
+    }
+
+    public String stableKey() {
+        if (!TextUtils.isEmpty(descriptor)) {
+            return descriptor;
+        }
+        if (!TextUtils.isEmpty(displayName)) {
+            return displayName + "#" + vendorId + ":" + productId;
+        }
+        return "device:" + deviceId;
+    }
+
+    public boolean shouldTrack() {
+        return external || bluetoothLikely;
+    }
+
+    private static boolean isExternal(InputDevice device) {
+        if (device == null) {
+            return false;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (device.isExternal()) {
+                return true;
+            }
+        }
+        int sources = device.getSources();
+        if ((sources & InputDevice.SOURCE_CLASS_BUTTON) != 0
+                || (sources & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {
+            return true;
+        }
+        if ((sources & InputDevice.SOURCE_KEYBOARD) != 0
+                && device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
+            return true;
+        }
+        return device.getVendorId() != 0 || device.getProductId() != 0;
+    }
+}

--- a/android-app/src/main/java/com/example/ttreader/data/DeviceStatsDao.java
+++ b/android-app/src/main/java/com/example/ttreader/data/DeviceStatsDao.java
@@ -1,0 +1,132 @@
+package com.example.ttreader.data;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.text.TextUtils;
+
+public class DeviceStatsDao {
+    private final SQLiteDatabase db;
+    private final DbWriteQueue writeQueue;
+
+    public DeviceStatsDao(SQLiteDatabase db) {
+        this(db, DbWriteQueue.getInstance());
+    }
+
+    public DeviceStatsDao(SQLiteDatabase db, DbWriteQueue queue) {
+        this.db = db;
+        this.writeQueue = queue;
+    }
+
+    public void recordPauseReaction(DeviceIdentity device, long pauseOffsetMs,
+                                    long targetOffsetMs, long deltaMs, long charDelta,
+                                    String languagePair, String workId, long recordedAtMs) {
+        if (device == null || !device.shouldTrack()) {
+            return;
+        }
+        final String descriptor = sanitize(device.stableKey());
+        final String displayName = sanitize(device.displayName);
+        final int vendorId = device.vendorId;
+        final int productId = device.productId;
+        final int sourceFlags = device.sourceFlags;
+        final long safePauseOffset = Math.max(0L, pauseOffsetMs);
+        final long safeTargetOffset = Math.max(0L, targetOffsetMs);
+        final long safeDelta = Math.max(0L, deltaMs);
+        final long safeCharDelta = Math.max(0L, charDelta);
+        final String safeLanguage = sanitize(languagePair);
+        final String safeWork = sanitize(workId);
+        final long timestamp = recordedAtMs <= 0 ? System.currentTimeMillis() : recordedAtMs;
+
+        writeQueue.enqueue(() -> {
+            ContentValues event = new ContentValues();
+            event.put("descriptor", descriptor);
+            event.put("display_name", displayName);
+            event.put("vendor_id", vendorId);
+            event.put("product_id", productId);
+            event.put("source_flags", sourceFlags);
+            event.put("pause_offset_ms", safePauseOffset);
+            event.put("target_offset_ms", safeTargetOffset);
+            event.put("delta_ms", safeDelta);
+            event.put("char_delta", safeCharDelta);
+            event.put("language_pair", safeLanguage);
+            event.put("work_id", safeWork);
+            event.put("recorded_at_ms", timestamp);
+            db.insert("device_pause_events", null, event);
+
+            int count = 0;
+            double avgDelay = 0;
+            try (Cursor c = db.rawQuery(
+                    "SELECT sample_count, avg_reaction_delay_ms FROM device_reaction_stats WHERE descriptor=?",
+                    new String[]{descriptor})) {
+                if (c.moveToFirst()) {
+                    count = c.getInt(0);
+                    avgDelay = c.getDouble(1);
+                }
+            }
+            int newCount = count + 1;
+            double newAvg = newCount == 0 ? safeDelta
+                    : ((avgDelay * count) + safeDelta) / Math.max(1, newCount);
+            ContentValues stats = new ContentValues();
+            stats.put("descriptor", descriptor);
+            stats.put("display_name", displayName);
+            stats.put("vendor_id", vendorId);
+            stats.put("product_id", productId);
+            stats.put("source_flags", sourceFlags);
+            stats.put("sample_count", newCount);
+            stats.put("avg_reaction_delay_ms", newAvg);
+            stats.put("last_seen_ms", timestamp);
+            db.insertWithOnConflict("device_reaction_stats", null, stats, SQLiteDatabase.CONFLICT_REPLACE);
+        });
+    }
+
+    public DeviceReactionStats getStats(String descriptor) {
+        String key = sanitize(descriptor);
+        if (TextUtils.isEmpty(key)) {
+            return null;
+        }
+        try (Cursor c = db.rawQuery(
+                "SELECT descriptor, display_name, vendor_id, product_id, source_flags, sample_count, avg_reaction_delay_ms, last_seen_ms " +
+                        "FROM device_reaction_stats WHERE descriptor=?",
+                new String[]{key})) {
+            if (c.moveToFirst()) {
+                return new DeviceReactionStats(
+                        c.getString(0),
+                        c.getString(1),
+                        c.getInt(2),
+                        c.getInt(3),
+                        c.getInt(4),
+                        c.getInt(5),
+                        c.getDouble(6),
+                        c.getLong(7));
+            }
+        }
+        return null;
+    }
+
+    private static String sanitize(String value) {
+        return value == null ? "" : value;
+    }
+
+    public static final class DeviceReactionStats {
+        public final String descriptor;
+        public final String displayName;
+        public final int vendorId;
+        public final int productId;
+        public final int sourceFlags;
+        public final int sampleCount;
+        public final double averageDelayMs;
+        public final long lastSeenMs;
+
+        DeviceReactionStats(String descriptor, String displayName, int vendorId, int productId,
+                            int sourceFlags, int sampleCount, double averageDelayMs, long lastSeenMs) {
+            this.descriptor = descriptor == null ? "" : descriptor;
+            this.displayName = displayName == null ? "" : displayName;
+            this.vendorId = vendorId;
+            this.productId = productId;
+            this.sourceFlags = sourceFlags;
+            this.sampleCount = sampleCount;
+            this.averageDelayMs = averageDelayMs;
+            this.lastSeenMs = lastSeenMs;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a DbWriteQueue and update MemoryDao/UsageStatsDao to batch database inserts off the UI thread
- Extend the SQLite schema with device pause/reaction tables and a DeviceStatsDao for tracking per-device rewind delays
- Capture headset pause metadata in MainActivity, store device identity, and auto-adjust highlights based on learned averages

## Testing
- `./mvnw -pl android-app test` *(fails: missing android SDK jars in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d04558fc48832abc37ce9fea8db772