### PR TITLE
Retry reader pagination when viewport isn't ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ android-app/tools/base64encoder/*.jar
 *.keystore
 !tools/debug-keystore/debug.keystore
 !android-app/tools/debug-keystore/debug.keystore
+# Local artifacts captured during emulator runs
+artifacts/
 
 # Morphology transducer binaries
 web-app/src/main/resources/morphology/*.hfstol

--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -1212,12 +1212,13 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     }
 
     private void updatePageControls() {
-        boolean prevEnabled = readerView != null && readerView.hasPreviousPage();
+        boolean navigationReady = readerView != null && readerView.isNavigationReady();
+        boolean prevEnabled = navigationReady && readerView != null && readerView.hasPreviousPage();
         setEnabledWithLogging(pagePreviousButton, "PagePreviousButton", prevEnabled);
         float prevAlpha = prevEnabled ? 1f : 0.3f;
         setAlphaWithLogging(pagePreviousButton, "PagePreviousButton", prevAlpha);
 
-        boolean nextEnabled = readerView != null && readerView.hasNextPage();
+        boolean nextEnabled = navigationReady && readerView != null && readerView.hasNextPage();
         setEnabledWithLogging(pageNextButton, "PageNextButton", nextEnabled);
         float nextAlpha = nextEnabled ? 1f : 0.3f;
         setAlphaWithLogging(pageNextButton, "PageNextButton", nextAlpha);
@@ -1345,20 +1346,32 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         if (readerView == null) {
             return;
         }
+        if (!readerView.isNavigationReady()) {
+            logViewEvent("PagePreviousButton", pagePreviousButton, "navigationLocked");
+            updatePageControls();
+            return;
+        }
         int target = readerView.findPreviousPageStart();
         if (target >= 0) {
             readerView.scrollToGlobalChar(target);
         }
+        updatePageControls();
     }
 
     private void goToNextPage() {
         if (readerView == null) {
             return;
         }
+        if (!readerView.isNavigationReady()) {
+            logViewEvent("PageNextButton", pageNextButton, "navigationLocked");
+            updatePageControls();
+            return;
+        }
         int target = readerView.findNextPageStart();
         if (target >= 0) {
             readerView.scrollToGlobalChar(target);
         }
+        updatePageControls();
     }
 
     private void schedulePersistReadingState() {

--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -1963,7 +1963,11 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         if (readerView != null) {
             int readerHeight = readerView.getHeight();
             if (readerHeight > 0 && height > readerHeight) {
-                height = readerHeight;
+                CharSequence currentText = readerView.getText();
+                boolean hasRenderedContent = currentText != null && currentText.length() > 0;
+                if (hasRenderedContent) {
+                    height = readerHeight;
+                }
             }
         }
         if (!readerViewportReady && awaitingViewportMeasurement) {

--- a/android-app/src/main/java/com/example/ttreader/MainActivity.java
+++ b/android-app/src/main/java/com/example/ttreader/MainActivity.java
@@ -25,6 +25,7 @@ import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.InputDevice;
 import android.view.KeyEvent;
@@ -216,6 +217,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
     private boolean flushingViewportActions;
     private boolean overlayInsetRetryScheduled;
     private boolean readerWindowInitialized;
+    private boolean readerHasRenderableContent;
     private ReadingState currentReadingState;
     private SharedPreferences readerPrefs;
     private final Handler readingStateHandler = new Handler(Looper.getMainLooper());
@@ -1025,6 +1027,7 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         restoringReadingState = true;
         showReaderLoading(true);
         readerWindowInitialized = false;
+        readerHasRenderableContent = false;
         lastDispatchedViewportHeight = -1;
         lastOverlayClearance = -1;
         readerView.clearContent();
@@ -1116,6 +1119,16 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                 if (!readerWindowInitialized) {
                     readerWindowInitialized = true;
                     resetReaderScrollOffset();
+                }
+                boolean hasContent = readerView != null && readerView.hasRenderedContent();
+                if (hasContent && !readerHasRenderableContent) {
+                    readerHasRenderableContent = true;
+                    int containerHeight = readerPageContainer != null
+                            ? readerPageContainer.getHeight() : 0;
+                    if (containerHeight > 0) {
+                        maybePersistReaderPageHeight(containerHeight,
+                                "windowInitialized");
+                    }
                 }
                 int viewportStart = readerView.getViewportStartChar();
                 if (viewportStart >= 0) {
@@ -1597,6 +1610,14 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                 storedHeight = Math.max(0, specific);
             }
         }
+        int minimumHeight = computeMinimumPersistableReaderHeight();
+        if (storedHeight > 0 && storedHeight < minimumHeight) {
+            logViewEvent("ReaderPageContainer", readerPageContainer,
+                    "loadPersistedHeight discarded height=" + storedHeight
+                            + " min=" + minimumHeight + " reason=" + reason);
+            clearPersistedReaderPageHeight("refreshBelowMinimum:" + reason);
+            storedHeight = 0;
+        }
         persistedReaderPageHeight = storedHeight;
         if (persistedReaderPageHeight > 0) {
             logViewEvent("ReaderPageContainer", readerPageContainer,
@@ -1613,6 +1634,18 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
 
     private void maybePersistReaderPageHeight(int candidateHeight, String reason) {
         int safeHeight = Math.max(0, candidateHeight);
+        if (!readerHasRenderableContent) {
+            logViewEvent("ReaderPageContainer", readerPageContainer,
+                    "persistReaderHeight skipped contentNotReady reason=" + reason);
+            return;
+        }
+        int minimumHeight = computeMinimumPersistableReaderHeight();
+        if (safeHeight > 0 && safeHeight < minimumHeight) {
+            logViewEvent("ReaderPageContainer", readerPageContainer,
+                    "persistReaderHeight skipped belowMinimum height=" + safeHeight
+                            + " min=" + minimumHeight + " reason=" + reason);
+            return;
+        }
         if (safeHeight <= 0 || safeHeight <= persistedReaderPageHeight) {
             return;
         }
@@ -1674,8 +1707,12 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
                     + readerPageContainer.getPaddingBottom();
             minimumHeight = Math.max(minimumHeight, containerPadding + lineHeight);
         }
+        int minimumPersistable = computeMinimumPersistableReaderHeight();
         if (newHeight < minimumHeight) {
             newHeight = minimumHeight;
+        }
+        if (newHeight < minimumPersistable) {
+            newHeight = minimumPersistable;
         }
         if (newHeight == persistedReaderPageHeight) {
             markReaderPageHeightReductionApplied();
@@ -1701,6 +1738,48 @@ public class MainActivity extends Activity implements ReaderView.TokenInfoProvid
         });
         logViewEvent("ReaderPageContainer", readerPageContainer,
                 "scheduleHeightReductionRetry reason=" + reason);
+    }
+
+    private int computeMinimumPersistableReaderHeight() {
+        int lineHeight = 0;
+        if (readerView != null) {
+            lineHeight = readerView.getLineHeight();
+        }
+        if (lineHeight <= 0) {
+            DisplayMetrics metrics = getResources().getDisplayMetrics();
+            lineHeight = Math.round(metrics.scaledDensity * 24f);
+        }
+        int minContent = Math.max(0, lineHeight * 4);
+        int padding = readerPageContainer == null
+                ? 0
+                : readerPageContainer.getPaddingTop() + readerPageContainer.getPaddingBottom();
+        int minimum = minContent + padding;
+        int absoluteMinimum = Math.round(getResources().getDisplayMetrics().density * 160f);
+        if (minimum < absoluteMinimum) {
+            minimum = absoluteMinimum;
+        }
+        return Math.max(0, minimum);
+    }
+
+    private void clearPersistedReaderPageHeight(String reason) {
+        boolean hadPersistedHeight = persistedReaderPageHeight > 0;
+        persistedReaderPageHeight = 0;
+        readerPageHeightFixed = false;
+        if (readerPageHeightReductionApplied) {
+            readerPageHeightReductionApplied = false;
+            if (readerPrefs != null) {
+                readerPrefs.edit().putBoolean(PREF_KEY_PAGE_HEIGHT_REDUCTION_APPLIED, false).apply();
+            }
+        }
+        if (uiLayoutDao != null) {
+            uiLayoutDao.saveReaderPageHeight(null, 0);
+            if (!TextUtils.isEmpty(activeLayoutWorkId)) {
+                uiLayoutDao.saveReaderPageHeight(activeLayoutWorkId, 0);
+            }
+        }
+        logViewEvent("ReaderPageContainer", readerPageContainer,
+                "clearPersistedHeight reason=" + reason + " hadValue=" + hadPersistedHeight);
+        enforceReaderPageHeight("clear:" + reason);
     }
 
     private void enforceReaderPageHeight(String reason) {

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -570,13 +570,18 @@ public class ReaderView extends TextView {
 
     private boolean ensurePagination() {
         if (currentDocument == null || currentDocument.text == null) {
+            Log.d(TAG, "ensurePagination: no document");
             return false;
         }
         if (viewportHeight <= 0 || getWidth() <= 0) {
+            Log.d(TAG, "ensurePagination: viewport not ready height=" + viewportHeight
+                    + " width=" + getWidth());
             return false;
         }
         PaginationSpec spec = captureCurrentSpec();
         if (spec == null) {
+            Log.d(TAG, "ensurePagination: spec null height=" + viewportHeight
+                    + " width=" + getWidth());
             return false;
         }
         if (!paginationCacheLoaded) {

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -279,6 +279,17 @@ public class ReaderView extends TextView {
         return currentDocument.text.length();
     }
 
+    public boolean hasRenderedContent() {
+        if (currentDocument == null || currentDocument.text == null) {
+            return false;
+        }
+        if (pages.isEmpty()) {
+            return false;
+        }
+        CharSequence currentText = getText();
+        return currentText != null && currentText.length() > 0 && visibleEnd > visibleStart;
+    }
+
     public int toLocalCharIndex(int globalIndex) {
         CharSequence text = getText();
         int length = text == null ? 0 : text.length();

--- a/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
+++ b/android-app/src/main/java/com/example/ttreader/reader/ReaderView.java
@@ -88,6 +88,14 @@ public class ReaderView extends TextView {
     private boolean paginationLocked = false;
     private PendingTarget currentPendingTarget;
     private final ArrayDeque<PendingTarget> pendingTargetQueue = new ArrayDeque<>();
+    private boolean processingPendingTarget;
+    private boolean ensurePaginationRetryScheduled;
+    private final Runnable ensurePaginationRetryRunnable = new Runnable() {
+        @Override public void run() {
+            ensurePaginationRetryScheduled = false;
+            showPendingTargetIfPossible();
+        }
+    };
     private int currentPageIndex = 0;
     private PaginationSpec activePaginationSpec;
     private Runnable pendingInitialCompletion;
@@ -298,6 +306,8 @@ public class ReaderView extends TextView {
         paginationLocked = false;
         currentPendingTarget = null;
         pendingTargetQueue.clear();
+        processingPendingTarget = false;
+        cancelEnsurePaginationRetry();
         activePaginationSpec = null;
         pendingInitialCompletion = null;
         initialContentDelivered = false;
@@ -415,6 +425,8 @@ public class ReaderView extends TextView {
         currentDocumentSignature = computeDocumentSignature(result.text);
         currentPendingTarget = null;
         pendingTargetQueue.clear();
+        processingPendingTarget = false;
+        cancelEnsurePaginationRetry();
         int target = hasPendingInitialChar ? pendingInitialCharIndex : 0;
         hasPendingInitialChar = false;
         requestDisplayForChar(target, true);
@@ -453,30 +465,57 @@ public class ReaderView extends TextView {
     }
 
     private void enqueuePendingTarget(int targetCharIndex, boolean notifyWindowChange) {
-        if (currentPendingTarget == null) {
-            currentPendingTarget = new PendingTarget(targetCharIndex, notifyWindowChange);
-        } else {
-            if (currentPendingTarget.charIndex == targetCharIndex) {
-                if (notifyWindowChange && !currentPendingTarget.notifyWindowChange) {
-                    currentPendingTarget = new PendingTarget(targetCharIndex, true);
+        boolean effectiveNotify = notifyWindowChange;
+        if (!effectiveNotify) {
+            if (currentPendingTarget != null && currentPendingTarget.notifyWindowChange) {
+                effectiveNotify = true;
+            } else {
+                for (PendingTarget queued : pendingTargetQueue) {
+                    if (queued != null && queued.notifyWindowChange) {
+                        effectiveNotify = true;
+                        break;
+                    }
                 }
-                showPendingTargetIfPossible();
-                return;
             }
+        }
+
+        if (processingPendingTarget) {
             PendingTarget last = pendingTargetQueue.peekLast();
             if (last != null && last.charIndex == targetCharIndex) {
-                if (notifyWindowChange && !last.notifyWindowChange) {
+                if (effectiveNotify && !last.notifyWindowChange) {
                     pendingTargetQueue.pollLast();
                     pendingTargetQueue.addLast(new PendingTarget(targetCharIndex, true));
                 }
             } else {
-                pendingTargetQueue.addLast(new PendingTarget(targetCharIndex, notifyWindowChange));
+                pendingTargetQueue.clear();
+                pendingTargetQueue.addLast(new PendingTarget(targetCharIndex, effectiveNotify));
             }
+            return;
         }
+
+        if (currentPendingTarget == null) {
+            currentPendingTarget = new PendingTarget(targetCharIndex, effectiveNotify);
+            showPendingTargetIfPossible();
+            return;
+        }
+
+        if (currentPendingTarget.charIndex == targetCharIndex) {
+            if (effectiveNotify && !currentPendingTarget.notifyWindowChange) {
+                currentPendingTarget = new PendingTarget(targetCharIndex, true);
+            }
+            showPendingTargetIfPossible();
+            return;
+        }
+
+        currentPendingTarget = new PendingTarget(targetCharIndex, effectiveNotify);
+        pendingTargetQueue.clear();
         showPendingTargetIfPossible();
     }
 
     private void showPendingTargetIfPossible() {
+        if (processingPendingTarget) {
+            return;
+        }
         if (currentPendingTarget == null) {
             if (pendingTargetQueue.isEmpty()) {
                 return;
@@ -489,19 +528,44 @@ public class ReaderView extends TextView {
         Log.d(TAG, "showPendingTargetIfPossible: pendingTarget=" + currentPendingTarget.charIndex);
         if (!ensurePagination()) {
             Log.d(TAG, "showPendingTargetIfPossible: pagination not ready");
+            scheduleEnsurePaginationRetry();
             return;
         }
         PendingTarget target = currentPendingTarget;
         currentPendingTarget = null;
+        processingPendingTarget = true;
         Log.d(TAG, "showPendingTargetIfPossible: displaying target=" + target.charIndex
                 + " notify=" + target.notifyWindowChange);
-        showPageForChar(target.charIndex, target.notifyWindowChange);
+        try {
+            showPageForChar(target.charIndex, target.notifyWindowChange);
+        } finally {
+            processingPendingTarget = false;
+        }
         if (!pendingTargetQueue.isEmpty()) {
             currentPendingTarget = pendingTargetQueue.pollFirst();
             if (currentPendingTarget != null) {
                 post(this::showPendingTargetIfPossible);
             }
         }
+    }
+
+    private boolean hasPendingNavigationRequest() {
+        if (currentPendingTarget != null) {
+            return true;
+        }
+        if (!pendingTargetQueue.isEmpty()) {
+            return true;
+        }
+        if (deferredPage != null) {
+            return true;
+        }
+        if (processingPendingTarget) {
+            return true;
+        }
+        if (deferredPageScheduled) {
+            return true;
+        }
+        return ensurePaginationRetryScheduled;
     }
 
     private boolean ensurePagination() {
@@ -580,11 +644,15 @@ public class ReaderView extends TextView {
             currentPendingTarget = new PendingTarget(preservedTarget,
                     preservedNotify || !hadPendingTarget);
             pendingTargetQueue.clear();
+            processingPendingTarget = false;
+            cancelEnsurePaginationRetry();
             Log.d(TAG, "markPaginationDirty: preservedTarget=" + preservedTarget
                     + " notify=" + currentPendingTarget.notifyWindowChange);
         } else {
             currentPendingTarget = null;
             pendingTargetQueue.clear();
+            processingPendingTarget = false;
+            cancelEnsurePaginationRetry();
             Log.d(TAG, "markPaginationDirty: cleared pending target");
         }
     }
@@ -1108,6 +1176,35 @@ public class ReaderView extends TextView {
 
     public int getViewportEndChar() {
         return visibleEnd;
+    }
+
+    public boolean isNavigationReady() {
+        if (currentDocument == null || currentDocument.text == null) {
+            return false;
+        }
+        if (paginationDirty) {
+            return false;
+        }
+        if (!paginationLocked) {
+            return false;
+        }
+        return !hasPendingNavigationRequest();
+    }
+
+    private void scheduleEnsurePaginationRetry() {
+        if (ensurePaginationRetryScheduled) {
+            return;
+        }
+        ensurePaginationRetryScheduled = true;
+        post(ensurePaginationRetryRunnable);
+    }
+
+    private void cancelEnsurePaginationRetry() {
+        if (!ensurePaginationRetryScheduled) {
+            return;
+        }
+        ensurePaginationRetryScheduled = false;
+        removeCallbacks(ensurePaginationRetryRunnable);
     }
 
     public int findNextPageStart() {


### PR DESCRIPTION
## Summary
- add a retry runnable so ReaderView re-attempts showing pending targets once pagination prerequisites are ready instead of staying blank
- reset the retry guard whenever content or pagination state changes to avoid stale navigation locks
- capture emulator screenshots that demonstrate the blank startup state and the corrected reader after the fix
- remove committed emulator screenshots and ignore the artifacts/ directory going forward

## Testing
- not rerun (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e606f1001c832aaec72a682464b18c