### PR TITLE
Implement page-based pagination for ReaderView

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -133,7 +133,6 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private View pageControls;
     private TextView pageNumberText;
     private View readerBottomPanel;
-    private View readerPageContainer;
     private int readerBasePaddingLeft;
     private int readerBasePaddingTop;
     private int readerBasePaddingRight;
@@ -143,8 +142,6 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private final List<Runnable> pendingViewportReadyActions = new ArrayList<>();
     private boolean awaitingViewportMeasurement;
     private boolean readerViewportReady;
-    private int readerContainerMarginTop;
-    private int readerContainerMarginBottom;
     private int readerBottomPanelBaseHeight;
     private ViewTreeObserver.OnPreDrawListener viewportReadyListener;
     private boolean flushingViewportActions;
@@ -342,15 +339,6 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         pageControls = findViewById(R.id.pageControls);
         pageNumberText = findViewById(R.id.pageNumberText);
         readerBottomPanel = findViewById(R.id.readerBottomPanel);
-        readerPageContainer = findViewById(R.id.readerPageContainer);
-        if (readerPageContainer != null) {
-            ViewGroup.LayoutParams containerParams = readerPageContainer.getLayoutParams();
-            if (containerParams instanceof ViewGroup.MarginLayoutParams) {
-                ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) containerParams;
-                readerContainerMarginTop = mlp.topMargin;
-                readerContainerMarginBottom = mlp.bottomMargin;
-            }
-        }
         if (readerBottomPanel != null) {
             ViewGroup.LayoutParams panelParams = readerBottomPanel.getLayoutParams();
             if (panelParams != null && panelParams.height > 0) {
@@ -1088,40 +1076,13 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         int overlayClearance = 0;
         if (pageControls != null && pageControls.getVisibility() == View.VISIBLE) {
             int overlayHeight = Math.max(0, pageControls.getHeight());
-            int overlayMargin = 0;
-            ViewGroup.LayoutParams lp = pageControls.getLayoutParams();
-            if (lp instanceof ViewGroup.MarginLayoutParams) {
-                overlayMargin = ((ViewGroup.MarginLayoutParams) lp).bottomMargin;
+            if (overlayHeight == 0) {
+                overlayHeight = Math.max(overlayHeight, pageControls.getMeasuredHeight());
             }
             int extra = getResources().getDimensionPixelSize(R.dimen.reader_page_controls_clearance);
-            int overlayReach = overlayHeight + overlayMargin + extra;
-            overlayClearance = Math.max(0, overlayReach);
+            overlayClearance = Math.max(0, overlayHeight + extra);
         }
         int desiredPanelHeight = Math.max(readerBottomPanelBaseHeight, overlayClearance);
-        if (readerScrollView != null && readerPageContainer != null) {
-            int scrollHeight = readerScrollView.getHeight();
-            int scrollPaddingTop = readerScrollView.getPaddingTop();
-            int scrollPaddingBottom = readerScrollView.getPaddingBottom();
-            int availableHeight = scrollHeight - scrollPaddingTop - scrollPaddingBottom;
-            if (availableHeight < 0) {
-                availableHeight = 0;
-            }
-            int verticalMargins = readerContainerMarginTop + readerContainerMarginBottom;
-            if (verticalMargins > 0) {
-                availableHeight = Math.max(0, availableHeight - verticalMargins);
-            }
-            int readerHeight = readerView.getHeight();
-            if (readerHeight <= 0) {
-                readerHeight = readerView.getMeasuredHeight();
-            }
-            if (readerHeight > availableHeight) {
-                readerHeight = availableHeight;
-            }
-            if (availableHeight > 0 && readerHeight >= 0) {
-                int leftover = Math.max(0, availableHeight - readerHeight);
-                desiredPanelHeight = Math.max(desiredPanelHeight, leftover);
-            }
-        }
 
         boolean panelChanged = false;
         if (readerBottomPanel != null) {

--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -47,6 +47,7 @@ import com.example.ttreader.data.DbHelper;
 import com.example.ttreader.data.DeviceIdentity;
 import com.example.ttreader.data.DeviceStatsDao;
 import com.example.ttreader.data.MemoryDao;
+import com.example.ttreader.data.PaginationDao;
 import com.example.ttreader.data.ReadingStateDao;
 import com.example.ttreader.data.UsageStatsDao;
 import com.example.ttreader.model.ReadingState;
@@ -122,6 +123,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private UsageStatsDao usageStatsDao;
     private DeviceStatsDao deviceStatsDao;
     private ReadingStateDao readingStateDao;
+    private PaginationDao paginationDao;
     private ScrollView readerScrollView;
     private ReaderView readerView;
     private ProgressBar readerLoadingIndicator;
@@ -297,6 +299,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         usageStatsDao = new UsageStatsDao(db);
         deviceStatsDao = new DeviceStatsDao(db);
         readingStateDao = new ReadingStateDao(db);
+        paginationDao = new PaginationDao(db);
 
         readerPrefs = getSharedPreferences(PREFS_READER_STATE, MODE_PRIVATE);
         if (readerPrefs != null) {
@@ -335,7 +338,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
             readerBasePaddingTop = readerView.getPaddingTop();
             readerBasePaddingRight = readerView.getPaddingRight();
             readerBasePaddingBottom = readerView.getPaddingBottom();
-            readerView.setup(dbHelper, memoryDao, usageStatsDao, this);
+            readerView.setup(dbHelper, memoryDao, usageStatsDao, paginationDao, this);
             readerView.setWindowChangeListener(this::handleReaderWindowChanged);
             readerView.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) ->
                     updateReaderBottomInset());

--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -150,6 +150,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private int readerPageBaseMarginBottom;
     private int lastOverlayClearance;
     private int lastKnownOverlayHeight = -1;
+    private int resolvedOverlayHeight = -1;
     private ViewTreeObserver.OnPreDrawListener viewportReadyListener;
     private boolean flushingViewportActions;
     private boolean overlayInsetRetryScheduled;
@@ -386,6 +387,9 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                 int newHeight = Math.max(0, bottom - top);
                 if (pageControls.getVisibility() != View.VISIBLE) {
                     newHeight = 0;
+                }
+                if (newHeight > 0 && resolvedOverlayHeight != newHeight) {
+                    resolvedOverlayHeight = newHeight;
                 }
                 if (lastKnownOverlayHeight != newHeight) {
                     lastKnownOverlayHeight = newHeight;
@@ -1128,6 +1132,12 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                 Log.d(LAYOUT_LOG_TAG, "updateReaderBottomInset: awaiting overlay measurement");
             } else {
                 overlayInsetRetryScheduled = false;
+                if (resolvedOverlayHeight <= 0) {
+                    resolvedOverlayHeight = overlayHeight;
+                }
+                if (resolvedOverlayHeight > 0) {
+                    overlayHeight = resolvedOverlayHeight;
+                }
                 int extra = getResources().getDimensionPixelSize(R.dimen.reader_page_controls_clearance);
                 overlayClearance = Math.max(0, overlayHeight + extra);
                 lastKnownOverlayHeight = overlayHeight;
@@ -1187,8 +1197,8 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         }
 
         if (overlayChanged || readerPaddingChanged || containerMarginChanged || insetChanged) {
-            Log.d(LAYOUT_LOG_TAG, "updateReaderBottomInset: dispatch viewport change");
-            dispatchReaderViewportChanged();
+            Log.d(LAYOUT_LOG_TAG, "updateReaderBottomInset: schedule viewport change");
+            scheduleReaderViewportDispatch();
         }
         Log.d(LAYOUT_LOG_TAG, "updateReaderBottomInset: end");
     }

--- a/android-app/src/main/java/com/example/ttreader/data/DbHelper.java
+++ b/android-app/src/main/java/com/example/ttreader/data/DbHelper.java
@@ -18,7 +18,7 @@ import java.io.OutputStream;
 
 public class DbHelper extends SQLiteOpenHelper {
     public static final String APP_DB_NAME = "appdata.db";
-    private static final int APP_DB_VERSION = 6;
+    private static final int APP_DB_VERSION = 7;
 
     private static final String TAG = "DbHelper";
     private static final String PREFS_NAME = "com.example.ttreader.DB_PREFS";
@@ -45,6 +45,7 @@ public class DbHelper extends SQLiteOpenHelper {
         createUsageTables(db);
         createDeviceStatsTables(db);
         createReadingStateTable(db);
+        createPaginationTable(db);
     }
 
     @Override public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
@@ -73,6 +74,9 @@ public class DbHelper extends SQLiteOpenHelper {
         }
         if (oldVersion < 6) {
             createReadingStateTable(db);
+        }
+        if (oldVersion < 7) {
+            createPaginationTable(db);
         }
     }
 
@@ -272,6 +276,23 @@ public class DbHelper extends SQLiteOpenHelper {
                 " count INTEGER NOT NULL DEFAULT 0,\n" +
                 " last_seen_ms INTEGER NOT NULL,\n" +
                 " PRIMARY KEY(lemma, pos, feature_code, event_type)\n" +
+                ")");
+    }
+
+    private void createPaginationTable(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS visual_pagination(\n" +
+                " language_pair TEXT NOT NULL,\n" +
+                " work_id TEXT NOT NULL,\n" +
+                " content_width INTEGER NOT NULL,\n" +
+                " content_height INTEGER NOT NULL,\n" +
+                " text_size REAL NOT NULL,\n" +
+                " line_spacing_extra REAL NOT NULL,\n" +
+                " line_spacing_multiplier REAL NOT NULL,\n" +
+                " letter_spacing REAL NOT NULL,\n" +
+                " document_signature INTEGER NOT NULL,\n" +
+                " page_breaks TEXT NOT NULL,\n" +
+                " updated_ms INTEGER NOT NULL,\n" +
+                " PRIMARY KEY(language_pair, work_id)\n" +
                 ")");
     }
 }

--- a/android-app/src/main/java/com/example/ttreader/data/PaginationDao.java
+++ b/android-app/src/main/java/com/example/ttreader/data/PaginationDao.java
@@ -1,0 +1,169 @@
+package com.example.ttreader.data;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.text.TextUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PaginationDao {
+    private static final String TABLE_NAME = "visual_pagination";
+
+    private final SQLiteDatabase db;
+    private final DbWriteQueue writeQueue;
+
+    public PaginationDao(SQLiteDatabase db) {
+        this(db, DbWriteQueue.getInstance());
+    }
+
+    public PaginationDao(SQLiteDatabase db, DbWriteQueue queue) {
+        this.db = db;
+        this.writeQueue = queue;
+    }
+
+    public Snapshot getSnapshot(String languagePair, String workId) {
+        String lang = sanitize(languagePair);
+        String work = sanitize(workId);
+        try (Cursor c = db.query(TABLE_NAME,
+                new String[]{"content_width", "content_height", "text_size",
+                        "line_spacing_extra", "line_spacing_multiplier", "letter_spacing",
+                        "document_signature", "page_breaks", "updated_ms"},
+                "language_pair=? AND work_id=?",
+                new String[]{lang, work}, null, null, null)) {
+            if (c.moveToFirst()) {
+                int contentWidth = c.getInt(0);
+                int contentHeight = c.getInt(1);
+                float textSize = c.getFloat(2);
+                float lineSpacingExtra = c.getFloat(3);
+                float lineSpacingMultiplier = c.getFloat(4);
+                float letterSpacing = c.getFloat(5);
+                int documentSignature = c.getInt(6);
+                String encoded = c.getString(7);
+                long updatedMs = c.getLong(8);
+                List<PageBreak> pageBreaks = decodePageBreaks(encoded);
+                if (!pageBreaks.isEmpty()) {
+                    return new Snapshot(lang, work, contentWidth, contentHeight, textSize,
+                            lineSpacingExtra, lineSpacingMultiplier, letterSpacing,
+                            documentSignature, pageBreaks, updatedMs);
+                }
+            }
+        }
+        return null;
+    }
+
+    public void saveSnapshot(Snapshot snapshot) {
+        if (snapshot == null) {
+            return;
+        }
+        final Snapshot safe = snapshot;
+        writeQueue.enqueue(() -> {
+            ContentValues values = new ContentValues();
+            values.put("language_pair", safe.languagePair);
+            values.put("work_id", safe.workId);
+            values.put("content_width", safe.contentWidth);
+            values.put("content_height", safe.contentHeight);
+            values.put("text_size", safe.textSize);
+            values.put("line_spacing_extra", safe.lineSpacingExtra);
+            values.put("line_spacing_multiplier", safe.lineSpacingMultiplier);
+            values.put("letter_spacing", safe.letterSpacing);
+            values.put("document_signature", safe.documentSignature);
+            values.put("page_breaks", encodePageBreaks(safe.pageBreaks));
+            values.put("updated_ms", safe.updatedMs);
+            db.insertWithOnConflict(TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_REPLACE);
+        });
+    }
+
+    public void deleteSnapshot(String languagePair, String workId) {
+        final String lang = sanitize(languagePair);
+        final String work = sanitize(workId);
+        writeQueue.enqueue(() -> db.delete(TABLE_NAME, "language_pair=? AND work_id=?",
+                new String[]{lang, work}));
+    }
+
+    private static List<PageBreak> decodePageBreaks(String encoded) {
+        if (TextUtils.isEmpty(encoded)) {
+            return Collections.emptyList();
+        }
+        String[] parts = encoded.split(",");
+        List<PageBreak> result = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            if (TextUtils.isEmpty(part)) continue;
+            String[] bounds = part.split(":");
+            if (bounds.length != 2) continue;
+            try {
+                int start = Integer.parseInt(bounds[0].trim());
+                int end = Integer.parseInt(bounds[1].trim());
+                if (end > start) {
+                    result.add(new PageBreak(start, end));
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return result;
+    }
+
+    private static String encodePageBreaks(List<PageBreak> breaks) {
+        if (breaks == null || breaks.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (PageBreak page : breaks) {
+            if (page == null) continue;
+            if (sb.length() > 0) sb.append(',');
+            sb.append(page.start).append(':').append(page.end);
+        }
+        return sb.toString();
+    }
+
+    private String sanitize(String value) {
+        return value == null ? "" : value;
+    }
+
+    public static final class Snapshot {
+        public final String languagePair;
+        public final String workId;
+        public final int contentWidth;
+        public final int contentHeight;
+        public final float textSize;
+        public final float lineSpacingExtra;
+        public final float lineSpacingMultiplier;
+        public final float letterSpacing;
+        public final int documentSignature;
+        public final List<PageBreak> pageBreaks;
+        public final long updatedMs;
+
+        public Snapshot(String languagePair, String workId, int contentWidth, int contentHeight,
+                        float textSize, float lineSpacingExtra, float lineSpacingMultiplier,
+                        float letterSpacing, int documentSignature, List<PageBreak> pageBreaks,
+                        long updatedMs) {
+            this.languagePair = sanitize(languagePair);
+            this.workId = sanitize(workId);
+            this.contentWidth = Math.max(0, contentWidth);
+            this.contentHeight = Math.max(0, contentHeight);
+            this.textSize = textSize;
+            this.lineSpacingExtra = lineSpacingExtra;
+            this.lineSpacingMultiplier = lineSpacingMultiplier;
+            this.letterSpacing = letterSpacing;
+            this.documentSignature = documentSignature;
+            this.pageBreaks = pageBreaks == null ? Collections.emptyList() : new ArrayList<>(pageBreaks);
+            this.updatedMs = Math.max(0L, updatedMs);
+        }
+
+        private String sanitize(String value) {
+            return value == null ? "" : value;
+        }
+    }
+
+    public static final class PageBreak {
+        public final int start;
+        public final int end;
+
+        public PageBreak(int start, int end) {
+            this.start = Math.max(0, start);
+            this.end = Math.max(this.start, end);
+        }
+    }
+}

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -451,8 +451,13 @@ public class ReaderView extends TextView {
             pages.clear();
         }
         if (!currentDocument.text.isEmpty()) {
-            pendingTargetCharIndex = clamp(visibleStart, 0, currentDocument.text.length());
-            hasPendingTarget = true;
+            int clampedVisibleStart = clamp(visibleStart, 0, currentDocument.text.length());
+            if (!hasPendingTarget) {
+                pendingTargetCharIndex = clampedVisibleStart;
+                hasPendingTarget = true;
+            } else {
+                pendingTargetCharIndex = clamp(pendingTargetCharIndex, 0, currentDocument.text.length());
+            }
             pendingNotifyWindowChange = true;
         }
     }

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -443,6 +443,16 @@ public class ReaderView extends TextView {
                 && activePaginationSpec.matchesDimensions(currentSpec)) {
             return;
         }
+        int preservedTarget = -1;
+        boolean hadPendingTarget = hasPendingTarget;
+        boolean preservedNotify = pendingNotifyWindowChange;
+        if (currentDocument.text != null && !currentDocument.text.isEmpty()) {
+            if (hasPendingTarget) {
+                preservedTarget = clamp(pendingTargetCharIndex, 0, currentDocument.text.length());
+            } else {
+                preservedTarget = clamp(visibleStart, 0, currentDocument.text.length());
+            }
+        }
         paginationDirty = true;
         paginationLocked = false;
         paginationCacheLoaded = false;
@@ -450,15 +460,13 @@ public class ReaderView extends TextView {
         if (!pages.isEmpty()) {
             pages.clear();
         }
-        if (!currentDocument.text.isEmpty()) {
-            int clampedVisibleStart = clamp(visibleStart, 0, currentDocument.text.length());
-            if (!hasPendingTarget) {
-                pendingTargetCharIndex = clampedVisibleStart;
-                hasPendingTarget = true;
-            } else {
-                pendingTargetCharIndex = clamp(pendingTargetCharIndex, 0, currentDocument.text.length());
-            }
-            pendingNotifyWindowChange = true;
+        if (preservedTarget >= 0) {
+            pendingTargetCharIndex = preservedTarget;
+            hasPendingTarget = true;
+            pendingNotifyWindowChange = preservedNotify || !hadPendingTarget;
+        } else {
+            hasPendingTarget = false;
+            pendingNotifyWindowChange = false;
         }
     }
 

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -217,16 +217,6 @@ public class ReaderView extends TextView {
         return local;
     }
 
-    public void ensureWindowContains(int globalCharIndex) {
-        if (globalCharIndex < visibleStart || globalCharIndex >= visibleEnd) {
-            requestDisplayForChar(globalCharIndex, true);
-        }
-    }
-
-    public void scrollToGlobalChar(int globalCharIndex) {
-        requestDisplayForChar(globalCharIndex, true);
-    }
-
     public void clearContent() {
         visibleStart = 0;
         visibleEnd = 0;

--- a/android-app/src/main/res/layout/activity_main.xml
+++ b/android-app/src/main/res/layout/activity_main.xml
@@ -54,13 +54,6 @@
                     android:background="@android:color/transparent"
                     android:padding="24dp"
                     android:textColor="@color/reader_text_primary" />
-
-                <View
-                    android:id="@+id/readerBottomPanel"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:background="@android:color/transparent"
-                    android:visibility="gone" />
             </LinearLayout>
         </com.example.ttreader.widget.StaticPageScrollView>
 

--- a/android-app/src/main/res/layout/activity_main.xml
+++ b/android-app/src/main/res/layout/activity_main.xml
@@ -58,8 +58,9 @@
                 <View
                     android:id="@+id/readerBottomPanel"
                     android:layout_width="match_parent"
-                    android:layout_height="@dimen/reader_bottom_panel_min_height"
-                    android:background="@android:color/transparent" />
+                    android:layout_height="0dp"
+                    android:background="@android:color/transparent"
+                    android:visibility="gone" />
             </LinearLayout>
         </com.example.ttreader.widget.StaticPageScrollView>
 

--- a/android-app/src/main/res/layout/activity_main.xml
+++ b/android-app/src/main/res/layout/activity_main.xml
@@ -59,7 +59,7 @@
                     android:id="@+id/readerBottomPanel"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/reader_bottom_panel_min_height"
-                    android:background="@color/app_surface" />
+                    android:background="@android:color/transparent" />
             </LinearLayout>
         </com.example.ttreader.widget.StaticPageScrollView>
 


### PR DESCRIPTION
## Summary
- replace the scrolling window logic in `ReaderView` with page-based pagination that measures content height and stores page ranges
- expose new pagination APIs from `ReaderView` and recompute pagination when the viewport changes
- update `MainActivity` to work with the new paging APIs, refresh page controls, and remove ScrollView-driven scrolling

## Testing
- `./mvnw -pl android-app -am -DskipTests compile` *(fails: missing /usr/lib/android-sdk/platforms/android-33/android.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e252b45794832aa6f2fb826a798915