### PR TITLE
Adjust menu typography and log bluetooth device presence

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/DeviceStatsActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/DeviceStatsActivity.java
@@ -76,9 +76,6 @@ public class DeviceStatsActivity extends Activity {
                     if (!entry.bluetoothLikely && !looksLikeBluetooth(entry)) {
                         continue;
                     }
-                    if (entry.sampleCount <= 0) {
-                        continue;
-                    }
                     filtered.add(entry);
                 }
             }
@@ -157,9 +154,13 @@ public class DeviceStatsActivity extends Activity {
                 nameView.setText(name);
 
                 double seconds = Math.max(0d, stats.averageDelayMs) / 1000d;
-                String averageText = stats.sampleCount > 0
-                        ? context.getString(R.string.device_stats_average_with_samples, seconds, stats.sampleCount)
-                        : context.getString(R.string.device_stats_average_only, seconds);
+                String averageText;
+                if (stats.sampleCount > 0) {
+                    averageText = context.getString(R.string.device_stats_average_with_samples, seconds, stats.sampleCount);
+                } else {
+                    averageText = context.getString(R.string.device_stats_average_no_samples,
+                            Math.max(0, stats.sampleCount));
+                }
                 averageView.setText(averageText);
 
                 if (stats.lastSeenMs > 0 && dateFormat != null) {

--- a/android-app/src/main/res/values/strings.xml
+++ b/android-app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="device_stats_empty">Пока нет данных о Bluetooth-устройствах.</string>
     <string name="device_stats_average_only">Средняя задержка: %1$.1f с</string>
     <string name="device_stats_average_with_samples">Средняя задержка: %1$.1f с · %2$d наблюдений</string>
+    <string name="device_stats_average_no_samples">Средняя задержка: нет данных · %1$d наблюдений</string>
     <string name="device_stats_last_seen">Последний раз: %1$s</string>
     <string name="device_stats_unknown_device">Неизвестное устройство</string>
     <string name="stats_lemma_header">Леммы и части речи</string>


### PR DESCRIPTION
## Summary
- reduce the toolbar work-menu text sizing so long titles and saved page numbers stay visible
- persist bluetooth device presence data even when no pause reaction exists and reuse it across media events
- surface zero-sample bluetooth devices in the stats screen with updated messaging

## Testing
- ./mvnw -pl android-app -am package
- Unable to complete emulator-based manual verification: `adb install` consistently failed with `java.lang.NullPointerException` from `PackageHelper.resolveInstallVolume` when communicating with the emulator's package manager


------
https://chatgpt.com/codex/tasks/task_e_68d42ada11fc832a9c1767ec698ae267