### PR TITLE
Persist reader state before switching works

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -815,6 +815,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
             updateWorkMenuDisplay();
             return;
         }
+        persistReadingStateNow();
         stopSpeech();
         currentWork = work;
         reloadReaderForCurrentSelection();


### PR DESCRIPTION
## Summary
- save the current reading position before changing to a different work so returning to a text restores its scroll position

## Testing
- ./mvnw -e clean install *(fails: D8 reports missing classes.jar in unpacked AndroidX libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68d2367d08d4832a96421cd9daa3e6f4