### PR TITLE
Display reading progress pages and add Bluetooth device stats

### DIFF
--- a/android-app/pom.xml
+++ b/android-app/pom.xml
@@ -488,5 +488,28 @@ fi
       <version>1.3.2</version>
       <type>aar</type>
     </dependency>
+    <dependency>
+      <groupId>androidx.customview</groupId>
+      <artifactId>customview-poolingcontainer</artifactId>
+      <version>1.0.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.core</groupId>
+      <artifactId>core-ktx</artifactId>
+      <version>1.5.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.6.21</version>
+    </dependency>
+    <dependency>
+      <groupId>androidx.arch.core</groupId>
+      <artifactId>core-runtime</artifactId>
+      <version>2.1.0</version>
+      <type>aar</type>
+    </dependency>
   </dependencies>
 </project>

--- a/android-app/src/main/AndroidManifest.xml
+++ b/android-app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".StatsActivity" />
+        <activity android:name=".DeviceStatsActivity" />
 
     </application>
 </manifest>

--- a/android-app/src/main/java/com/example/ttreader/DeviceStatsActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/DeviceStatsActivity.java
@@ -1,0 +1,175 @@
+package com.example.ttreader;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.ttreader.data.DbHelper;
+import com.example.ttreader.data.DeviceStatsDao;
+
+import java.text.DateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class DeviceStatsActivity extends Activity {
+    private DeviceStatsDao deviceStatsDao;
+    private RecyclerView statsRecycler;
+    private View emptyView;
+    private DeviceStatsAdapter adapter;
+    private ExecutorService executor;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private DateFormat dateFormat;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_device_stats);
+        setTitle(R.string.device_stats_title);
+
+        statsRecycler = findViewById(R.id.deviceStatsRecycler);
+        emptyView = findViewById(R.id.deviceStatsEmpty);
+        statsRecycler.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new DeviceStatsAdapter();
+        statsRecycler.setAdapter(adapter);
+
+        deviceStatsDao = new DeviceStatsDao(new DbHelper(this).getReadableDatabase());
+        executor = Executors.newSingleThreadExecutor();
+        dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.getDefault());
+
+        loadStats();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (executor != null) {
+            executor.shutdownNow();
+            executor = null;
+        }
+    }
+
+    private void loadStats() {
+        if (executor == null) {
+            return;
+        }
+        executor.submit(() -> {
+            List<DeviceStatsDao.DeviceReactionStats> allStats = deviceStatsDao.getAllStats();
+            List<DeviceStatsDao.DeviceReactionStats> filtered = new ArrayList<>();
+            if (allStats != null) {
+                for (DeviceStatsDao.DeviceReactionStats entry : allStats) {
+                    if (entry == null) continue;
+                    if (!entry.bluetoothLikely && !looksLikeBluetooth(entry)) {
+                        continue;
+                    }
+                    if (entry.sampleCount <= 0) {
+                        continue;
+                    }
+                    filtered.add(entry);
+                }
+            }
+            mainHandler.post(() -> applyStats(filtered));
+        });
+    }
+
+    private boolean looksLikeBluetooth(DeviceStatsDao.DeviceReactionStats stats) {
+        if (stats == null) {
+            return false;
+        }
+        String descriptor = stats.descriptor == null ? "" : stats.descriptor.toLowerCase(Locale.ROOT);
+        String name = stats.displayName == null ? "" : stats.displayName.toLowerCase(Locale.ROOT);
+        return descriptor.contains("bluetooth") || name.contains("bluetooth");
+    }
+
+    private void applyStats(List<DeviceStatsDao.DeviceReactionStats> stats) {
+        adapter.setItems(stats, dateFormat);
+        boolean empty = stats == null || stats.isEmpty();
+        statsRecycler.setVisibility(empty ? View.GONE : View.VISIBLE);
+        emptyView.setVisibility(empty ? View.VISIBLE : View.GONE);
+    }
+
+    private static final class DeviceStatsAdapter extends RecyclerView.Adapter<DeviceStatsAdapter.ViewHolder> {
+        private final List<DeviceStatsDao.DeviceReactionStats> items = new ArrayList<>();
+        private DateFormat dateFormat;
+
+        void setItems(List<DeviceStatsDao.DeviceReactionStats> stats, DateFormat format) {
+            items.clear();
+            if (stats != null) {
+                items.addAll(stats);
+            }
+            dateFormat = format;
+            notifyDataSetChanged();
+        }
+
+        @NonNull
+        @Override
+        public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_device_stat, parent, false);
+            return new ViewHolder(view);
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+            holder.bind(items.get(position), dateFormat);
+        }
+
+        @Override
+        public int getItemCount() {
+            return items.size();
+        }
+
+        private static final class ViewHolder extends RecyclerView.ViewHolder {
+            private final TextView nameView;
+            private final TextView averageView;
+            private final TextView lastSeenView;
+
+            ViewHolder(@NonNull View itemView) {
+                super(itemView);
+                nameView = itemView.findViewById(R.id.deviceStatName);
+                averageView = itemView.findViewById(R.id.deviceStatAverage);
+                lastSeenView = itemView.findViewById(R.id.deviceStatLastSeen);
+            }
+
+            void bind(DeviceStatsDao.DeviceReactionStats stats, DateFormat dateFormat) {
+                Context context = itemView.getContext();
+                String name;
+                if (!TextUtils.isEmpty(stats.displayName)) {
+                    name = stats.displayName;
+                } else if (!TextUtils.isEmpty(stats.descriptor)) {
+                    name = stats.descriptor;
+                } else {
+                    name = context.getString(R.string.device_stats_unknown_device);
+                }
+                nameView.setText(name);
+
+                double seconds = Math.max(0d, stats.averageDelayMs) / 1000d;
+                String averageText = stats.sampleCount > 0
+                        ? context.getString(R.string.device_stats_average_with_samples, seconds, stats.sampleCount)
+                        : context.getString(R.string.device_stats_average_only, seconds);
+                averageView.setText(averageText);
+
+                if (stats.lastSeenMs > 0 && dateFormat != null) {
+                    String formatted = dateFormat.format(new Date(stats.lastSeenMs));
+                    lastSeenView.setText(context.getString(R.string.device_stats_last_seen, formatted));
+                    lastSeenView.setVisibility(View.VISIBLE);
+                } else {
+                    lastSeenView.setVisibility(View.GONE);
+                }
+            }
+        }
+    }
+}

--- a/android-app/src/main/java/com/example/ttreader/data/DbHelper.java
+++ b/android-app/src/main/java/com/example/ttreader/data/DbHelper.java
@@ -18,7 +18,7 @@ import java.io.OutputStream;
 
 public class DbHelper extends SQLiteOpenHelper {
     public static final String APP_DB_NAME = "appdata.db";
-    private static final int APP_DB_VERSION = 4;
+    private static final int APP_DB_VERSION = 5;
 
     private static final String TAG = "DbHelper";
     private static final String PREFS_NAME = "com.example.ttreader.DB_PREFS";
@@ -57,6 +57,18 @@ public class DbHelper extends SQLiteOpenHelper {
         }
         if (oldVersion < 4) {
             createDeviceStatsTables(db);
+        }
+        if (oldVersion < 5) {
+            try {
+                db.execSQL("ALTER TABLE device_pause_events ADD COLUMN bluetooth_likely INTEGER NOT NULL DEFAULT 0");
+            } catch (Exception ignored) {
+                // Column may already exist on some devices.
+            }
+            try {
+                db.execSQL("ALTER TABLE device_reaction_stats ADD COLUMN bluetooth_likely INTEGER NOT NULL DEFAULT 0");
+            } catch (Exception ignored) {
+                // Column may already exist on some devices.
+            }
         }
     }
 
@@ -209,6 +221,7 @@ public class DbHelper extends SQLiteOpenHelper {
                 " vendor_id INTEGER,\n" +
                 " product_id INTEGER,\n" +
                 " source_flags INTEGER,\n" +
+                " bluetooth_likely INTEGER NOT NULL DEFAULT 0,\n" +
                 " pause_offset_ms INTEGER NOT NULL,\n" +
                 " target_offset_ms INTEGER NOT NULL,\n" +
                 " delta_ms INTEGER NOT NULL,\n" +
@@ -225,6 +238,7 @@ public class DbHelper extends SQLiteOpenHelper {
                 " vendor_id INTEGER,\n" +
                 " product_id INTEGER,\n" +
                 " source_flags INTEGER,\n" +
+                " bluetooth_likely INTEGER NOT NULL DEFAULT 0,\n" +
                 " sample_count INTEGER NOT NULL DEFAULT 0,\n" +
                 " avg_reaction_delay_ms REAL NOT NULL DEFAULT 0,\n" +
                 " last_seen_ms INTEGER NOT NULL DEFAULT 0\n" +

--- a/android-app/src/main/res/drawable/ic_stats_bluetooth.xml
+++ b/android-app/src/main/res/drawable/ic_stats_bluetooth.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?android:attr/textColorPrimary"
+        android:pathData="M12,2L12,10L8.41,6.41L7,7.83L11.17,12L7,16.17L8.41,17.59L12,14L12,22H13L18.71,16.29L14.41,12L18.71,7.71L13,2H12Z" />
+    <path
+        android:fillColor="?android:attr/textColorPrimary"
+        android:pathData="M5,9H7V15H5z" />
+</vector>

--- a/android-app/src/main/res/layout/activity_device_stats.xml
+++ b/android-app/src/main/res/layout/activity_device_stats.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/deviceStatsRecycler"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="16dp" />
+
+    <TextView
+        android:id="@+id/deviceStatsEmpty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="24dp"
+        android:text="@string/device_stats_empty"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/android-app/src/main/res/layout/item_device_stat.xml
+++ b/android-app/src/main/res/layout/item_device_stat.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp">
+
+    <TextView
+        android:id="@+id/deviceStatName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textStyle="bold"
+        android:textColor="?android:attr/textColorPrimary" />
+
+    <TextView
+        android:id="@+id/deviceStatAverage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <TextView
+        android:id="@+id/deviceStatLastSeen"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?android:attr/textColorSecondary"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/android-app/src/main/res/menu/main_actions.xml
+++ b/android-app/src/main/res/menu/main_actions.xml
@@ -32,6 +32,11 @@
         android:title="@string/stats_button_work"
         android:showAsAction="ifRoom" />
     <item
+        android:id="@+id/action_device_stats"
+        android:icon="@drawable/ic_stats_bluetooth"
+        android:title="@string/stats_button_device"
+        android:showAsAction="ifRoom" />
+    <item
         android:id="@+id/action_install_talgat"
         android:title="@string/speech_install_talgat"
         android:showAsAction="never" />

--- a/android-app/src/main/res/values/colors.xml
+++ b/android-app/src/main/res/values/colors.xml
@@ -1,4 +1,6 @@
 <resources>
     <color name="reader_sentence_outline">#4CAF50</color>
     <color name="reader_letter_highlight">#2E7D32</color>
+    <color name="work_menu_progress_reading">#FF000000</color>
+    <color name="work_menu_progress_listening">@color/reader_letter_highlight</color>
 </resources>

--- a/android-app/src/main/res/values/strings.xml
+++ b/android-app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">UquReader</string>
     <string name="stats_button_language">Статистика языка</string>
     <string name="stats_button_work">Статистика произведения</string>
+    <string name="stats_button_device">Статистика Bluetooth</string>
     <string name="language_pair_button_format">Языки: %1$s</string>
     <string name="language_pair_button_unset">Выбрать пару языков</string>
     <string name="language_pair_tt_ru">🇷🇺 Русский · Татарский</string>
@@ -32,6 +33,12 @@
     <string name="no_features_placeholder">Дополнительных грамматических элементов нет</string>
     <string name="stats_language_title">Статистика языка</string>
     <string name="stats_work_title">Статистика произведения</string>
+    <string name="device_stats_title">Статистика Bluetooth-устройств</string>
+    <string name="device_stats_empty">Пока нет данных о Bluetooth-устройствах.</string>
+    <string name="device_stats_average_only">Средняя задержка: %1$.1f с</string>
+    <string name="device_stats_average_with_samples">Средняя задержка: %1$.1f с · %2$d наблюдений</string>
+    <string name="device_stats_last_seen">Последний раз: %1$s</string>
+    <string name="device_stats_unknown_device">Неизвестное устройство</string>
     <string name="stats_lemma_header">Леммы и части речи</string>
     <string name="stats_feature_header">Просмотры суффиксов</string>
     <string name="stats_exposure_label">Просмотрено в тексте: %1$d (последний раз %2$s)</string>


### PR DESCRIPTION
## Summary
- extend the work picker menu to show approximate reading and listening pages with colored spans and persist the new focus position in preferences
- track whether pause events come from bluetooth devices, expose a DAO query, and bump the database schema to store the flag
- add a dedicated Bluetooth device statistics activity with layouts, strings, and menu entry to surface average reaction delays

## Testing
- `./mvnw -pl android-app -am test` *(fails: android SDK platform jar not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d7dbe12c832a90b2205e65278ec1