### PR TITLE
Prevent whitespace-only pages in reader pagination

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -691,6 +691,18 @@ public class ReaderView extends TextView {
             if (end <= start) {
                 end = Math.min(docLength, start + Math.max(MIN_PAGE_ADVANCE_CHARS, availableWidth));
             }
+
+            if (isAllWhitespace(text, start, end)) {
+                if (!pages.isEmpty()) {
+                    Page previous = pages.remove(pages.size() - 1);
+                    int mergedStart = previous.start;
+                    int mergedEnd = Math.max(previous.end, end);
+                    pages.add(new Page(mergedStart, mergedEnd));
+                }
+                start = end;
+                continue;
+            }
+
             pages.add(new Page(start, end));
             start = end;
         }
@@ -1319,6 +1331,20 @@ public class ReaderView extends TextView {
             result--;
         }
         return Math.max(result, limit);
+    }
+
+    private boolean isAllWhitespace(String content, int start, int end) {
+        if (content == null) {
+            return true;
+        }
+        int safeStart = Math.max(0, start);
+        int safeEnd = Math.min(content.length(), Math.max(start, end));
+        for (int i = safeStart; i < safeEnd; i++) {
+            if (!Character.isWhitespace(content.charAt(i))) {
+                return false;
+            }
+        }
+        return safeEnd > safeStart;
     }
 
     private Spannable getSpannableText() {


### PR DESCRIPTION
## Summary
- merge whitespace-only pagination chunks into the previous page so the reader never emits empty pages
- add an `isAllWhitespace` helper used by pagination to detect whitespace-only ranges

## Testing
- ./tools/codex-install-apk.sh
- adb logcat -d ReaderTextTrace:D *:S | grep "applyPage render"


------
https://chatgpt.com/codex/tasks/task_e_68e51bf586bc832ab96e87af0baf4a15