### PR TITLE
Support explicit original files in Morph3Fb2Exporter

### DIFF
--- a/web-app/src/test/java/com/example/uqureader/webapp/cli/Morph3Fb2ExporterTest.java
+++ b/web-app/src/test/java/com/example/uqureader/webapp/cli/Morph3Fb2ExporterTest.java
@@ -1,0 +1,65 @@
+package com.example.uqureader.webapp.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class Morph3Fb2ExporterTest {
+
+    private static final Path MORPH_FILE = Path.of("src/main/resources/markup/qubiz_qabiz.txt.morph3.tsv");
+    private static final Path ORIGINAL_FILE = Path.of("src/main/resources/markup/qubiz_qabiz.txt");
+    private static final Path OUTPUT_FILE = MORPH_FILE.getParent().resolve("Qubiz qabiz.fb2");
+
+    private ByteArrayOutputStream outBuffer;
+    private ByteArrayOutputStream errBuffer;
+
+    @BeforeEach
+    void deleteOutputBefore() throws Exception {
+        Files.deleteIfExists(OUTPUT_FILE);
+        outBuffer = new ByteArrayOutputStream();
+        errBuffer = new ByteArrayOutputStream();
+    }
+
+    @AfterEach
+    void deleteOutputAfter() throws Exception {
+        Files.deleteIfExists(OUTPUT_FILE);
+    }
+
+    @Test
+    void runWithExplicitMorphAndOriginal() throws Exception {
+        Morph3Fb2Exporter exporter = new Morph3Fb2Exporter(
+                new PrintStream(outBuffer, true, StandardCharsets.UTF_8),
+                new PrintStream(errBuffer, true, StandardCharsets.UTF_8));
+
+        int exitCode = exporter.run(new String[]{
+                MORPH_FILE.toString(),
+                ORIGINAL_FILE.toString()
+        });
+
+        assertEquals(0, exitCode, "Экспорт должен завершиться без ошибок");
+        assertTrue(Files.exists(OUTPUT_FILE), "Должен быть создан fb2-файл");
+        assertTrue(Files.size(OUTPUT_FILE) > 0, "Сгенерированный fb2-файл не должен быть пустым");
+    }
+
+    @Test
+    void runWithOriginalOnly() throws Exception {
+        Morph3Fb2Exporter exporter = new Morph3Fb2Exporter(
+                new PrintStream(outBuffer, true, StandardCharsets.UTF_8),
+                new PrintStream(errBuffer, true, StandardCharsets.UTF_8));
+
+        int exitCode = exporter.run(new String[]{ORIGINAL_FILE.toString()});
+
+        assertEquals(0, exitCode, "Экспорт должен завершиться без ошибок");
+        assertTrue(Files.exists(OUTPUT_FILE), "Должен быть создан fb2-файл");
+        assertTrue(Files.size(OUTPUT_FILE) > 0, "Сгенерированный fb2-файл не должен быть пустым");
+    }
+}


### PR DESCRIPTION
## Summary
- allow Morph3Fb2Exporter to accept either an explicit morph/original file pair or a single original text path
- ensure original lookup uses explicit files when provided and improves missing-file validation messaging
- add regression tests covering both invocation styles using the bundled qubiz_qabiz resources

## Testing
- mvn -Dtest=com.example.uqureader.webapp.cli.Morph3Fb2ExporterTest test

------
https://chatgpt.com/codex/tasks/task_e_68def87bd1f8832a94d132796a1fe5d8