### PR TITLE
Ensure Morph3 exporter prefers original txt files

### DIFF
--- a/web-app/src/main/java/com/example/uqureader/webapp/cli/Morph3Fb2Exporter.java
+++ b/web-app/src/main/java/com/example/uqureader/webapp/cli/Morph3Fb2Exporter.java
@@ -181,23 +181,30 @@ public final class Morph3Fb2Exporter {
             throw new IllegalStateException("Не удалось определить базовое имя для файла " + morphFile);
         }
 
+        List<String> possibleNames = new ArrayList<>();
+        possibleNames.add(baseName);
+        String lowerBase = baseName.toLowerCase(Locale.ROOT);
+        if (!lowerBase.endsWith(".txt")) {
+            possibleNames.add(baseName + ".txt");
+        }
+
         Set<Path> candidates = new LinkedHashSet<>();
         Path parent = morphFile.getParent();
         if (parent != null) {
-            candidates.add(parent.resolve(baseName));
+            for (String name : possibleNames) {
+                candidates.add(parent.resolve(name));
+            }
             Path resources = parent.getParent();
             if (resources != null) {
-                candidates.add(resources.resolve(baseName));
-                candidates.add(resources.resolve("texts").resolve(baseName));
+                for (String name : possibleNames) {
+                    candidates.add(resources.resolve(name));
+                    candidates.add(resources.resolve("texts").resolve(name));
+                }
             }
         }
         if (explicitDir != null) {
-            candidates.add(explicitDir.resolve(baseName));
-        }
-
-        for (Path candidate : candidates) {
-            if (Files.exists(candidate) && Files.isRegularFile(candidate)) {
-                return candidate;
+            for (String name : possibleNames) {
+                candidates.add(explicitDir.resolve(name));
             }
         }
 


### PR DESCRIPTION
## Summary
- look for matching *.txt originals when resolving source text for Morph3 exports
- try each candidate directory with both the base name and a .txt variant to locate the true original text file

## Testing
- ./mvnw -pl web-app -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68def58d668c832a88d0f5ead4ad4ab2