### PR TITLE
Make book loading asynchronous

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -641,8 +641,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         WorkInfo work = getCurrentWork();
         if (readerView == null || work == null) return;
         readerView.setUsageContext(currentLanguagePair, work.id);
-        readerView.loadFromJsonlAsset(work.asset);
-        readerView.post(this::updateSentenceRanges);
+        readerView.loadFromJsonlAsset(work.asset, this::updateSentenceRanges);
         updateWorkMenuDisplay();
     }
 


### PR DESCRIPTION
## Summary
- move ReaderView JSONL parsing and span construction onto a background executor with cancellation
- expose an async load API that updates spans and sentence ranges on the UI thread when complete
- update MainActivity to await the async load before refreshing sentence metadata

## Testing
- ./mvnw -pl android-app test *(fails: missing /usr/lib/android-sdk/platforms/android-28/android.jar in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d17c2db2f8832aa12f44434268d185