### PR TITLE
Add progress reporting for Tatar morphology batches

### DIFF
--- a/web-app/src/main/java/com/example/uqureader/webapp/cli/TatarMorphologyAnnotator.java
+++ b/web-app/src/main/java/com/example/uqureader/webapp/cli/TatarMorphologyAnnotator.java
@@ -91,7 +91,9 @@ public final class TatarMorphologyAnnotator {
         }
 
         out.printf("# Файл: %s%n", file);
-        List<WordMarkup> markup = client.analyzeText(content);
+        List<WordMarkup> markup = client.analyzeText(content, (index, total, fragment) -> {
+            out.printf("# → Отправка фрагмента %d/%d (ожидаем ответ от сервиса):%n%s%n%n", index, total, fragment);
+        });
         String formatted = RemoteMorphologyClient.formatAsMarkup(markup);
         writeOutput(outputFile, formatted);
         out.printf("# Результат сохранён в: %s%n%n", outputFile);


### PR DESCRIPTION
## Summary
- add a progress callback to RemoteMorphologyClient.analyzeText to expose batch submissions
- log batch counters and content in the CLI annotator while waiting for the remote service response

## Testing
- `mvn -pl web-app test` *(fails: android module requires local SDK artifacts and custom plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68db0eb86030832a89977dbe6930d432