### PR TITLE
Lock page navigation while paging

### DIFF
--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -1212,12 +1212,13 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     }
 
     private void updatePageControls() {
-        boolean prevEnabled = readerView != null && readerView.hasPreviousPage();
+        boolean navigationReady = readerView != null && readerView.isNavigationReady();
+        boolean prevEnabled = navigationReady && readerView != null && readerView.hasPreviousPage();
         setEnabledWithLogging(pagePreviousButton, "PagePreviousButton", prevEnabled);
         float prevAlpha = prevEnabled ? 1f : 0.3f;
         setAlphaWithLogging(pagePreviousButton, "PagePreviousButton", prevAlpha);
 
-        boolean nextEnabled = readerView != null && readerView.hasNextPage();
+        boolean nextEnabled = navigationReady && readerView != null && readerView.hasNextPage();
         setEnabledWithLogging(pageNextButton, "PageNextButton", nextEnabled);
         float nextAlpha = nextEnabled ? 1f : 0.3f;
         setAlphaWithLogging(pageNextButton, "PageNextButton", nextAlpha);
@@ -1345,20 +1346,32 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         if (readerView == null) {
             return;
         }
+        if (!readerView.isNavigationReady()) {
+            logViewEvent("PagePreviousButton", pagePreviousButton, "navigationLocked");
+            updatePageControls();
+            return;
+        }
         int target = readerView.findPreviousPageStart();
         if (target >= 0) {
             readerView.scrollToGlobalChar(target);
         }
+        updatePageControls();
     }
 
     private void goToNextPage() {
         if (readerView == null) {
             return;
         }
+        if (!readerView.isNavigationReady()) {
+            logViewEvent("PageNextButton", pageNextButton, "navigationLocked");
+            updatePageControls();
+            return;
+        }
         int target = readerView.findNextPageStart();
         if (target >= 0) {
             readerView.scrollToGlobalChar(target);
         }
+        updatePageControls();
     }
 
     private void schedulePersistReadingState() {

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -504,6 +504,19 @@ public class ReaderView extends TextView {
         }
     }
 
+    private boolean hasPendingNavigationRequest() {
+        if (currentPendingTarget != null) {
+            return true;
+        }
+        if (!pendingTargetQueue.isEmpty()) {
+            return true;
+        }
+        if (deferredPage != null) {
+            return true;
+        }
+        return deferredPageScheduled;
+    }
+
     private boolean ensurePagination() {
         if (currentDocument == null || currentDocument.text == null) {
             return false;
@@ -1108,6 +1121,19 @@ public class ReaderView extends TextView {
 
     public int getViewportEndChar() {
         return visibleEnd;
+    }
+
+    public boolean isNavigationReady() {
+        if (currentDocument == null || currentDocument.text == null) {
+            return false;
+        }
+        if (paginationDirty) {
+            return false;
+        }
+        if (!paginationLocked) {
+            return false;
+        }
+        return !hasPendingNavigationRequest();
     }
 
     public int findNextPageStart() {


### PR DESCRIPTION
## Summary
- disable the next/previous page buttons while pagination is running to prevent flicker and skipped page numbers
- expose ReaderView navigation readiness so the UI can wait for pagination completion and rely on cached pagination snapshots

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e606f1001c832aaec72a682464b18c