### PR TITLE
Normalize remote morphology output format

### DIFF
--- a/web-app/src/main/java/com/example/uqureader/webapp/cli/TatarMorphologyAnnotator.java
+++ b/web-app/src/main/java/com/example/uqureader/webapp/cli/TatarMorphologyAnnotator.java
@@ -88,8 +88,9 @@ public final class TatarMorphologyAnnotator {
 
         out.printf("# Файл: %s%n", file);
         List<WordMarkup> markup = client.analyzeText(content);
-        for (WordMarkup token : markup) {
-            out.printf("%s\t%s%n", token.word(), String.join(" | ", token.analyses()));
+        String formatted = RemoteMorphologyClient.formatAsMarkup(markup);
+        if (!formatted.isEmpty()) {
+            out.println(formatted);
         }
         out.println();
     }

--- a/web-app/src/test/java/com/example/uqureader/webapp/morphology/RemoteMarkupFormatterTest.java
+++ b/web-app/src/test/java/com/example/uqureader/webapp/morphology/RemoteMarkupFormatterTest.java
@@ -1,0 +1,33 @@
+package com.example.uqureader.webapp.morphology;
+
+import com.example.uqureader.webapp.morphology.RemoteMorphologyClient.WordMarkup;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RemoteMarkupFormatterTest {
+
+    @Test
+    void convertsMarkupToResourceFormat() {
+        List<WordMarkup> tokens = List.of(
+                new WordMarkup("Комедия", List.of("комедия+N+Sg+Nom")),
+                new WordMarkup("1", List.of("Num")),
+                new WordMarkup("иске", List.of("NR", "иске+Adj"))
+        );
+
+        String formatted = RemoteMorphologyClient.formatAsMarkup(tokens);
+
+        assertEquals("Комедия\tкомедия+N+Sg+Nom;\n1\tNum\nиске\tNR;иске+Adj;", formatted);
+    }
+
+    @Test
+    void fallsBackToErrorWhenAnalysesMissing() {
+        List<WordMarkup> tokens = List.of(new WordMarkup("?", List.of(" ")));
+
+        String formatted = RemoteMorphologyClient.formatAsMarkup(tokens);
+
+        assertEquals("?\tError", formatted);
+    }
+}


### PR DESCRIPTION
## Summary
- force the remote morphology client to always use an insecure SSL context to reach Tugantel
- add utilities to convert remote responses into the tab-separated markup format and reuse them in the CLI tool
- cover the formatter with unit tests to ensure punctuation and fallback behaviour stay stable

## Testing
- ./mvnw -pl web-app test

------
https://chatgpt.com/codex/tasks/task_e_68dafb598e44832aa55a95d6c01a55d7