### PR TITLE
Improve reader layout logging for pagination tracking

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -132,6 +132,15 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
             translationY = ty;
         }
 
+        void reset() {
+            left = Integer.MIN_VALUE;
+            top = Integer.MIN_VALUE;
+            right = Integer.MIN_VALUE;
+            bottom = Integer.MIN_VALUE;
+            translationX = Float.NaN;
+            translationY = Float.NaN;
+        }
+
         private boolean floatsEqual(float a, float b) {
             if (Float.isNaN(a) && Float.isNaN(b)) {
                 return true;
@@ -176,6 +185,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private TextView pageNumberText;
     private final ViewBoundsSnapshot pageControlsBounds = new ViewBoundsSnapshot();
     private final ViewBoundsSnapshot pageNumberBounds = new ViewBoundsSnapshot();
+    private final ViewBoundsSnapshot readerViewBounds = new ViewBoundsSnapshot();
     private int lastLoggedPageIndex = -1;
     private int lastLoggedPageTotal = -1;
     private int readerBasePaddingLeft;
@@ -1115,6 +1125,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                 logViewEvent("ReaderView", readerView,
                         "afterWindowChanged page=" + currentPageIndex + "/" + Math.max(1, totalPages)
                                 + " height=" + readerHeight);
+                logReaderViewBounds("afterWindowChanged");
                 enforceReaderPageHeight("afterWindowChanged");
                 logPageControlsBounds("afterWindowChanged");
             });
@@ -1125,6 +1136,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                     "afterWindowChanged (noReaderView) height=" + cardHeight);
             logViewEvent("ReaderView", null,
                     "afterWindowChanged (noReaderView) height=0");
+            logReaderViewBounds("afterWindowChanged:noReader");
             enforceReaderPageHeight("afterWindowChanged:noReader");
             logPageControlsBounds("afterWindowChanged:noReader");
         }
@@ -1221,6 +1233,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private void logViewBoundsSnapshot(String component, View view,
                                        ViewBoundsSnapshot snapshot, String stage) {
         if (view == null) {
+            snapshot.reset();
             logViewEvent(component, null, stage + " bounds skipped (view null)");
             return;
         }
@@ -1251,6 +1264,10 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         }
         logViewEvent(component, view, action.toString());
         snapshot.update(left, top, right, bottom, tx, ty);
+    }
+
+    private void logReaderViewBounds(String stage) {
+        logViewBoundsSnapshot("ReaderView", readerView, readerViewBounds, stage);
     }
 
     private void goToPreviousPage() {

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -922,6 +922,18 @@ public class ReaderView extends TextView {
                 .append(']');
         sb.append(" scroll=").append('[').append(getScrollX()).append(',').append(getScrollY()).append(']');
         sb.append(" visibleRange=").append('[').append(visibleStart).append(',').append(visibleEnd).append(')');
+        List<Page> pageList = this.pages;
+        int totalPages = pageList != null ? pageList.size() : 0;
+        if (pageList == null) {
+            sb.append(" page=<uninitialized>");
+        } else if (totalPages > 0) {
+            int currentPage = getCurrentPageIndex() + 1;
+            sb.append(" page=").append(currentPage).append('/')
+                    .append(Math.max(1, totalPages));
+        } else {
+            sb.append(" page=—");
+        }
+        sb.append(" paginationDirty=").append(paginationDirty);
         ViewParent parent = getParent();
         View cardView = parent instanceof View ? (View) parent : null;
         if (cardView != null) {
@@ -1009,7 +1021,7 @@ public class ReaderView extends TextView {
     }
 
     public int getTotalPageCount() {
-        return pages.size();
+        return pages != null ? pages.size() : 0;
     }
 
     public int getPageIndexForChar(int charIndex) {


### PR DESCRIPTION
## Summary
- track the reader view bounds across window changes using a dedicated snapshot and ensure snapshots reset when views are unavailable
- log the reader view bounds alongside page-control snapshots to spot layout shifts across pagination
- extend reader text logging with page index details while guarding against uninitialized pagination state

## Testing
- ./tools/codex-install-apk.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3f9c50360832ab3da818b4d301f3a