### PR TITLE
Remove bundled fonts from Android styling

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -1,6 +1,7 @@
 package com.example.ttreader.reader;
 
 import android.content.Context;
+import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -114,6 +115,11 @@ public class ReaderView extends TextView {
         sentenceOutlineStrokeWidth = 2f * density;
         sentenceOutlineCornerRadius = 6f * density;
         setMovementMethod(movementMethod);
+        setTextColor(resolveColorResource(com.example.ttreader.R.color.reader_text_primary));
+        setTypeface(Typeface.SERIF);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            setLetterSpacing(0.01f);
+        }
     }
 
     private MovementMethod createMovementMethod() {

--- a/android-app/src/main/java/com/example/ttreader/widget/UsageTimelineView.java
+++ b/android-app/src/main/java/com/example/ttreader/widget/UsageTimelineView.java
@@ -7,6 +7,8 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 
+import androidx.core.content.ContextCompat;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +43,9 @@ public class UsageTimelineView extends View {
         linePaint.setStyle(Paint.Style.STROKE);
         linePaint.setStrokeCap(Paint.Cap.ROUND);
         linePaint.setStrokeWidth(strokeWidth);
-        setColor(0xFF388E3C); // default green shade
+        int defaultColor = ContextCompat.getColor(getContext(),
+                com.example.ttreader.R.color.app_accent_blue);
+        setColor(defaultColor);
     }
 
     public void setColor(int color) {

--- a/android-app/src/main/res/drawable/reader_page_background.xml
+++ b/android-app/src/main/res/drawable/reader_page_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/app_surface" />
+    <stroke
+        android:width="3dp"
+        android:color="@color/app_primary" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android-app/src/main/res/drawable/vintage_card.xml
+++ b/android-app/src/main/res/drawable/vintage_card.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/app_surface_muted" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/app_primary" />
+    <corners android:radius="12dp" />
+</shape>

--- a/android-app/src/main/res/drawable/vintage_input.xml
+++ b/android-app/src/main/res/drawable/vintage_input.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/app_surface" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/app_primary" />
+    <corners android:radius="10dp" />
+    <padding
+        android:left="12dp"
+        android:top="8dp"
+        android:right="12dp"
+        android:bottom="8dp" />
+</shape>

--- a/android-app/src/main/res/layout/activity_device_stats.xml
+++ b/android-app/src/main/res/layout/activity_device_stats.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/app_background">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/deviceStatsRecycler"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:padding="16dp" />
+        android:padding="24dp" />
 
     <TextView
         android:id="@+id/deviceStatsEmpty"
@@ -17,8 +18,9 @@
         android:layout_gravity="center"
         android:gravity="center"
         android:padding="24dp"
+        android:textAppearance="@style/TextAppearance.UquReader.Body"
         android:text="@string/device_stats_empty"
-        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="@color/app_text_secondary"
         android:visibility="gone" />
 
 </FrameLayout>

--- a/android-app/src/main/res/layout/activity_main.xml
+++ b/android-app/src/main/res/layout/activity_main.xml
@@ -2,19 +2,23 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/app_background"
     android:orientation="vertical">
 
     <android.widget.Toolbar
         android:id="@+id/topToolbar"
         android:layout_width="match_parent"
         android:layout_height="?android:attr/actionBarSize"
-        android:background="?android:colorBackground"
+        android:layout_marginBottom="8dp"
+        android:popupTheme="@android:style/ThemeOverlay.Material.Light"
+        android:theme="@android:style/ThemeOverlay.Material.Dark"
+        android:background="@color/app_primary"
         android:elevation="4dp"
         android:gravity="center_vertical"
         android:logo="@mipmap/ic_launcher"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
-        android:popupTheme="@android:style/ThemeOverlay.Material.Light"
+        style="@style/Widget.UquReader.Toolbar"
         android:title="@null"
         android:subtitle="@null" />
 
@@ -27,13 +31,16 @@
             android:id="@+id/readerScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fillViewport="true">
+            android:fillViewport="true"
+            android:padding="24dp">
 
             <com.example.ttreader.reader.ReaderView
                 android:id="@+id/readerView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="16dp" />
+                android:background="@drawable/reader_page_background"
+                android:padding="24dp"
+                android:textColor="@color/reader_text_primary" />
         </ScrollView>
 
         <ImageButton

--- a/android-app/src/main/res/layout/activity_stats.xml
+++ b/android-app/src/main/res/layout/activity_stats.xml
@@ -3,5 +3,6 @@
     android:id="@+id/statsRecycler"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/app_background"
     android:clipToPadding="false"
-    android:padding="16dp" />
+    android:padding="24dp" />

--- a/android-app/src/main/res/layout/bottomsheet_token_info.xml
+++ b/android-app/src/main/res/layout/bottomsheet_token_info.xml
@@ -1,52 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@color/app_background">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:background="@drawable/vintage_card"
         android:orientation="vertical"
-        android:padding="16dp">
+        android:padding="20dp">
 
         <TextView
             android:id="@+id/tvSurface"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textStyle="bold"
-            android:textSize="18sp"/>
+            android:textAllCaps="false"
+            android:textAppearance="@style/TextAppearance.UquReader.Title" />
 
         <TextView
             android:id="@+id/tvLemma"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="4dp"/>
+            android:paddingTop="4dp"
+            android:textAppearance="@style/TextAppearance.UquReader.Body" />
 
         <TextView
             android:id="@+id/tvPos"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="4dp"/>
+            android:paddingTop="4dp"
+            android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
 
         <TextView
             android:id="@+id/tvSegments"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="8dp"/>
+            android:paddingTop="8dp"
+            android:textAppearance="@style/TextAppearance.UquReader.Body" />
 
         <TextView
             android:id="@+id/tvFeatureCodes"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="4dp"/>
+            android:paddingTop="4dp"
+            android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
 
         <TextView
             android:id="@+id/tvFeatureLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textStyle="bold"
             android:paddingTop="12dp"
-            android:text="@string/features_title"/>
+            android:text="@string/features_title"
+            android:textAllCaps="true"
+            android:textAppearance="@style/TextAppearance.UquReader.Subheading" />
 
         <LinearLayout
             android:id="@+id/featureContainer"
@@ -60,6 +68,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingTop="12dp"
-            android:textSize="16sp"/>
+            android:textAppearance="@style/TextAppearance.UquReader.Body"
+            android:textColor="@color/app_accent_red" />
     </LinearLayout>
 </ScrollView>

--- a/android-app/src/main/res/layout/item_device_stat.xml
+++ b/android-app/src/main/res/layout/item_device_stat.xml
@@ -2,35 +2,30 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:background="@drawable/vintage_card"
     android:orientation="vertical"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:paddingTop="12dp"
-    android:paddingBottom="12dp">
+    android:padding="20dp">
 
     <TextView
         android:id="@+id/deviceStatName"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textStyle="bold"
-        android:textColor="?android:attr/textColorPrimary" />
+        android:textAppearance="@style/TextAppearance.UquReader.Subheading" />
 
     <TextView
         android:id="@+id/deviceStatAverage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?android:attr/textColorSecondary" />
+        android:layout_marginTop="8dp"
+        android:textAppearance="@style/TextAppearance.UquReader.Body" />
 
     <TextView
         android:id="@+id/deviceStatLastSeen"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?android:attr/textColorSecondary"
+        android:textAppearance="@style/TextAppearance.UquReader.Body.Small"
         android:visibility="gone" />
 
 </LinearLayout>

--- a/android-app/src/main/res/layout/item_stats_empty.xml
+++ b/android-app/src/main/res/layout/item_stats_empty.xml
@@ -6,5 +6,6 @@
     android:gravity="center_horizontal"
     android:paddingTop="24dp"
     android:paddingBottom="24dp"
-    android:textAppearance="?android:attr/textAppearanceMedium"
-    android:text="@string/stats_filter_empty" />
+    android:text="@string/stats_filter_empty"
+    android:textAppearance="@style/TextAppearance.UquReader.Body"
+    android:textColor="@color/app_text_secondary" />

--- a/android-app/src/main/res/layout/item_stats_entry.xml
+++ b/android-app/src/main/res/layout/item_stats_entry.xml
@@ -2,27 +2,29 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:background="@drawable/vintage_card"
     android:orientation="vertical"
-    android:paddingBottom="12dp">
+    android:padding="20dp">
 
     <TextView
         android:id="@+id/statsTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textStyle="bold"
-        android:textSize="16sp"/>
+        android:textAppearance="@style/TextAppearance.UquReader.Subheading" />
 
     <TextView
         android:id="@+id/statsExposure"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="4dp"/>
+        android:paddingTop="4dp"
+        android:textAppearance="@style/TextAppearance.UquReader.Body" />
 
     <com.example.ttreader.widget.UsageTimelineView
         android:id="@+id/statsExposureTimeline"
         android:layout_width="match_parent"
         android:layout_height="36dp"
-        android:paddingTop="4dp"/>
+        android:paddingTop="4dp" />
 
     <LinearLayout
         android:id="@+id/statsExposureTimelineLabels"
@@ -35,7 +37,7 @@
             android:id="@+id/statsExposureTimelineStart"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"/>
+            android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
 
         <TextView
             android:id="@+id/statsExposureTimelineEnd"
@@ -43,20 +45,21 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:gravity="end"
-            android:textAppearance="?android:attr/textAppearanceSmall"/>
+            android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
     </LinearLayout>
 
     <TextView
         android:id="@+id/statsLookup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="2dp"/>
+        android:paddingTop="12dp"
+        android:textAppearance="@style/TextAppearance.UquReader.Body" />
 
     <com.example.ttreader.widget.UsageTimelineView
         android:id="@+id/statsLookupTimeline"
         android:layout_width="match_parent"
         android:layout_height="36dp"
-        android:paddingTop="4dp"/>
+        android:paddingTop="4dp" />
 
     <LinearLayout
         android:id="@+id/statsLookupTimelineLabels"
@@ -69,7 +72,7 @@
             android:id="@+id/statsLookupTimelineStart"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall"/>
+            android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
 
         <TextView
             android:id="@+id/statsLookupTimelineEnd"
@@ -77,7 +80,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:gravity="end"
-            android:textAppearance="?android:attr/textAppearanceSmall"/>
+            android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
     </LinearLayout>
 
 </LinearLayout>

--- a/android-app/src/main/res/layout/item_stats_feature_entry.xml
+++ b/android-app/src/main/res/layout/item_stats_feature_entry.xml
@@ -10,14 +10,13 @@
         android:id="@+id/statsFeatureTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textStyle="bold"
-        android:textSize="16sp" />
+        android:textAppearance="@style/TextAppearance.UquReader.Subheading" />
 
     <TextView
         android:id="@+id/statsFeatureDetails"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="4dp"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
 
 </LinearLayout>

--- a/android-app/src/main/res/layout/item_stats_feature_header.xml
+++ b/android-app/src/main/res/layout/item_stats_feature_header.xml
@@ -3,8 +3,8 @@
     android:id="@+id/statsFeatureHeaderText"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:text="@string/stats_feature_header"
-    android:textStyle="bold"
-    android:textSize="18sp"
     android:paddingTop="16dp"
-    android:paddingBottom="8dp" />
+    android:paddingBottom="8dp"
+    android:text="@string/stats_feature_header"
+    android:textAllCaps="true"
+    android:textAppearance="@style/TextAppearance.UquReader.Title" />

--- a/android-app/src/main/res/layout/item_stats_header.xml
+++ b/android-app/src/main/res/layout/item_stats_header.xml
@@ -2,8 +2,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:background="@drawable/vintage_card"
     android:orientation="vertical"
-    android:paddingBottom="12dp">
+    android:padding="20dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -16,11 +18,13 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:background="@drawable/vintage_input"
             android:hint="@string/stats_filter_hint"
             android:imeOptions="actionDone"
             android:inputType="text"
             android:maxLines="1"
-            android:padding="8dp" />
+            android:textAppearance="@style/TextAppearance.UquReader.Body"
+            android:textColorHint="@color/app_text_secondary" />
 
         <HorizontalScrollView
             android:layout_width="wrap_content"
@@ -42,7 +46,8 @@
                     android:contentDescription="@string/stats_sort_alpha_asc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_alpha_up" />
+                    android:src="@drawable/ic_sort_alpha_up"
+                    android:tint="@color/app_primary" />
 
                 <ImageButton
                     android:id="@+id/buttonSortAlphaDesc"
@@ -52,7 +57,8 @@
                     android:contentDescription="@string/stats_sort_alpha_desc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_alpha_down" />
+                    android:src="@drawable/ic_sort_alpha_down"
+                    android:tint="@color/app_primary" />
 
                 <ImageButton
                     android:id="@+id/buttonSortLookupCountDesc"
@@ -62,7 +68,8 @@
                     android:contentDescription="@string/stats_sort_lookup_count_desc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_lookup_down" />
+                    android:src="@drawable/ic_sort_lookup_down"
+                    android:tint="@color/app_primary" />
 
                 <ImageButton
                     android:id="@+id/buttonSortLookupTimeDesc"
@@ -72,7 +79,8 @@
                     android:contentDescription="@string/stats_sort_lookup_time_desc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_time_down" />
+                    android:src="@drawable/ic_sort_time_down"
+                    android:tint="@color/app_primary" />
 
                 <ImageButton
                     android:id="@+id/buttonSortLookupTimeAsc"
@@ -82,7 +90,8 @@
                     android:contentDescription="@string/stats_sort_lookup_time_asc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_time_up" />
+                    android:src="@drawable/ic_sort_time_up"
+                    android:tint="@color/app_primary" />
 
                 <ImageButton
                     android:id="@+id/buttonSortLookupCountAsc"
@@ -92,7 +101,8 @@
                     android:contentDescription="@string/stats_sort_lookup_count_asc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_lookup_up" />
+                    android:src="@drawable/ic_sort_lookup_up"
+                    android:tint="@color/app_primary" />
 
                 <ImageButton
                     android:id="@+id/buttonSortExposureCountDesc"
@@ -102,7 +112,8 @@
                     android:contentDescription="@string/stats_sort_exposure_count_desc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_exposure_down" />
+                    android:src="@drawable/ic_sort_exposure_down"
+                    android:tint="@color/app_primary" />
 
                 <ImageButton
                     android:id="@+id/buttonSortExposureCountAsc"
@@ -112,7 +123,8 @@
                     android:contentDescription="@string/stats_sort_exposure_count_asc"
                     android:padding="6dp"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_sort_exposure_up" />
+                    android:src="@drawable/ic_sort_exposure_up"
+                    android:tint="@color/app_primary" />
 
             </LinearLayout>
         </HorizontalScrollView>
@@ -122,17 +134,17 @@
         android:id="@+id/statsAxisDescription"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:paddingTop="8dp"
-        android:paddingBottom="8dp" />
+        android:paddingTop="12dp"
+        android:paddingBottom="8dp"
+        android:textAppearance="@style/TextAppearance.UquReader.Body.Small" />
 
     <TextView
         android:id="@+id/statsLemmaHeader"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:paddingBottom="8dp"
         android:text="@string/stats_lemma_header"
-        android:textStyle="bold"
-        android:textSize="18sp"
-        android:paddingBottom="8dp" />
+        android:textAllCaps="true"
+        android:textAppearance="@style/TextAppearance.UquReader.Title" />
 
 </LinearLayout>

--- a/android-app/src/main/res/layout/menu_action_language_pair.xml
+++ b/android-app/src/main/res/layout/menu_action_language_pair.xml
@@ -16,5 +16,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:contentDescription="@null"
-        android:src="@drawable/ic_language_menu" />
+        android:src="@drawable/ic_language_menu"
+        android:tint="@color/toolbar_icon_tint" />
 </FrameLayout>

--- a/android-app/src/main/res/menu/main_actions.xml
+++ b/android-app/src/main/res/menu/main_actions.xml
@@ -3,37 +3,44 @@
     <item
         android:id="@+id/action_toggle_speech"
         android:icon="@drawable/ic_voice"
+        android:iconTint="@color/toolbar_icon_tint"
         android:title="@string/speech_toggle_content_start"
         android:showAsAction="always" />
     <item
         android:id="@+id/action_stop_speech"
         android:icon="@drawable/ic_stop"
+        android:iconTint="@color/toolbar_icon_tint"
         android:title="@string/speech_stop_content"
         android:showAsAction="always" />
     <item
         android:id="@+id/action_language_pair"
         android:actionLayout="@layout/menu_action_language_pair"
         android:icon="@drawable/ic_language_menu"
+        android:iconTint="@color/toolbar_icon_tint"
         android:title="@string/language_pair_button_unset"
         android:showAsAction="always" />
     <item
         android:id="@+id/action_select_work"
         android:icon="@drawable/ic_menu_work"
+        android:iconTint="@color/toolbar_icon_tint"
         android:title="@string/work_menu_title"
         android:showAsAction="always" />
     <item
         android:id="@+id/action_language_stats"
         android:icon="@drawable/ic_stats_language"
+        android:iconTint="@color/toolbar_icon_tint"
         android:title="@string/stats_button_language"
         android:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_work_stats"
         android:icon="@drawable/ic_stats_work"
+        android:iconTint="@color/toolbar_icon_tint"
         android:title="@string/stats_button_work"
         android:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_device_stats"
         android:icon="@drawable/ic_stats_bluetooth"
+        android:iconTint="@color/toolbar_icon_tint"
         android:title="@string/stats_button_device"
         android:showAsAction="ifRoom" />
     <item

--- a/android-app/src/main/res/values/colors.xml
+++ b/android-app/src/main/res/values/colors.xml
@@ -1,6 +1,20 @@
 <resources>
-    <color name="reader_sentence_outline">#4CAF50</color>
-    <color name="reader_letter_highlight">#2E7D32</color>
-    <color name="work_menu_progress_reading">#FF000000</color>
+    <color name="app_background">#F5EEDB</color>
+    <color name="app_surface">#E2C171</color>
+    <color name="app_surface_muted">#F1E4C4</color>
+    <color name="app_primary">#24324D</color>
+    <color name="app_primary_dark">#1B253A</color>
+    <color name="app_accent_red">#C24432</color>
+    <color name="app_accent_blue">#2B4F7F</color>
+    <color name="app_text_primary">#2B2623</color>
+    <color name="app_text_secondary">#5B5047</color>
+    <color name="toolbar_icon_tint">#F7F0DF</color>
+    <color name="app_control_highlight">#33C24432</color>
+
+    <color name="reader_sentence_outline">@color/app_primary</color>
+    <color name="reader_letter_highlight">@color/app_accent_red</color>
+    <color name="reader_text_primary">@color/app_text_primary</color>
+
+    <color name="work_menu_progress_reading">@color/app_primary</color>
     <color name="work_menu_progress_listening">@color/reader_letter_highlight</color>
 </resources>

--- a/android-app/src/main/res/values/styles.xml
+++ b/android-app/src/main/res/values/styles.xml
@@ -1,4 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="@android:style/Theme.Material.Light.NoActionBar" />
+    <style name="AppTheme" parent="@android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:colorPrimary">@color/app_primary</item>
+        <item name="android:colorPrimaryDark">@color/app_primary_dark</item>
+        <item name="android:colorAccent">@color/app_accent_red</item>
+        <item name="android:colorControlNormal">@color/toolbar_icon_tint</item>
+        <item name="android:colorControlHighlight">@color/app_control_highlight</item>
+        <item name="android:colorEdgeEffect">@color/app_accent_red</item>
+        <item name="android:windowBackground">@color/app_background</item>
+        <item name="android:textColor">@color/app_text_primary</item>
+        <item name="android:textColorPrimary">@color/app_text_primary</item>
+        <item name="android:textColorSecondary">@color/app_text_secondary</item>
+        <item name="android:navigationBarColor">@color/app_primary_dark</item>
+        <item name="android:statusBarColor">@color/app_primary_dark</item>
+    </style>
+
+    <style name="TextAppearance.UquReader.Title" parent="@android:style/TextAppearance.Material.Headline">
+        <item name="android:textColor">@color/app_primary</item>
+        <item name="android:fontFamily">sans-serif-condensed</item>
+        <item name="android:letterSpacing">0.05</item>
+    </style>
+
+    <style name="TextAppearance.UquReader.Subheading" parent="@android:style/TextAppearance.Material.Subhead">
+        <item name="android:textColor">@color/app_accent_blue</item>
+        <item name="android:fontFamily">sans-serif-condensed</item>
+        <item name="android:letterSpacing">0.04</item>
+    </style>
+
+    <style name="TextAppearance.UquReader.Body" parent="@android:style/TextAppearance.Material.Body1">
+        <item name="android:textColor">@color/app_text_primary</item>
+        <item name="android:fontFamily">serif</item>
+        <item name="android:letterSpacing">0.01</item>
+    </style>
+
+    <style name="TextAppearance.UquReader.Body.Small" parent="@android:style/TextAppearance.Material.Body2">
+        <item name="android:textColor">@color/app_text_secondary</item>
+        <item name="android:fontFamily">serif</item>
+        <item name="android:letterSpacing">0.01</item>
+    </style>
+
+    <style name="Widget.UquReader.Toolbar" parent="@android:style/Widget.Material.Toolbar">
+        <item name="android:background">@color/app_primary</item>
+        <item name="android:logo">@mipmap/ic_launcher</item>
+        <item name="android:contentInsetStartWithNavigation">16dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
- delete previously added bundled font binaries from the Android resources
- swap custom font references for system serif and condensed families in the shared text styles
- load the default serif typeface in the reader view so runtime font lookups are no longer required

## Testing
- `./mvnw -pl android-app -am -DskipTests package` *(fails: missing Android SDK platform 33 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0465ee134832abd3932e0ce4f62c4