### PR TITLE
Enable stdin streaming in morphology console application

### DIFF
--- a/web-app/src/main/java/com/example/uqureader/webapp/cli/MorphologyConsoleApplication.java
+++ b/web-app/src/main/java/com/example/uqureader/webapp/cli/MorphologyConsoleApplication.java
@@ -23,7 +23,22 @@ public final class MorphologyConsoleApplication {
 
     public static void main(String[] args) {
         MorphologyAnalyzer analyzer = MorphologyAnalyzer.loadDefault();
-        String input = readInput(args);
+        if (args != null && args.length > 0) {
+            processInput(analyzer, Arrays.stream(args).collect(Collectors.joining(" ")));
+            return;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                processInput(analyzer, line);
+            }
+        } catch (IOException ex) {
+            throw new MorphologyException("Failed to read input", ex);
+        }
+    }
+
+    private static void processInput(MorphologyAnalyzer analyzer, String input) {
         try {
             MorphologyAnalyzer.TextAnalysis analysis = analyzer.analyze(input);
             System.out.println(analysis.markup());
@@ -33,27 +48,6 @@ public final class MorphologyConsoleApplication {
                 ex.getCause().printStackTrace(System.err);
             }
             System.exit(1);
-        }
-    }
-
-    private static String readInput(String[] args) {
-        if (args != null && args.length > 0) {
-            return Arrays.stream(args).collect(Collectors.joining(" "));
-        }
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8))) {
-            StringBuilder builder = new StringBuilder();
-            String line;
-            boolean first = true;
-            while ((line = reader.readLine()) != null) {
-                if (!first) {
-                    builder.append(System.lineSeparator());
-                }
-                builder.append(line);
-                first = false;
-            }
-            return builder.toString();
-        } catch (IOException ex) {
-            throw new MorphologyException("Failed to read input", ex);
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow the morphology console application to process stdin line by line when no arguments are supplied
- reuse the existing processing path for both argument and console input to keep error handling consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8fc22a41c832aa5a5e0c387b6029b